### PR TITLE
Initial Data Modelling and User Management

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,10 @@ gem "vite_rails"
 
 gem "passwordless"
 
+gem "jwt"
+
+gem "action_policy"
+
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ gem "bootsnap", require: false
 
 gem "vite_rails"
 
+gem "passwordless"
+
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    action_policy (0.7.5)
+      ruby-next-core (>= 1.0)
     actioncable (7.2.2.2)
       actionpack (= 7.2.2.2)
       activesupport (= 7.2.2.2)
@@ -100,6 +102,8 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jwt (3.1.2)
+      base64
     logger (1.7.0)
     loofah (2.24.1)
       crass (~> 1.0.2)
@@ -193,6 +197,7 @@ GEM
       psych (>= 4.0.0)
     reline (0.6.2)
       io-console (~> 0.5)
+    ruby-next-core (1.1.2)
     securerandom (0.4.1)
     stringio (3.1.7)
     thor (1.4.0)
@@ -227,8 +232,10 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  action_policy
   bootsnap
   error_highlight (>= 0.4.0)
+  jwt
   passwordless
   pg (~> 1.1)
   puma (>= 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
     base64 (0.3.0)
+    bcrypt (3.1.20)
     benchmark (0.4.1)
     bigdecimal (3.2.3)
     bindex (0.8.1)
@@ -131,6 +132,9 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.9-x86_64-darwin)
       racc (~> 1.4)
+    passwordless (1.8.1)
+      bcrypt (>= 3.1.11)
+      rails (>= 5.1.4)
     pg (1.6.2-aarch64-linux)
     pg (1.6.2-arm64-darwin)
     pg (1.6.2-x86_64-darwin)
@@ -225,6 +229,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   error_highlight (>= 0.4.0)
+  passwordless
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.2)

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,0 +1,3 @@
+class Api::BaseController < ApplicationController
+  authorize :user, through: :current_user
+end

--- a/app/controllers/api/experiences_controller.rb
+++ b/app/controllers/api/experiences_controller.rb
@@ -1,49 +1,138 @@
-class Api::ExperiencesController < ApplicationController
+class Api::ExperiencesController < Api::BaseController
   skip_before_action :verify_authenticity_token
 
   # POST /api/experiences
   def create
-    @experience = Experience.new(code: generate_experience_code.downcase)
+    authorize! Experience, to: :create?
 
-    if @experience.save
-      render json: {
-        success: true,
-        experience: {
-          id: @experience.id,
-          code: @experience.code,
-          created_at: @experience.created_at
-        },
-        lobby_url: lobby_url(@experience.code)
-      }, status: :created
+    valid, message = Experience.validate_code(experience_params[:code])
+
+    if valid
+      experience = current_user.created_experiences.build(experience_params)
+
+      if experience.save
+        render json: {
+          success: true,
+          experience: {
+            id: experience.id,
+            code: experience.code,
+            created_at: experience.created_at
+          },
+          url: experience_path(experience.code)
+        }, status: :created
+      else
+        render json: {
+          success: false,
+          message: "Failed to create experience",
+          errors: experience.errors.full_messages
+        }, status: :unprocessable_entity
+      end
     else
       render json: {
         success: false,
-        errors: @experience.errors.full_messages
+        message: "Invalid experience code",
+        errors: [message]
       }, status: :unprocessable_entity
     end
   end
 
-  # POST /api/experiences/join
-  def join
-    @experience = Experience.find_by_code(params[:code].downcase)
+  # GET /api/experiences/:id
+  def show
+    experience = Experience.find_by(code: params[:id])
 
-    if @experience.blank?
-      render json: {
-        success: false,
-        error: "Experience not found with code: #{params[:code]}"
-      }, status: :not_found
+    if experience.nil?
+      render json: { error: "Invalid experience code" }, status: :not_found
+      return
     end
