### PR TITLE
Show Admin hints when not registered.

### DIFF
--- a/app/frontend/Contexts/UserContext.tsx
+++ b/app/frontend/Contexts/UserContext.tsx
@@ -4,7 +4,11 @@ interface User {
   id: string;
   email: string;
   name: string;
-  role: 'admin' | 'user' | 'superuser';
+  created_at: string;
+  updated_at: string;
+  role: 'superadmin' | 'admin' | 'user';
+  admin: boolean;
+  super_admin: boolean;
 }
 
 interface UserContextType {
@@ -26,7 +30,7 @@ export function UserProvider({ children }: UserProviderProps) {
   const [isLoading, setIsLoading] = useState(true);
 
   const isAuthenticated = user !== null;
-  const isAdmin = user?.role === 'admin' || user?.role === 'superadmin';
+  const isAdmin = user?.super_admin === true || user?.admin === true;
 
   const refreshUser = async () => {
     setIsLoading(true);

--- a/app/frontend/Pages/Experience/Experience.module.scss
+++ b/app/frontend/Pages/Experience/Experience.module.scss
@@ -111,3 +111,45 @@
 .disconnected {
   color: var(--yellow);
 }
+
+// Admin notification styles
+.adminNotification {
+  background-color: rgba(255, 165, 0, 0.15);
+  border: 1px solid rgba(255, 165, 0, 0.3);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.adminMessage {
+  margin: 0 0 1rem 0;
+  color: var(--yellow);
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.adminActions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.adminActionButton {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: var(--white);
+  text-decoration: none;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  transition: all 0.2s ease;
+
+  &:hover {
+    background-color: rgba(255, 255, 255, 0.2);
+    border-color: rgba(255, 255, 255, 0.4);
+    text-decoration: none;
+  }
+}

--- a/app/frontend/Pages/Experience/Experience.tsx
+++ b/app/frontend/Pages/Experience/Experience.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 
 import { useExperience } from '@cctv/contexts/ExperienceContext';
+import { useUser } from '@cctv/contexts/UserContext';
 import ExperienceBlockContainer from '@cctv/experiences/ExperienceBlockContainer/ExperienceBlockContainer';
 
 import styles from './Experience.module.scss';
@@ -17,6 +18,7 @@ export default function Experience() {
     wsConnected,
     wsError,
   } = useExperience();
+  const { isAdmin } = useUser();
 
   if (isLoading) {
     return (
@@ -53,6 +55,23 @@ export default function Experience() {
           <div className={styles.experienceInfo}>
             <h2 className={styles.experienceName}>{experience.name}</h2>
             <p className={styles.experienceStatus}>Status: {experience.status}</p>
+          </div>
+        )}
+
+        {/* Admin viewing notification */}
+        {isAdmin && !participant && (
+          <div className={styles.adminNotification}>
+            <p className={styles.adminMessage}>
+              You're viewing this experience as an admin but aren't registered as a participant.
+            </p>
+            <div className={styles.adminActions}>
+              <Link to={`/experiences/${code}/register`} className={styles.adminActionButton}>
+                Register to Participate
+              </Link>
+              <Link to={`/experiences/${code}/manage`} className={styles.adminActionButton}>
+                Manage Experience
+              </Link>
+            </div>
           </div>
         )}
 
@@ -111,6 +130,24 @@ export default function Experience() {
       <section className="page">
         <div className={styles.activeExperience}>
           <h1 className={styles.title}>{experience?.name || code}</h1>
+
+          {/* Admin viewing notification */}
+          {isAdmin && !participant && (
+            <div className={styles.adminNotification}>
+              <p className={styles.adminMessage}>
+                You're viewing this experience as an admin but aren't registered as a participant.
+              </p>
+              <div className={styles.adminActions}>
+                <Link to={`/experiences/${code}/register`} className={styles.adminActionButton}>
+                  Register to Participate
+                </Link>
+                <Link to={`/experiences/${code}/manage`} className={styles.adminActionButton}>
+                  Manage Experience
+                </Link>
+              </div>
+            </div>
+          )}
+
           <div className={styles.experienceContent}>
             {openBlock && participant ? (
               <div className={styles.activeBlock}>


### PR DESCRIPTION
Note: this was a quick AI implementation to prompt an admin who was viewing an experience but wasn't registered.

We may just redirect them to the register or manage page in the future, but for now I just wanted to make sure people weren't confused why they weren't seeing themselves if they:
* logged in as admin
* did not regsiter for experience
* visisted the experience show page