### PR TITLE
More Manage page polish

### DIFF
--- a/app/frontend/Contexts/ExperienceContext.tsx
+++ b/app/frontend/Contexts/ExperienceContext.tsx
@@ -354,6 +354,7 @@ export function ExperienceProvider({ children }: ExperienceProviderProps) {
     setJWT: setJWTHandler,
     clearJWT,
     experienceFetch,
+    refetchExperience: loadExperienceData,
 
     // WebSocket properties
     wsConnected,

--- a/app/frontend/Core/Dropdown/Dropdown.module.scss
+++ b/app/frontend/Core/Dropdown/Dropdown.module.scss
@@ -7,3 +7,19 @@
   font-weight: 600;
   color: var(--white);
 }
+
+.input {
+  z-index: 3;
+  position: relative;
+  font-size: 16px;
+  color: var(--white);
+  background: var(--black);
+  border: 2px solid var(--white);
+  padding: 4px;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: border-color 0.2s ease;
+}
+.input:hover {
+  border-color: var(--yellow);
+}

--- a/app/frontend/Core/Pill/Pill.module.scss
+++ b/app/frontend/Core/Pill/Pill.module.scss
@@ -1,0 +1,11 @@
+.pill {
+  display: inline-block;
+  font-size: 0.75rem;
+  line-height: 1;
+  padding: 0.35rem 0.5rem;
+  border-radius: 9999px;
+  background: var(--pill-bg, #f3f4f6);
+  color: var(--pill-fg, #374151);
+  border: 1px solid var(--pill-border, #e5e7eb);
+  margin-right: 0.25rem;
+}

--- a/app/frontend/Core/Pill/Pill.tsx
+++ b/app/frontend/Core/Pill/Pill.tsx
@@ -1,0 +1,5 @@
+import styles from './Pill.module.scss';
+
+export function Pill({ label }: { label: string }) {
+  return <span className={styles.pill}>{label}</span>;
+}

--- a/app/frontend/Core/Table/Table.module.scss
+++ b/app/frontend/Core/Table/Table.module.scss
@@ -1,0 +1,126 @@
+.tableWrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.table thead th {
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.825rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--card-border, #e5e7eb);
+  white-space: nowrap;
+}
+
+.table tbody td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--row-border, #f1f5f9);
+  vertical-align: top;
+}
+
+.table tbody tr:hover {
+  background: var(--row-hover, #fafafa);
+  color: black;
+}
+
+.table tbody tr td {
+  text-align: left;
+}
+
+.mono {
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+  font-size: 0.85em;
+}
+
+.rowMenuCell {
+  width: 1%;
+  white-space: nowrap;
+  text-align: left;
+  color: white;
+  background: black;
+}
+
+.menu {
+  position: relative;
+  display: inline-block;
+  z-index: 11;
+}
+
+.menuButton {
+  list-style: none;
+  cursor: pointer;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  border: 1px solid var(--btn-border, #e5e7eb);
+  background: var(--btn-bg, #fff);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.menuButton::-webkit-details-marker {
+  display: none;
+}
+
+.menuButton:focus-visible {
+  outline: 2px solid var(--focus, #2563eb);
+  outline-offset: 2px;
+}
+
+/* Kebab icon */
+.menuButton::after {
+  content: '⋮';
+  font-size: 16px;
+  line-height: 1;
+  color: var(--btn-fg, #374151);
+}
+
+.menu[open] .menuButton {
+  background: var(--btn-hover, #f9fafb);
+}
+
+.menuList {
+  position: absolute;
+  color: black;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 160px;
+  border: 1px solid var(--menu-border, #e5e7eb);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+  padding: 6px;
+  z-index: 20;
+}
+
+.menuItem {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.menuItem:hover:not(:disabled) {
+  background: var(--row-hover, #f3f4f6);
+}
+
+.menuItem:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}

--- a/app/frontend/Core/Table/Table.tsx
+++ b/app/frontend/Core/Table/Table.tsx
@@ -1,0 +1,55 @@
+import { ReactNode } from 'react';
+
+import styles from './Table.module.scss';
+
+export interface Column<T extends object> {
+  key: string;
+  label: string;
+  isHidden?: boolean;
+  Cell?: (value: T) => ReactNode;
+}
+
+export interface TableProps<T extends object> {
+  columns: Column<T>[];
+  data: T[];
+  emptyState?: ReactNode;
+}
+
+export function Table<T extends object>({ columns, data, emptyState }: TableProps<T>) {
+  if (!data?.length) {
+    return <div className={styles.emptyState}>{emptyState}</div>;
+  }
+
+  return (
+    <div className={styles.tableWrap}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            {columns.map((column) => (
+              <th
+                key={column.key as string}
+                aria-label={column.isHidden ? column.label : undefined}
+              >
+                {column.isHidden ? null : column.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((data, index) => {
+            const row = columns.map((column) => column.Cell?.(data) || data[column.key as keyof T]);
+            const rowKey = 'row-' + index;
+
+            return (
+              <tr key={'row:' + index}>
+                {row.map((cell, cellIndex) => {
+                  return <td key={rowKey + '-cell-' + cellIndex}>{cell as ReactNode}</td>;
+                })}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/frontend/Core/index.ts
+++ b/app/frontend/Core/index.ts
@@ -3,3 +3,5 @@ export { Button } from './Button/Button';
 export { TextInput } from './TextInput/TextInput';
 export { Pill } from './Pill/Pill';
 export { Dropdown } from './Dropdown/Dropdown';
+export { Table } from './Table/Table';
+export type { Column } from './Table/Table';

--- a/app/frontend/Core/index.ts
+++ b/app/frontend/Core/index.ts
@@ -1,3 +1,5 @@
 export { Option } from './Option/Option';
 export { Button } from './Button/Button';
 export { TextInput } from './TextInput/TextInput';
+export { Pill } from './Pill/Pill';
+export { Dropdown } from './Dropdown/Dropdown';

--- a/app/frontend/Experiences/ExperienceBlockContainer/ExperienceBlockContainer.tsx
+++ b/app/frontend/Experiences/ExperienceBlockContainer/ExperienceBlockContainer.tsx
@@ -7,7 +7,7 @@ import Question from '../Question/Question';
 
 interface ExperienceBlockContainerProps {
   block: Block;
-  participant: ParticipantSummary;
+  participant?: ParticipantSummary;
   disabled?: boolean;
 }
 

--- a/app/frontend/Experiences/Question/Question.module.scss
+++ b/app/frontend/Experiences/Question/Question.module.scss
@@ -7,41 +7,20 @@
 }
 
 .fieldset {
-  border: 2px solid var(--card-border, #e9ecef);
-  border-radius: 8px;
-  padding: 24px;
-  margin: 0 auto;
-  max-width: 600px;
+  border: none;
+}
+
+.legend,
+.value {
+  position: relative;
+  z-index: 3;
+  font-size: 28px;
   width: 100%;
-  background: var(--card-bg, #f8f9fa);
+  color: var(--yellow);
+  padding-top: 12px;
 }
 
 .legend {
-  font-size: 1.2rem;
-  font-weight: 600;
-  color: var(--text-primary, #333);
-  margin-bottom: 1rem;
-  padding: 0 0.5rem;
-}
-
-.value {
-  font-size: 1rem;
-  color: var(--muted-fg, #6b7280);
-  margin: 0;
-}
-
-.submittedValue {
-  background: var(--card-bg, #f8f9fa);
-  border: 2px solid var(--card-border, #e9ecef);
-  border-radius: 8px;
-  padding: 24px;
-  margin: 0 auto;
-  max-width: 600px;
-  text-align: center;
-}
-
-.error {
-  color: var(--error-fg, #991b1b);
-  font-size: 0.875rem;
-  margin-bottom: 1rem;
+  font-size: 32px;
+  color: white;
 }

--- a/app/frontend/Hooks/useCreateExperienceBlock.ts
+++ b/app/frontend/Hooks/useCreateExperienceBlock.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 
 import { useExperience } from '@cctv/contexts/ExperienceContext';
+import { Block } from '@cctv/types';
 import { qaLogger } from '@cctv/utils';
 
 type BlockStatus = 'hidden' | 'open' | 'closed';
@@ -17,11 +18,15 @@ export interface CreateExperienceBlockParams {
 
 export interface CreateExperienceBlockResponse {
   success: boolean;
-  data?: any;
+  data?: Block;
   error?: string;
 }
 
-export function useCreateExperienceBlock() {
+export function useCreateExperienceBlock({
+  refetchExperience,
+}: {
+  refetchExperience: () => Promise<void>;
+}) {
   const { code, experienceFetch } = useExperience();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -80,6 +85,9 @@ export function useCreateExperienceBlock() {
         }
 
         qaLogger('Successfully created block');
+
+        await refetchExperience();
+
         return data;
       } catch (e: any) {
         const msg =

--- a/app/frontend/Hooks/useCreateExperienceBlock.ts
+++ b/app/frontend/Hooks/useCreateExperienceBlock.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 
 import { useExperience } from '@cctv/contexts/ExperienceContext';
-import { Block } from '@cctv/types';
+import { Block, CreateExperienceApiResponse } from '@cctv/types';
 import { qaLogger } from '@cctv/utils';
 
 type BlockStatus = 'hidden' | 'open' | 'closed';
@@ -14,12 +14,6 @@ export interface CreateExperienceBlockParams {
   target_user_ids?: string[];
   status?: BlockStatus; // defaults to "hidden"
   open_immediately?: boolean; // defaults to false
-}
-
-export interface CreateExperienceBlockResponse {
-  success: boolean;
-  data?: Block;
-  error?: string;
 }
 
 export function useCreateExperienceBlock({
@@ -40,7 +34,7 @@ export function useCreateExperienceBlock({
       target_user_ids = [],
       status = 'hidden',
       open_immediately = false,
-    }: CreateExperienceBlockParams): Promise<CreateExperienceBlockResponse | null> => {
+    }: CreateExperienceBlockParams): Promise<CreateExperienceApiResponse | null> => {
       if (!code) {
         setError('Missing experience code');
         return null;
@@ -76,12 +70,12 @@ export function useCreateExperienceBlock({
           body: JSON.stringify({ experience: submitPayload }),
         });
 
-        const data: CreateExperienceBlockResponse = await res.json();
+        const data: CreateExperienceApiResponse = await res.json();
 
         if (!data?.success) {
           const msg = data?.error || 'Block create failed';
           setError(msg);
-          return { success: false, error: msg };
+          return { type: 'error', success: false, error: msg, message: msg };
         }
 
         qaLogger('Successfully created block');

--- a/app/frontend/Pages/Manage/BlocksTable/BlocksTable.tsx
+++ b/app/frontend/Pages/Manage/BlocksTable/BlocksTable.tsx
@@ -1,7 +1,6 @@
+import { Pill } from '@cctv/core';
 import { Block, BlockStatus, ParticipantSummary } from '@cctv/types';
 import { fmtDate } from '@cctv/utils';
-
-import { KVPill } from '../Manage';
 
 import styles from './BlocksTable.module.scss';
 
@@ -42,7 +41,7 @@ export function BlocksTable({
               <td className={styles.mono}>{b.id}</td>
               <td>{b.kind}</td>
               <td>
-                <KVPill label={b.status} />
+                <Pill label={b.status} />
                 {busyId === b.id && <span className={styles.subtle}> • updating…</span>}
               </td>
               <td>
@@ -78,12 +77,12 @@ export function BlocksTable({
               </td>
               <td>
                 {b.visible_to_roles?.length
-                  ? b.visible_to_roles.map((r) => <KVPill key={r} label={r} />)
+                  ? b.visible_to_roles.map((r) => <Pill key={r} label={r} />)
                   : '—'}
               </td>
               <td>
                 {b.visible_to_segments?.length
-                  ? b.visible_to_segments.map((s) => <KVPill key={s} label={s} />)
+                  ? b.visible_to_segments.map((s) => <Pill key={s} label={s} />)
                   : '—'}
               </td>
               <td>{b.target_user_ids?.length ?? 0}</td>

--- a/app/frontend/Pages/Manage/BlocksTable/BlocksTable.tsx
+++ b/app/frontend/Pages/Manage/BlocksTable/BlocksTable.tsx
@@ -1,4 +1,6 @@
-import { Pill } from '@cctv/core';
+import { useMemo } from 'react';
+
+import { Column, Pill, Table } from '@cctv/core';
 import { Block, BlockStatus, ParticipantSummary } from '@cctv/types';
 import { fmtDate } from '@cctv/utils';
 
@@ -15,87 +17,62 @@ export function BlocksTable({
   busyId?: string | null;
   participants?: ParticipantSummary[];
 }) {
-  if (!blocks?.length) return <div className={styles.emptyState}>No blocks yet.</div>;
-
   const totalParticipants = participants?.length || 0;
 
-  return (
-    <div className={styles.tableWrap}>
-      <table className={styles.table}>
-        <thead>
-          <tr>
-            <th>Block ID</th>
-            <th>Kind</th>
-            <th>Status</th>
-            <th>Responses</th>
-            <th>Visible roles</th>
-            <th>Segments</th>
-            <th>Targets</th>
-            <th>Created</th>
-            <th aria-label="Row actions" />
-          </tr>
-        </thead>
-        <tbody>
-          {blocks.map((b) => (
-            <tr key={b.id}>
-              <td className={styles.mono}>{b.id}</td>
-              <td>{b.kind}</td>
-              <td>
-                <Pill label={b.status} />
-                {busyId === b.id && <span className={styles.subtle}> • updating…</span>}
-              </td>
-              <td>
-                {b.responses ? (
-                  <div>
-                    <div>
-                      {b.responses.total} / {totalParticipants}
-                    </div>
-                    {b.kind === 'poll' &&
-                      b.responses.aggregate &&
-                      Object.keys(b.responses.aggregate).length > 0 && (
-                        <details className={styles.pollDetails}>
-                          <summary>View breakdown</summary>
-                          <ul className={styles.pollBreakdown}>
-                            {Object.entries(b.responses?.aggregate || {}).map(([option, count]) => (
-                              <li key={option}>
-                                {option}: {count} (
-                                {Math.round((count / (b.responses?.total || 1)) * 100)}%)
-                              </li>
-                            ))}
-                          </ul>
-                        </details>
-                      )}
-                    {(b.kind === 'question' || b.kind === 'multistep_form') && (
-                      <div className={styles.responseCount}>
-                        {b.responses.total} response{b.responses.total !== 1 ? 's' : ''}
-                      </div>
-                    )}
-                  </div>
-                ) : (
-                  '—'
-                )}
-              </td>
-              <td>
-                {b.visible_to_roles?.length
-                  ? b.visible_to_roles.map((r) => <Pill key={r} label={r} />)
-                  : '—'}
-              </td>
-              <td>
-                {b.visible_to_segments?.length
-                  ? b.visible_to_segments.map((s) => <Pill key={s} label={s} />)
-                  : '—'}
-              </td>
-              <td>{b.target_user_ids?.length ?? 0}</td>
-              <td>{fmtDate(b.created_at)}</td>
-              <td className={styles.rowMenuCell}>
-                <BlockRowMenu block={b} onChange={(s) => onChange(b, s)} busy={busyId === b.id} />
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
+  const columns: Column<Block>[] = useMemo(() => {
+    return [
+      { key: 'id', label: 'Block ID', Cell: (b) => <span className={styles.mono}>{b.id}</span> },
+      { key: 'kind', label: 'Kind', Cell: (b) => <span>{b.kind}</span> },
+      { key: 'status', label: 'Status', Cell: (b) => <Pill label={b.status} /> },
+      {
+        key: 'responses',
+        label: 'Responses',
+        Cell: (b) => (
+          <span>
+            {b.responses?.total} / {totalParticipants}
+          </span>
+        ),
+      },
+      {
+        key: 'visible_to_roles',
+        label: 'Visible roles',
+        Cell: (b) => (
+          <span>
+            {b.visible_to_roles?.length
+              ? b.visible_to_roles.map((r) => <Pill key={r} label={r} />)
+              : '—'}
+          </span>
+        ),
+      },
+      {
+        key: 'visible_to_segments',
+        label: 'Segments',
+        Cell: (b) => (
+          <span>
+            {b.visible_to_segments?.length
+              ? b.visible_to_segments.map((s) => <Pill key={s} label={s} />)
+              : '—'}
+          </span>
+        ),
+      },
+      {
+        key: 'target_user_ids',
+        label: 'Targets',
+        Cell: (b) => <span>{b.target_user_ids?.length ?? 0}</span>,
+      },
+      { key: 'created_at', label: 'Created', Cell: (b) => <span>{fmtDate(b.created_at)}</span> },
+      {
+        key: 'actions',
+        label: 'Actions',
+        isHidden: true,
+        Cell: (b) => (
+          <BlockRowMenu block={b} onChange={(s) => onChange(b, s)} busy={busyId === b.id} />
+        ),
+      },
+    ];
+  }, []);
+
+  return <Table columns={columns} data={blocks} emptyState="No blocks yet." />;
 }
 
 function BlockRowMenu({

--- a/app/frontend/Pages/Manage/CreateExperience/CreateExperience.module.scss
+++ b/app/frontend/Pages/Manage/CreateExperience/CreateExperience.module.scss
@@ -84,3 +84,10 @@
   justify-content: space-between;
   width: 100%;
 }
+
+.error {
+  text-shadow: none;
+  color: var(--yellow);
+  padding-top: 12px;
+  font-size: 16px;
+}

--- a/app/frontend/Pages/Manage/Manage.module.scss
+++ b/app/frontend/Pages/Manage/Manage.module.scss
@@ -88,12 +88,6 @@
   opacity: 0.85;
 }
 
-.headerRow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
 .meta {
   display: flex;
   align-items: center;
@@ -108,11 +102,6 @@
   gap: 0.5rem;
 }
 
-.headerActions {
-  display: inline-flex;
-  gap: 0.5rem;
-}
-
 .card {
   background: var(--card-bg, black);
   border: 1px solid var(--card-border, #e5e7eb);
@@ -120,12 +109,6 @@
   padding: 1rem;
   margin: 1rem 0;
   box-shadow: var(--card-shadow, 0 1px 2px rgba(0, 0, 0, 0.04));
-}
-
-.cardTitle {
-  margin: 0 0 0.75rem 0;
-  font-size: 1rem;
-  font-weight: 600;
 }
 
 .errorBanner {
@@ -154,21 +137,6 @@
   margin: 0.5rem 0 0;
   padding-left: 1rem;
   font-size: 0.85rem;
-}
-
-/*********
- * Pills *
- *********/
-.pill {
-  display: inline-block;
-  font-size: 0.75rem;
-  line-height: 1;
-  padding: 0.35rem 0.5rem;
-  border-radius: 9999px;
-  background: var(--pill-bg, #f3f4f6);
-  color: var(--pill-fg, #374151);
-  border: 1px solid var(--pill-border, #e5e7eb);
-  margin-right: 0.25rem;
 }
 
 /***********

--- a/app/frontend/Pages/Manage/Manage.tsx
+++ b/app/frontend/Pages/Manage/Manage.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo, useState } from 'react';
 import classNames from 'classnames';
 
 import { useExperience } from '@cctv/contexts';
-import { Button, Pill } from '@cctv/core';
+import { Button, Column, Pill, Table } from '@cctv/core';
 import { useChangeBlockStatus, useExperienceStart } from '@cctv/hooks';
 import { Block, BlockStatus, Experience, ParticipantSummary } from '@cctv/types';
 
@@ -15,36 +15,6 @@ import ViewExperienceDetails from './ViewExperienceDetails/ViewExperienceDetails
 import ViewTvSection from './ViewTvSection/ViewTvSection';
 
 import styles from './Manage.module.scss';
-
-function ParticipantsTable({ rows }: { rows: ParticipantSummary[] }) {
-  if (!rows?.length) return <div className={styles.emptyState}>No participants yet.</div>;
-  return (
-    <div className={styles.tableWrap}>
-      <table className={styles.table}>
-        <thead>
-          <tr>
-            <th>ID</th>
-            <th>Name</th>
-            <th>Email</th>
-            <th>Role</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((p) => (
-            <tr key={`${p.role}:${p.id}`}>
-              <td className={styles.mono}>{p.id}</td>
-              <td>{p.name || '—'}</td>
-              <td>{p.email || '—'}</td>
-              <td>
-                <Pill label={p.role} />
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
-}
 
 export default function Manage() {
   const {
@@ -208,4 +178,17 @@ export default function Manage() {
       </div>
     </section>
   );
+}
+
+function ParticipantsTable({ rows }: { rows: ParticipantSummary[] }) {
+  const columns: Column<ParticipantSummary>[] = useMemo(() => {
+    return [
+      { key: 'id', label: 'ID', Cell: (p) => <span className={styles.mono}>{p.id}</span> },
+      { key: 'name', label: 'Name', Cell: (p) => <span>{p.name || '—'}</span> },
+      { key: 'email', label: 'Email', Cell: (p) => <span>{p.email || '—'}</span> },
+      { key: 'role', label: 'Role', Cell: (p) => <Pill label={p.role} /> },
+    ];
+  }, []);
+
+  return <Table columns={columns} data={rows} emptyState="No participants yet." />;
 }

--- a/app/frontend/Pages/Manage/SectionHeader/SectionHeader.module.scss
+++ b/app/frontend/Pages/Manage/SectionHeader/SectionHeader.module.scss
@@ -1,0 +1,16 @@
+.headerRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.cardTitle {
+  margin: 0 0 0.75rem 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.headerActions {
+  display: inline-flex;
+  gap: 0.5rem;
+}

--- a/app/frontend/Pages/Manage/SectionHeader/SectionHeader.tsx
+++ b/app/frontend/Pages/Manage/SectionHeader/SectionHeader.tsx
@@ -1,0 +1,16 @@
+import { PropsWithChildren } from 'react';
+
+import styles from './SectionHeader.module.scss';
+
+interface SectionHeaderProps extends PropsWithChildren {
+  title: string;
+}
+
+export default function SectionHeader({ title, children }: SectionHeaderProps) {
+  return (
+    <div className={styles.headerRow}>
+      <h2 className={styles.cardTitle}>{title}</h2>
+      <div className={styles.headerActions}>{children}</div>
+    </div>
+  );
+}

--- a/app/frontend/Pages/Manage/ViewAudienceSection/ViewAudienceSection.module.scss
+++ b/app/frontend/Pages/Manage/ViewAudienceSection/ViewAudienceSection.module.scss
@@ -1,0 +1,21 @@
+.viewNextBlock,
+.viewCurrentBlock,
+.viewDetails {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 16px;
+  gap: 16px;
+
+  background: rgba(0, 0, 0, 0.5);
+  border-radius: 12px;
+
+  z-index: 10;
+  box-shadow: var(--card-shadow, 0 8px 12px rgba(0, 0, 0, 0.4));
+  flex: 1;
+  min-height: 340px;
+}
+
+.screen {
+  width: 100%;
+}

--- a/app/frontend/Pages/Manage/ViewAudienceSection/ViewAudienceSection.tsx
+++ b/app/frontend/Pages/Manage/ViewAudienceSection/ViewAudienceSection.tsx
@@ -1,0 +1,75 @@
+import { useMemo } from 'react';
+
+import { Dropdown } from '@cctv/core';
+import { Experience } from '@cctv/types';
+
+import SectionHeader from '../SectionHeader/SectionHeader';
+import ViewBlockDetails from '../ViewBlockDetails/ViewBlockDetails';
+import ViewUserScreen from '../ViewUserScreen/ViewUserScreen';
+
+import styles from './ViewAudienceSection.module.scss';
+
+export default function ViewAudienceSection({
+  className,
+  experience,
+  participantId,
+  setSelectedParticipantId,
+}: {
+  className: string;
+  experience?: Experience;
+  participantId?: string;
+  setSelectedParticipantId: (participantId: string) => void;
+}) {
+  const participant = useMemo(() => {
+    if (!participantId) {
+      return undefined;
+    }
+
+    return experience?.participants.find((p) => p.id === participantId);
+  }, [experience, participantId]);
+
+  const { currentBlock, nextBlock } = useMemo(() => {
+    if (!experience) {
+      return { currentBlock: undefined, nextBlock: undefined };
+    }
+
+    const sortedBlocksByCreatedAt = experience.blocks.sort(
+      (a, b) => new Date(a.created_at || '').getTime() - new Date(b.created_at || '').getTime(),
+    );
+
+    const currentBlockIndex = sortedBlocksByCreatedAt.findIndex((block) => block.status === 'open');
+    const nextBlockIndex = currentBlockIndex + 1;
+
+    const currentBlock = sortedBlocksByCreatedAt.at(currentBlockIndex);
+    const nextBlock = sortedBlocksByCreatedAt.at(nextBlockIndex);
+
+    return { currentBlock, nextBlock };
+  }, [experience]);
+
+  if (!experience) {
+    return <div>No experience found</div>;
+  }
+
+  return (
+    <div className={className}>
+      <div className={styles.viewNextBlock}>
+        <SectionHeader title="Next view" />
+        <ViewUserScreen className={styles.screen} block={nextBlock} participant={participant} />
+      </div>
+      <div className={styles.viewDetails}>
+        <SectionHeader title="Experience Details" />
+        <ViewBlockDetails currentBlock={currentBlock} />
+        <Dropdown
+          options={experience.participants.map((p) => ({ label: p.name, value: p.id }))}
+          value={participantId}
+          onChange={setSelectedParticipantId}
+          label="Viewing as"
+        />
+      </div>
+      <div className={styles.viewCurrentBlock}>
+        <SectionHeader title="Current view" />
+        <ViewUserScreen className={styles.screen} block={currentBlock} participant={participant} />
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/Pages/Manage/ViewBlockDetails/ViewBlockDetails.tsx
+++ b/app/frontend/Pages/Manage/ViewBlockDetails/ViewBlockDetails.tsx
@@ -1,4 +1,5 @@
 import { Block } from '@cctv/types';
+import { capitalize } from '@cctv/utils';
 
 import styles from './ViewBlockDetails.module.scss';
 
@@ -9,9 +10,9 @@ export default function ViewBlockDetails({ currentBlock }: { currentBlock?: Bloc
 
   return (
     <div className={styles.viewBlockDetails}>
-      <div>Kind: {currentBlock?.kind}</div>
+      <div>Kind: {capitalize(currentBlock?.kind)}</div>
       <div>Responses: {currentBlock?.responses?.total}</div>
-      <div>Status: {currentBlock?.status}</div>
+      <div>Status: {capitalize(currentBlock?.status)}</div>
       {currentBlock?.visible_to_roles?.length && (
         <div>Visible to roles: {currentBlock?.visible_to_roles?.join(', ')}</div>
       )}

--- a/app/frontend/Pages/Manage/ViewExperienceDetails/ViewExperienceDetails.module.scss
+++ b/app/frontend/Pages/Manage/ViewExperienceDetails/ViewExperienceDetails.module.scss
@@ -4,4 +4,5 @@
   align-items: start;
   gap: 16px;
   width: 100%;
+  text-align: left;
 }

--- a/app/frontend/Pages/Manage/ViewExperienceDetails/ViewExperienceDetails.tsx
+++ b/app/frontend/Pages/Manage/ViewExperienceDetails/ViewExperienceDetails.tsx
@@ -1,9 +1,15 @@
 import { Experience } from '@cctv/types';
-import { fmtDate } from '@cctv/utils';
+import { capitalize, fmtDate } from '@cctv/utils';
 
 import styles from './ViewExperienceDetails.module.scss';
 
-export default function ViewExperienceDetails({ experience }: { experience?: Experience }) {
+export default function ViewExperienceDetails({
+  experience,
+  isPolling,
+}: {
+  experience?: Experience;
+  isPolling: boolean;
+}) {
   if (!experience) {
     return <div>No experience found</div>;
   }
@@ -11,7 +17,8 @@ export default function ViewExperienceDetails({ experience }: { experience?: Exp
   return (
     <div className={styles.viewExperienceDetails}>
       <div>Code: {experience.code}</div>
-      <div>Status: {experience.status}</div>
+      <div>Status: {capitalize(experience.status)}</div>
+      <div>Polling: {isPolling ? 'Yes' : 'No'}</div>
       <div>Created: {fmtDate(experience.created_at)}</div>
       <div>Updated: {fmtDate(experience.updated_at)}</div>
     </div>

--- a/app/frontend/Pages/Manage/ViewTvSection/ViewTvSection.module.scss
+++ b/app/frontend/Pages/Manage/ViewTvSection/ViewTvSection.module.scss
@@ -1,0 +1,21 @@
+.viewNextBlock,
+.viewCurrentBlock,
+.viewDetails {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 16px;
+  gap: 16px;
+
+  background: rgba(0, 0, 0, 0.5);
+  border-radius: 12px;
+
+  z-index: 10;
+  box-shadow: var(--card-shadow, 0 8px 12px rgba(0, 0, 0, 0.4));
+  flex: 1;
+  min-height: 340px;
+}
+
+.screen {
+  width: 100%;
+}

--- a/app/frontend/Pages/Manage/ViewTvSection/ViewTvSection.tsx
+++ b/app/frontend/Pages/Manage/ViewTvSection/ViewTvSection.tsx
@@ -1,0 +1,70 @@
+import { useMemo } from 'react';
+
+import { Dropdown } from '@cctv/core';
+import { Block, Experience } from '@cctv/types';
+
+import SectionHeader from '../SectionHeader/SectionHeader';
+import ViewBlockDetails from '../ViewBlockDetails/ViewBlockDetails';
+
+import styles from './ViewTvSection.module.scss';
+
+export default function ViewTvSection({
+  className,
+  experience,
+  participantId,
+  setSelectedParticipantId,
+}: {
+  className?: string;
+  experience?: Experience;
+  participantId?: string;
+  setSelectedParticipantId: (participantId: string) => void;
+}) {
+  const { currentBlock, nextBlock } = useMemo(() => {
+    if (!experience) {
+      return { currentBlock: undefined, nextBlock: undefined };
+    }
+
+    const sortedBlocksByCreatedAt = experience.blocks.sort(
+      (a, b) => new Date(a.created_at || '').getTime() - new Date(b.created_at || '').getTime(),
+    );
+
+    const currentBlockIndex = sortedBlocksByCreatedAt.findIndex((block) => block.status === 'open');
+    const nextBlockIndex = currentBlockIndex + 1;
+
+    const currentBlock = sortedBlocksByCreatedAt.at(currentBlockIndex);
+    const nextBlock = sortedBlocksByCreatedAt.at(nextBlockIndex);
+
+    return { currentBlock, nextBlock };
+  }, [experience]);
+
+  return (
+    <div className={className}>
+      <div className={styles.viewNextBlock}>
+        <SectionHeader title="Next view" />
+        <ViewTvScreen block={nextBlock} className={styles.screen} />
+      </div>
+      <div className={styles.viewDetails}>
+        <SectionHeader title="Experience Details" />
+        <ViewBlockDetails currentBlock={currentBlock} />
+        <Dropdown
+          options={experience?.participants.map((p) => ({ label: p.name, value: p.id })) ?? []}
+          value={participantId}
+          onChange={setSelectedParticipantId}
+          label="Viewing as"
+        />
+      </div>
+      <div className={styles.viewCurrentBlock}>
+        <SectionHeader title="Current view" />
+        <ViewTvScreen block={currentBlock} className={styles.screen} />
+      </div>
+    </div>
+  );
+}
+
+function ViewTvScreen({ className, block }: { className: string; block?: Block }) {
+  if (!block) {
+    return <div>No block found</div>;
+  }
+
+  return <div className={className}>TV Screen for: {block.kind}</div>;
+}

--- a/app/frontend/Pages/Manage/ViewUserScreen/ViewUserScreen.tsx
+++ b/app/frontend/Pages/Manage/ViewUserScreen/ViewUserScreen.tsx
@@ -1,34 +1,26 @@
 import classNames from 'classnames';
 
 import { ExperienceBlockContainer } from '@cctv/experiences';
-import { Experience } from '@cctv/types';
+import { Block, ParticipantSummary } from '@cctv/types';
 
 import styles from './ViewUserScreen.module.scss';
 
 export default function ViewUserScreen({
   className,
-  experience,
+  block,
+  participant,
 }: {
   className?: string;
-  experience?: Experience;
+  block?: Block;
+  participant?: ParticipantSummary;
 }) {
-  if (!experience) {
-    return <div>No experience found</div>;
-  }
-
-  const firstOpenBlock = experience.blocks.findIndex((block) => block.status === 'open');
-
-  if (firstOpenBlock === -1) {
+  if (!block) {
     return <div>No open block found</div>;
   }
 
   return (
     <div className={classNames(styles.root, className)}>
-      <ExperienceBlockContainer
-        block={experience.blocks[firstOpenBlock]}
-        participant={experience.participants[0]}
-        disabled
-      />
+      <ExperienceBlockContainer block={block} participant={participant} disabled />
     </div>
   );
 }

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -377,6 +377,7 @@ export interface ExperienceContextType {
   setJWT: (token: string) => void;
   clearJWT: () => void;
   experienceFetch: (url: string, options?: RequestInit) => Promise<Response>;
+  refetchExperience: () => Promise<void>;
 
   // WebSocket properties
   wsConnected: boolean;

--- a/app/frontend/utils.ts
+++ b/app/frontend/utils.ts
@@ -33,3 +33,5 @@ export const getJWTKey = (code: string) => `experience_jwt_${code}`;
 export const getStoredJWT = (code: string) => localStorage.getItem(getJWTKey(code));
 
 export const fmtDate = (s?: string | null) => (s ? new Date(s).toLocaleString() : '—');
+
+export const capitalize = (s?: string | null) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : '');


### PR DESCRIPTION
Here I go polishing again!

Still more to do, but getting close here.

# Future TODOs:
- Add TV Screen
  - I think we should include TV details within an Experience Block. In that, we should have some configuration depending on the Block. I included what I think we could use down below
- Mobile styling (nice to have, I imagine the worst case where someone needs to use their phone, would be nice to support)
- Reusable Table Core UI component
- Better Participant view
- Better Block view
- Block ordering configuration

## Block ordering
- Right now the way we're ordering blocks is a bit too chaotic
- Proposed solution: Add `block_order: Experience['id'][]` to the `Experience` object so that we can allow for configuring the order rather than only relying on 'open' status


## TV Screen Configurations
Type: Poll
- type: 'poll'
- revealed: boolean
- display: 'chart' | 'pie'

Type: Question
- type: 'question'
- revealed: boolean

Type: Multistep Form
- type: 'multistep_form'
- revealed: QuestionPayload['formKey'][] // If the formKey is present, the question + answer is revealed

Type: Announcement
- type: 'announcement'

Type: Family Feud
- type: 'family_feud'
- revealed: FamilyFeudPayload['formKey'][] // If the formKey is present, the answer is revealed on the board
- currentTeam: 'team1' | 'team2'
- team1AmountWrong: number
- team2AmountWrong: number