+
+    authorize! experience, to: :show?
 
     render json: {
       success: true,
       experience: {
-        id: @experience.id,
-        code: @experience.code,
-        participant_count: @experience.users.count,
-        created_at: @experience.created_at
+        id: experience.id,
+        code: experience.code,
+        status: 'lobby',
+        participants: experience.users.map do |user|
+          {
+            id: user.id,
+            name: user.name,
+            email: user.email
+          }
+        end
       },
-      lobby_url: lobby_url(@experience.code)
-    }, status: :ok
+      user: current_user ? {
+        id: current_user.id,
+        name: current_user.name,
+        email: current_user.email
+      } : nil
+    }
+  end
+
+  # POST /api/experiences/join
+  # Handles code submission - checks if user exists and is registered
+  def join
+    code = join_params
+    experience = Experience.find_by(code: code)
+
+    if experience.nil?
+      render json: { error: "Invalid experience code" }, status: :not_found
+      return
+    end
+
+    if current_user && experience.user_registered?(current_user)
+      render json: {
+        jwt: experience.jwt_token_for(current_user),
+        experience_url: experience_path(experience.code),
+        status: "registered"
+      }
+    else
+      render json: {
+        experience_code: code,
+        status: "needs_registration"
+      }
+    end
+  end
+
+  # POST /api/experiences/register
+  # Handles user registration for an experience
+  def register
+    experience = Experience.find_by(code: register_params[:code])
+
+    if experience.nil?
+      render json: { error: "Invalid experience code" }, status: :not_found
+      return
+    end
+
+    authorize! experience, to: :register?
+
+    user = current_user
+
+    if user.nil?
+      user = User.find_or_create_by(email: register_params[:email]) do |u|
+        u.name = register_params[:name] if register_params[:name].present?
+      end
+
+      sign_in(create_passwordless_session(user))
+    else
+      # Update name if provided
+      user.update(name: register_params[:name]) if register_params[:name].present?
+    end
+
+    if user.nil?
+      render json: { error: "Failed to create user account" }, status: :internal_server_error
+      return
+    end
+
+    unless experience.user_registered?(user)
+      experience.register_user(user)
+    end
+
+    render json: {
+      jwt: experience.jwt_token_for(user),
+      experience_url: experience_path(experience.code),
+      status: "registered"
+    }
   end
 
   private
@@ -56,12 +145,7 @@ class Api::ExperiencesController < ApplicationController
     params.require(:code)
   end
 
-  def generate_experience_code
-    # Use provided code or generate a new one
-    experience_params[:code].presence || Experience.generate_code
-  end
-
-  def lobby_url(code)
-    "#{request.base_url}/lobby/#{code}"
+  def register_params
+    params.permit(:code, :email, :name)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,16 @@
 class ApplicationController < ActionController::Base
+  include Passwordless::ControllerHelpers
+  include ActionPolicy::Controller
+
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 
   def index
     render 'layouts/application'
+  end
+
+  helper_method :current_user
+  def current_user
+    @current_user ||= authenticate_by_session(User)
   end
 end

--- a/app/controllers/spa_controller.rb
+++ b/app/controllers/spa_controller.rb
@@ -1,0 +1,7 @@
+class SpaController < ApplicationController
+  def index
+    # Invidual routes (not api routes) that point to this action should set up
+    # any required metatags here and ensure the view (app/views/spa.html.erb)
+    # renders them correctly.
+  end
+end

--- a/app/frontend/App.tsx
+++ b/app/frontend/App.tsx
@@ -5,6 +5,7 @@ import About from './Pages/about';
 import Join from './Pages/join';
 import Lobby from './Pages/lobby';
 import Experience from './Pages/Experience';
+import Register from './Pages/Register';
 import Admin from './Pages/admin';
 import Stylesheet from './Pages/stylesheet';
 import { TopNav } from './Components/topnav';
@@ -28,8 +29,8 @@ function App() {
           <Route path="/about" element={<About />} />
           <Route path="/join" element={<Join />} />
           <Route path="/admin" element={<Admin />} />
-          <Route path="/lobby/:code" element={<Lobby />} />
           <Route path="/experience/:code" element={<Experience />} />
+          <Route path="/experience/:code/register" element={<Register />} />
           <Route path="/stylesheet" element={<Stylesheet />} />
         </RouteWink>
       </div>

--- a/app/frontend/Pages/Experience.tsx
+++ b/app/frontend/Pages/Experience.tsx
@@ -1,74 +1,192 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 
 export default function Experience() {
   const params = useParams();
+  const navigate = useNavigate();
   const rawKey = decodeURIComponent(params.code || '');
+
   const { isValid, code } = useMemo(() => {
     const trimmed = (rawKey || '').trim();
     return { isValid: trimmed.length > 0, code: trimmed };
   }, [rawKey]);
 
-  const [loading, setLoading] = useState(true);
+  // State for different experience phases
+  const [experienceState, setExperienceState] = useState('loading'); // 'loading', 'lobby', 'active'
+  const [user, setUser] = useState(null);
+  const [experienceInfo, setExperienceInfo] = useState(null);
+  const [participants, setParticipants] = useState([]);
+  const [isPolling, setIsPolling] = useState(false);
   const [error, setError] = useState('');
-  const [startUrl, setStartUrl] = useState<string | null>(null);
+  const [startUrl, setStartUrl] = useState(null);
 
-  const fetchExperience = async () => {
+  // Check authentication and load experience
+  useEffect(() => {
     if (!isValid) return;
-    setLoading(true);
-    setError('');
+
+    const jwt = localStorage.getItem('experience_jwt');
+    if (!jwt) {
+      // No JWT, redirect to join flow
+      navigate(`/join?code=${code}`);
+      return;
+    }
+
+    loadExperience();
+  }, [code, navigate, isValid]);
+
+  // Set up polling when in lobby state
+  useEffect(() => {
+    if (experienceState === 'lobby') {
+      const interval = setInterval(loadExperience, 3000);
+      return () => clearInterval(interval);
+    }
+  }, [experienceState]);
+
+  const loadExperience = async () => {
+    if (!isValid) return;
+
+    const jwt = localStorage.getItem('experience_jwt');
+    if (!jwt) {
+      navigate(`/join?code=${code}`);
+      return;
+    }
+
+    setIsPolling(true);
     try {
-      const resp = await fetch(`/api/lobby/${encodeURIComponent(code)}`);
-      const data = await resp.json();
+      const response = await fetch(`/api/experiences/${encodeURIComponent(code)}`, {
+        headers: {
+          'Authorization': `Bearer ${jwt}`
+        }
+      });
+
+      const data = await response.json();
+
       if (data.success) {
-        setStartUrl(data.experience.start_url || null);
+        setUser(data.user);
+        setExperienceInfo(data.experience);
+        setParticipants(data.experience.participants || []);
+
+        setExperienceState('lobby');
+        setError('');
       } else {
         setError(data.error || 'Failed to load experience');
+        // If unauthorized, redirect to join
+        if (response.status === 401) {
+          localStorage.removeItem('experience_jwt');
+          navigate(`/join?code=${code}`);
+        }
       }
-    } catch (e) {
+    } catch (err) {
+      console.error('Error loading experience:', err);
       setError('Network error');
     } finally {
-      setLoading(false);
+      setIsPolling(false);
     }
   };
 
-  useEffect(() => {
-    if (isValid) fetchExperience();
-  }, [isValid, code]);
-
-  return (
-    <section className="page flex-centered">
-      <h1 style={{ marginBottom: '0.5rem' }}>{code || 'Experience'}</h1>
-      {loading ? (
+  // Loading state
+  if (experienceState === 'loading') {
+    return (
+      <section className="page flex-centered">
+        <h1 style={{ marginBottom: '0.5rem' }}>{code || 'Experience'}</h1>
         <p style={{ opacity: 0.85 }}>Preparing experience…</p>
-      ) : error ? (
-        <>
-          <p style={{ color: 'var(--yellow)' }}>{error}</p>
-          <Link
-            to={`/lobby/${encodeURIComponent(code)}`}
-            className="link"
-            style={{ marginTop: '1rem' }}
-          >
-            Back to lobby
-          </Link>
-        </>
-      ) : (
-        <>
-          <p style={{ marginBottom: '1rem', opacity: 0.85 }}>Experience has started.</p>
-          <button
-            className="join-submit"
-            disabled={!startUrl}
-            onClick={() => startUrl && window.open(startUrl, '_blank', 'noopener,noreferrer')}
-          >
-            {startUrl ? 'Open Link' : 'Waiting for link…'}
-          </button>
-          <p style={{ marginTop: '1rem' }}>
-            <Link to={`/lobby/${encodeURIComponent(code)}`} className="link">
-              Return to lobby
+      </section>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <section className="page flex-centered">
+        <h1 style={{ marginBottom: '0.5rem' }}>{code || 'Experience'}</h1>
+        <p style={{ color: 'var(--yellow)', marginBottom: '1rem' }}>{error}</p>
+        <button onClick={() => navigate('/join')} className="join-submit">
+          Try Again
+        </button>
+      </section>
+    );
+  }
+
+  // Lobby state (default state - waiting for experience to start)
+  if (experienceState === 'lobby') {
+    return (
+      <section className="page flex-centered">
+        {!isValid ? (
+          <>
+            <p style={{ color: 'var(--yellow)', marginBottom: '0.75rem' }}>Invalid code</p>
+            <Link className="link" to="/join">
+              Enter a code
             </Link>
-          </p>
-        </>
-      )}
-    </section>
-  );
+          </>
+        ) : (
+          // User is authenticated and in lobby
+          <>
+            <h1 style={{ marginBottom: '0.5rem' }}>{code}</h1>
+            <p style={{ marginBottom: '1rem', opacity: 0.85 }}>
+              Participants: {participants.length}
+              {isPolling && <span style={{ marginLeft: '0.5rem', fontSize: '0.8rem' }}>🔄</span>}
+            </p>
+
+            {/* Participants List */}
+            <div
+              style={{
+                width: '100%',
+                maxWidth: '300px',
+                backgroundColor: 'rgba(255, 255, 255, 0.1)',
+                borderRadius: '8px',
+                padding: '1rem',
+                marginBottom: '1rem',
+              }}
+            >
+              <h4 style={{ margin: '0 0 0.75rem 0', fontSize: '1rem', opacity: 0.9 }}>
+                Players in Lobby:
+              </h4>
+              {participants.length > 0 ? (
+                <ul
+                  style={{
+                    listStyle: 'none',
+                    padding: 0,
+                    margin: 0,
+                  }}
+                >
+                  {participants.map((participant) => (
+                    <li
+                      key={participant.id}
+                      style={{
+                        padding: '0.5rem 0',
+                        borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        position: 'relative',
+                      }}
+                    >
+                      <span
+                        style={{
+                          fontWeight: participant.id === user?.id ? 600 : 400,
+                          color: participant.id === user?.id ? 'var(--green)' : 'inherit',
+                        }}
+                      >
+                        {participant.name || participant.email}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p style={{ margin: 0, opacity: 0.7, fontStyle: 'italic' }}>
+                  Loading participants...
+                </p>
+              )}
+            </div>
+
+            <p style={{ marginTop: '1rem', opacity: 0.75, fontSize: '0.9rem' }}>
+              Waiting for the experience to start...
+            </p>
+          </>
+        )}
+      </section>
+    );
+  }
+
+  return null;
 }

--- a/app/frontend/Pages/Register.tsx
+++ b/app/frontend/Pages/Register.tsx
@@ -1,0 +1,120 @@
+import { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+
+export default function Register() {
+  const [email, setEmail] = useState('');
+  const [name, setName] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+  const { code } = useParams()
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    if (!email.trim()) {
+      setError('Please enter your email');
+      return;
+    }
+
+    if (!code.trim()) {
+      setError('Missing experience code');
+      return;
+    }
+
+    setIsLoading(true);
+    setError('');
+
+    try {
+      const response = await fetch('/api/experiences/register', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: email.trim(),
+          name: name.trim(),
+          code: code,
+        }),
+      });
+
+      const data = await response.json();
+
+      if (response.ok) {
+        // Store JWT and redirect to experience
+        localStorage.setItem('experience_jwt', data.jwt);
+        window.location.href = data.url;
+      } else {
+        setError(data.error || 'Registration failed');
+      }
+    } catch (err) {
+      setError('Connection error. Please try again.');
+      console.error('Registration error:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleEmailChange = (e) => {
+    setEmail(e.target.value);
+    // Clear error when user starts typing
+    if (error) {
+      setError('');
+    }
+  };
+
+  const handleNameChange = (e) => {
+    setName(e.target.value);
+    // Clear error when user starts typing
+    if (error) {
+      setError('');
+    }
+  };
+
+  const handleKeyPress = (e) => {
+    if (e.key === 'Enter') {
+      handleSubmit(e);
+    }
+  };
+
+  return (
+    <section className="page flex-centered">
+      <p className="hero-subtitle">Register for Experience</p>
+      <p style={{ marginBottom: '20px', opacity: 0.8 }}>Code: {code}</p>
+
+      <form onSubmit={handleSubmit}>
+        <input
+          className="join-input"
+          type="email"
+          placeholder="Your Email"
+          value={email}
+          onChange={handleEmailChange}
+          onKeyPress={handleKeyPress}
+          disabled={isLoading}
+          maxLength={100}
+          style={{ marginBottom: '0.5rem' }}
+        />
+
+        <input
+          className="join-input"
+          type="text"
+          placeholder="Your Name (optional)"
+          value={name}
+          onChange={handleNameChange}
+          onKeyPress={handleKeyPress}
+          disabled={isLoading}
+          maxLength={100}
+        />
+
+        {error && (
+          <p className="error-message" style={{ color: 'red', marginTop: '8px' }}>
+            {error}
+          </p>
+        )}
+
+        <button className="join-submit" type="submit" disabled={isLoading || !email.trim()}>
+          {isLoading ? 'Registering...' : 'Register'}
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/app/models/experience.rb
+++ b/app/models/experience.rb
@@ -2,9 +2,10 @@ class Experience < ApplicationRecord
   has_many :experience_participants, dependent: :destroy
   has_many :users, through: :experience_participants
 
+  belongs_to :creator, class_name: 'User'
+
   validates :code, presence: true, uniqueness: true, length: { minimum: 1, maximum: 255 }
 
-  # Convenience method to find experience by code
   def self.find_by_code(code)
     find_by(code: code)
   end
@@ -19,14 +20,32 @@ class Experience < ApplicationRecord
     users.include?(user)
   end
 
-  # Add a user to this experience with fingerprint
-  def add_user(user, fingerprint)
-    return if has_user?(user)
-    experience_participants.create!(user: user, fingerprint: fingerprint)
+  def user_registered?(user)
+    has_user?(user)
   end
 
-  # Find participant by fingerprint
-  def find_participant_by_fingerprint(fingerprint)
-    experience_participants.includes(:user).find_by(fingerprint: fingerprint)
+  def register_user(user)
+    users << user
+  end
+
+  # Add a user to this experience with fingerprint
+  def add_user(user)
+    return if has_user?(user)
+
+    experience_participants.create!(user: user)
+  end
+
+  def jwt_token_for(user)
+    ExperienceAuthService.jwt_token_for(self, user)
+  end
+
+  def validate_code(code)
+    return [false, "Nil code"] if code.nil?
+
+    if Experience.exists?(code: code)
+      [false, "Experience already exists with code: #{code}"]
+    else
+      [true, "Valid code"]
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,21 @@
 class User < ApplicationRecord
   has_many :experience_participants, dependent: :destroy
   has_many :experiences, through: :experience_participants
+  has_many :created_experiences, class_name: "Experience", foreign_key: :creator_id, dependent: :destroy
+
+  enum role: {
+    member: "member",
+    admin: "admin",
+    superadmin: "superadmin"
+  }
 
   validates :name, presence: true, length: { minimum: 1, maximum: 255 }
+  validates :email,
+    presence: true,
+    format: { with: URI::MailTo::EMAIL_REGEXP },
+    uniqueness: { case_sensitive: false }
+
+  passwordless_with :email
+
+  before_save { self.email = email.downcase.strip }
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,3 @@
+class ApplicationPolicy < ActionPolicy::Base
+  authorize :user, optional: true
+end

--- a/app/policies/experience_policy.rb
+++ b/app/policies/experience_policy.rb
@@ -1,0 +1,13 @@
+class ExperiencePolicy < ApplicationPolicy
+  def create?
+    user&.admin? || user&.superadmin?
+  end
+
+  def show?
+    true
+  end
+
+  def register?
+    true
+  end
+end

--- a/app/services/experience_auth_service.rb
+++ b/app/services/experience_auth_service.rb
@@ -1,0 +1,23 @@
+class ExperienceAuthService
+  JWT_SECRET = ENV.fetch("JWT_EXPERIENCE_SECRET", "todo-implement")
+
+  def self.jwt_token_for(experience, user)
+    new(experience).jwt_token_for(user)
+  end
+
+  attr_reader :experience
+  def initialize(experience)
+    @experience = experience
+  end
+
+  def jwt_token_for(user)
+    JWT.encode(
+      {
+        user_id: user.id,
+        experience_id: experience.id,
+        exp: (24 * 7).hours.from_now.to_i
+      },
+      JWT_SECRET
+    )
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,6 @@
   </head>
 
   <body>
-    <div id="root"></div>
     <%= yield %>
   </body>
 </html>

--- a/app/views/spa/index.html.erb
+++ b/app/views/spa/index.html.erb
@@ -1,0 +1,1 @@
+<div id="root"></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  passwordless_for :users
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
@@ -10,27 +10,20 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   namespace :api do
-    resources :experiences, only: [:create] do
+    resources :experiences, only: [:create, :show] do
       collection do
         post :join
+        post :register
       end
     end
-
-    # Lobby routes
-    get '/lobby/:code', to: 'experience_lobby#show'
-    post '/lobby/:code/join', to: 'experience_lobby#join'
-    post 'lobby/:code/check_fingerprint', to: 'experience_lobby#check_fingerprint'
-    post '/lobby/:code/start', to: 'lobby#start'
   end
 
-  get '/join', to: 'application#index'
-  get '/lobby/:code', to: 'application#index'
-  get '/experiences/:code', to: 'application#index'
+  get '/experiences/register', to: 'spa#index'
+  get '/experiences/:code', to: 'spa#index'
 
-
-  get '*path', to: 'application#index', constraints: ->(request) do
+  get '*path', to: 'spa#index', constraints: ->(request) do
     !request.xhr? && request.format.html?
   end
 
-  root 'application#index'
+  root 'spa#index'
 end

--- a/db/migrate/20250908202627_create_passwordless_sessions.passwordless_engine.rb
+++ b/db/migrate/20250908202627_create_passwordless_sessions.passwordless_engine.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# This migration comes from passwordless_engine (originally 20171104221735)
+class CreatePasswordlessSessions < ActiveRecord::Migration[6.0]
+  def change
+    create_table(:passwordless_sessions) do |t|
+      t.belongs_to(
+        :authenticatable,
+        polymorphic: true,
+        type: :uuid,
+        index: {name: "authenticatable"}
+      )
+
+      t.datetime(:timeout_at, null: false)
+      t.datetime(:expires_at, null: false)
+      t.datetime(:claimed_at)
+      t.string(:token_digest, null: false)
+      t.string(:identifier, null: false, index: {unique: true}, length: 36)
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250912153256_add_email_to_users.rb
+++ b/db/migrate/20250912153256_add_email_to_users.rb
@@ -1,0 +1,10 @@
+class AddEmailToUsers < ActiveRecord::Migration[7.2]
+  def change
+    # citext is a case insensitive data type. This allows us to consider emails:
+    # "X@y.com" and "x@y.com" as the same at the database level
+    enable_extension 'citext'
+
+    add_column :users, :email, :citext, null: false
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/migrate/20250912154444_add_roles_enum_and_virtual_role_cols_to_user.rb
+++ b/db/migrate/20250912154444_add_roles_enum_and_virtual_role_cols_to_user.rb
@@ -1,0 +1,46 @@
+class AddRolesEnumAndVirtualRoleColsToUser < ActiveRecord::Migration[7.2]
+  def change
+    create_enum "user_roles", ["user", "admin", "superadmin"]
+
+    add_column :users,
+      :role, :enum,
+      enum_type: "user_roles",
+      default: "user",
+      null: false
+
+    admin_sql = <<~SQL
+      CASE
+          WHEN (role = 'admin'::user_roles) THEN true
+          ELSE false
+      END
+    SQL
+
+    super_admin_sql = <<~SQL
+      CASE
+          WHEN (role = 'superadmin'::user_roles) THEN true
+          ELSE false
+      END
+    SQL
+
+    add_column :users,
+      :admin,
+      :virtual,
+      type: :boolean,
+      as: admin_sql,
+      stored: true
+
+    add_column :users,
+      :super_admin,
+      :virtual,
+      type: :boolean,
+      as: super_admin_sql,
+      stored: true
+  end
+
+  def down
+    remove_column :users, :super_admin
+    remove_column :users, :admin
+    remove_column :users, :role
+    drop_enum "user_roles"
+  end
+end

--- a/db/migrate/20250912171844_add_creator_id_to_experiences.rb
+++ b/db/migrate/20250912171844_add_creator_id_to_experiences.rb
@@ -1,0 +1,10 @@
+class AddCreatorIdToExperiences < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :experiences,
+      :creator,
+      null: false,
+      type: :uuid,
+      foreign_key: { to_table: :users, on_delete: :cascade },
+      index: true
+  end
+end

--- a/documents/registration_flow.md
+++ b/documents/registration_flow.md
@@ -1,0 +1,48 @@
+# User Registration
+
+```mermaid
+flowchart TD
+    A[User visits /join] --> B{Code prefilled from QR?}
+    B -->|Yes| C[Join form with prefilled code]
+    B -->|No| D[Join form - empty]
+
+    C --> E[User submits code]
+    D --> E
+
+    E --> F[POST /api/experiences/join]
+    F --> G{Valid experience code?}
+
+    G -->|No| H[Show error: Invalid code]
+    H --> D
+
+    G -->|Yes| I{User in session?}
+    I -->|No| J[Redirect to /register?code=XXX]
+    I -->|Yes| K{User registered for experience?}
+
+    K -->|No| J
+    K -->|Yes| L[Return JWT + experience_url]
+
+    J --> M[Registration form]
+    M --> N[User enters email]
+    N --> O[POST /api/experiences/register]
+
+    O --> P{Valid registration?}
+    P -->|No| Q[Show error]
+    Q --> M
+
+    P -->|Yes| R[Create/find user<br/>Register for experience<br/>Set session]
+    R --> S[Return JWT + experience_url]
+
+    L --> T[Store JWT in localStorage]
+    S --> T
+    T --> U[Redirect to /experience/:code]
+
+    U --> V[Experience page loads]
+    V --> W[Use JWT for authenticated requests]
+
+    style A fill:#e1f5fe
+    style U fill:#c8e6c9
+    style V fill:#c8e6c9
+    style H fill:#ffcdd2
+    style Q fill:#ffcdd2
+```


### PR DESCRIPTION
# User management

This adds in basic user roles and ensures email presence over name

Roles are: `user`, `admin`, and `superadmin`.

_Super admin is reserved for devs who need global access. All application use cases go through user or admin._

There are basic policy checks on the create endpoint. Everything else is open.

# Data Model & API

The experience management is all done via a single experience api. The "lobby" concept is just a state of an experience. The front end can still make lobby pages, or pages to other states, but from a routing/logic perspective I've tried to simplify this down to a single entity (experience).

For the game management (interactivity) this will be modelled by states of the experience, which the front-end can consume and build on top of on any way it needs. This will de couple the API from the actual user experiences we want to build. It also makes it more "graphql" like which will ease that migration if we want to go that way.

Application auth is done with [passwordless](https://github.com/mikker/passwordless). This renders the default routes, which look like garbage for now.

I've moved the SPA routing off to a dedicated controller. This will help in the future for meta tags and other SPA concerns, and allow us to serve up other content if needed. e.g the passwordless sign-in pages. This doesn't stop us from moving the passwordless experience to the SPA, just moves us forward quickly.

## Experience Flow.

The other big change here is the formalization of the experience flow.

I've modeled this in a [mermaid chart](https://mermaid.live/edit#pako:eNqNU9ly2yAU_RWGPjaJ6njXtMkkdjZn8560cqZDpCubVhIqoCx1_O9FINm4nczUD4zhnuUeLlpinwWAXRxG7NlfEC7RuDtLkPodeRMBHD1RQaVAzg9Gkwe0u3uAjpcdxUEph5BGEQQo5CxGg-HhyhCPc9TbVxBvqOP1FA2FjMfomcqFRcp9H2zCDXtDXQu_iyBO5WuBMWtHN3BiOhPZY5y3Zil1Td2mnOijU69_Oxojh6TUgZcUOIXEB2FSGeCpBp4tpySiAdqAtH6Zzaxn64bPvdGCPSPgnHEXXSRPmmx1dK5Vu_-y9f1cLHUSFVmAEJQlpc_F2qHnDSGgHHyJJEMOhzkVEvhh7vHl_v7-wSZo0UsjWiLzATFuBdrOcrlxsg-00pXylhlPUO9ujD5aEt8zHm0NpqdjXit8bsqJVFn0GAvUta7fmMFBotoSaryElio3un77zpTKKFuWt5rSL-bFLeMyYH8dbWCNqRAZmI5txf4m-dDrcCASnJAmAcpU158fuXMwLBr560Z1bQSynGJhMdQWo_--xCuNH3sjyThouHoYEfNJlJ-QefmmRgZnNmO9mWy_ko2J41qP0awTzZh6J5snnipx5UQCUSCnGnOXz0s3kuclmVyo0VFf3Ut-4b8yEDInGIqQrxGgI5R_3-4HqIT1EOzKpKj4LWj4bbsyfbdyXlTC0A-Cfbsy2KrgHTznNMCu5Bns4Bi4eltqi5c5Z4ZV4zHMsKv-BoT_nOFZslKclCTfGItLGmfZfIHdkERC7bI0UEG7lMw5idenHJIAeIdlicTufkVrYHeJX9SuUd1r16rVVr3WqlfaefEVu7XKXrvarDVb1Xa9Wak0qo3VDv6tXT_ttZr11R-8vbfK) under documentation as it is actually slightly more complex than we had it modeled.

What I have setup is as follows:
### Step 1 "Join".

This refers to a page that will ask for a "code". This can be directly navigated to, or redirected to from another source.

I imagine if a QR code is used, or another redirect (e.g a ticketing system integration gives a link to a user) we don't actually need a user to input a code. It'll auto-fill and submit, or skip this page and go straight to step 2.

### Step 2 "Register"

Here is where we collect details and see if a user is able to "register" for the event.

It asks for an email and optionally a name. The name is in the wrong place here, as what we really need is a "username" which will be saved on the experience_participant. Returning users can have it prefilled with the "most recent" exerpience_participant user name, as an example. but for now I've just optionally kept the field here.

Here is where we can also perform "authorization" in the future. For example, if we know a person has paid for a ticket in advance, we should have knowledge of that and we'll know we can register that email as an in person experience_participant. Other options here will be things like a ticketing integration where a user gets a unique code with their ticket. Register is the verb that encapsulates all of that.

### Step 3 "Experience"

After registration someone is "in the experience". I figure we can model this like a game in the future with state transitions. For now it just always returns a "lobby" state and the experience page renders lobby stuff from the lobby component. Obviously lots of cleanup here but I wanted to get this in place quickly so people could hack on the frontend of the experience and start getting patterns they liked in place.

## Misc:
* Remove all finger print logic. That was a hack to get session less state for the demo. The col still exists as optional as it is a viable future state, but not needed now.
* There is no create page, I know this is built on other branches. I just have a back end api route for it.
* I'm not using the auth, just generating it, storing it, and passing it around.