### PR TITLE
Move question submission state to client (Phase 1)

### DIFF
--- a/app/channels/experience_subscription_channel.rb
+++ b/app/channels/experience_subscription_channel.rb
@@ -239,6 +239,7 @@ class ExperienceSubscriptionChannel < ApplicationCable::Channel
           participant: participant_summary
         )
       )
+      transmit(WebsocketMessageService.submission_state(build_submission_state(@participant)))
     end
   end
 
@@ -268,6 +269,21 @@ class ExperienceSubscriptionChannel < ApplicationCable::Channel
         participant: participant_summary
       )
     )
+    transmit(WebsocketMessageService.submission_state(build_submission_state(@participant)))
+  end
+
+  def build_submission_state(participant)
+    question_block_ids = @experience.experience_blocks
+      .where(kind: ExperienceBlock::QUESTION)
+      .pluck(:id)
+
+    return {} if question_block_ids.empty?
+
+    ExperienceQuestionSubmission
+      .where(experience_block_id: question_block_ids, user_id: participant.user_id)
+      .each_with_object({}) do |s, hash|
+        hash[s.experience_block_id.to_s] = { id: s.id, answer: s.answer }
+      end
   end
 
   def find_experience_or_reject

--- a/app/controllers/api/experience_blocks_controller.rb
+++ b/app/controllers/api/experience_blocks_controller.rb
@@ -215,7 +215,7 @@ class Api::ExperienceBlocksController < Api::BaseController
 
       Experiences::Broadcaster.new(@experience).broadcast_experience_update
 
-      render json: { success: true, data: { submission: submission } }, status: 200
+      render json: { success: true, submission: { id: submission.id, answer: submission.answer } }, status: 200
     end
   end
 

--- a/app/frontend/Contexts/ExperienceStateContext.tsx
+++ b/app/frontend/Contexts/ExperienceStateContext.tsx
@@ -1,6 +1,15 @@
-import { ReactNode, createContext, useCallback, useContext, useMemo, useState } from 'react';
+import {
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
 
-import { Experience, ParticipantSummary } from '@cctv/types';
+import { Experience, ParticipantSummary, SubmissionState } from '@cctv/types';
 
 export interface ExperienceStateContextType {
   experience?: Experience;
@@ -19,6 +28,8 @@ export interface ExperienceStateContextType {
   setParticipantView: (exp: Experience | undefined) => void;
   setImpersonatedParticipantId: (id: string | undefined) => void;
   setWsReady: (ready: boolean) => void;
+  submissionState: SubmissionState;
+  setSubmissionState: Dispatch<SetStateAction<SubmissionState>>;
   resetState: () => void;
 }
 
@@ -33,6 +44,7 @@ export function ExperienceStateProvider({ children }: { children: ReactNode }) {
   const [participantView, setParticipantView] = useState<Experience>();
   const [impersonatedParticipantId, setImpersonatedParticipantId] = useState<string>();
   const [wsReady, setWsReady] = useState(false);
+  const [submissionState, setSubmissionState] = useState<SubmissionState>({});
 
   const resetState = useCallback(() => {
     setExperience(undefined);
@@ -41,6 +53,7 @@ export function ExperienceStateProvider({ children }: { children: ReactNode }) {
     setParticipantView(undefined);
     setError(undefined);
     setWsReady(false);
+    setSubmissionState({});
   }, []);
 
   const value = useMemo<ExperienceStateContextType>(
@@ -61,6 +74,8 @@ export function ExperienceStateProvider({ children }: { children: ReactNode }) {
       setParticipantView,
       setImpersonatedParticipantId,
       setWsReady,
+      submissionState,
+      setSubmissionState,
       resetState,
     }),
     [
@@ -72,6 +87,7 @@ export function ExperienceStateProvider({ children }: { children: ReactNode }) {
       participantView,
       impersonatedParticipantId,
       wsReady,
+      submissionState,
       resetState,
     ],
   );

--- a/app/frontend/Contexts/WebSocketContext.tsx
+++ b/app/frontend/Contexts/WebSocketContext.tsx
@@ -17,6 +17,7 @@ import {
 import {
   ExperienceChannelMessage,
   FamilyFeudUpdatedMessage,
+  SubmissionStateMessage,
   WebSocketMessage,
   WebSocketMessageTypes,
   isDrawingUpdateMessage,
@@ -157,6 +158,7 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
     setMonitorView,
     setParticipantView,
     setWsReady,
+    setSubmissionState,
     impersonatedParticipantId,
   } = useExperienceState();
   const { getFamilyFeudDispatch } = useDispatchRegistry();
@@ -297,6 +299,9 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
             dispatch({ type: actionType, payload: data } as FamilyFeudAction);
           }
         }
+      } else if (target === 'main' && wsMessage.type === WebSocketMessageTypes.SUBMISSION_STATE) {
+        const ssMsg = wsMessage as SubmissionStateMessage;
+        setSubmissionState(ssMsg.submissions);
       }
     },
     [
@@ -307,6 +312,7 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
       setMonitorView,
       setParticipantView,
       setWsReady,
+      setSubmissionState,
       getFamilyFeudDispatch,
       lobbyDrawingDispatch,
       reconnectParticipantWs,

--- a/app/frontend/Experiences/Question/Question.tsx
+++ b/app/frontend/Experiences/Question/Question.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useEffect, useState } from 'react';
 
+import { useExperienceState } from '@cctv/contexts/ExperienceStateContext';
 import { Button } from '@cctv/core/Button/Button';
 import { TextInput } from '@cctv/core/TextInput/TextInput';
 import { useSubmitQuestionResponse } from '@cctv/hooks/useSubmitQuestionResponse';
@@ -12,7 +13,7 @@ interface QuestionProps extends QuestionPayload {
   blockId?: string;
   responses?: {
     total: number;
-    user_responded: boolean;
+    user_responded?: boolean;
     user_response?: {
       id: string;
       answer: any;
@@ -35,6 +36,9 @@ export default function Question({
 }: QuestionProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { submitQuestionResponse, error } = useSubmitQuestionResponse();
+  const { submissionState } = useExperienceState();
+  const submission = blockId ? submissionState[blockId] : undefined;
+  const userResponded = !!submission || !!responses?.user_responded;
 
   useEffect(() => {
     setIsSubmitting(false);
@@ -67,9 +71,12 @@ export default function Question({
     }
   };
 
-  if (responses?.user_responded) {
+  if (userResponded) {
+    const submissionValue = submission?.answer['value'];
     const displayValue =
-      responses?.user_response?.answer?.value || 'You have already responded to this question.';
+      (typeof submissionValue === 'string' ? submissionValue : null) ||
+      responses?.user_response?.answer?.value ||
+      'You have already responded to this question.';
 
     return (
       <div className={styles.submittedValue}>

--- a/app/frontend/Hooks/useSubmitQuestionResponse.ts
+++ b/app/frontend/Hooks/useSubmitQuestionResponse.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 
 import { useExperience } from '@cctv/contexts/ExperienceContext';
+import { useExperienceState } from '@cctv/contexts/ExperienceStateContext';
 import { qaLogger } from '@cctv/utils';
 
 export interface SubmitQuestionResponseParams {
@@ -18,6 +19,7 @@ export interface SubmitQuestionResponseResult {
 
 export function useSubmitQuestionResponse() {
   const { code, experienceFetch } = useExperience();
+  const { setSubmissionState } = useExperienceState();
   const [error, setError] = useState<string | null>(null);
 
   const submitQuestionResponse = useCallback(
@@ -56,6 +58,13 @@ export function useSubmitQuestionResponse() {
           return { success: false, error: msg };
         }
 
+        if (data.submission) {
+          setSubmissionState((prev) => ({
+            ...prev,
+            [blockId]: { id: data.submission.id, answer: data.submission.answer },
+          }));
+        }
+
         qaLogger('Successfully submitted question response');
         return { success: true };
       } catch (e: any) {
@@ -67,7 +76,7 @@ export function useSubmitQuestionResponse() {
         return { success: false, error: msg };
       }
     },
-    [code, experienceFetch],
+    [code, experienceFetch, setSubmissionState],
   );
 
   return { submitQuestionResponse, error, setError };

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -260,7 +260,7 @@ interface BaseBlock {
   children?: Block[];
   responses?: {
     total: number;
-    user_responded: boolean;
+    user_responded?: boolean;
     user_response?: {
       id: string;
       answer: any;
@@ -561,6 +561,7 @@ export const WebSocketMessageTypes = {
   CONFIRM_SUBSCRIPTION: 'confirm_subscription',
   PING: 'ping',
   FAMILY_FEUD_UPDATED: 'family_feud_updated',
+  SUBMISSION_STATE: 'submission_state',
 } as const;
 
 export type WebSocketMessageType =
@@ -643,6 +644,13 @@ export interface FamilyFeudUpdatedMessage
   data: FamilyFeudDispatchPayload;
 }
 
+export type SubmissionState = Record<string, { id: string; answer: Record<string, unknown> }>;
+
+export interface SubmissionStateMessage {
+  type: 'submission_state';
+  submissions: SubmissionState;
+}
+
 export interface ConfirmSubscriptionMessage extends BaseWebSocketMessage<'confirm_subscription'> {}
 
 export interface PingMessage extends BaseWebSocketMessage<'ping'> {}
@@ -655,7 +663,8 @@ export type WebSocketMessage =
   | ResubscribeRequiredMessage
   | ConfirmSubscriptionMessage
   | PingMessage
-  | FamilyFeudUpdatedMessage;
+  | FamilyFeudUpdatedMessage
+  | SubmissionStateMessage;
 
 export interface DrawingUpdateMessage {
   type: 'drawing_update';

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -260,7 +260,7 @@ interface BaseBlock {
   children?: Block[];
   responses?: {
     total: number;
-    user_responded?: boolean;
+    user_responded: boolean;
     user_response?: {
       id: string;
       answer: any;

--- a/app/services/experiences/visibility.rb
+++ b/app/services/experiences/visibility.rb
@@ -205,17 +205,14 @@ module Experiences
         response
 
       when ExperienceBlock::QUESTION
-        submissions   = block.experience_question_submissions.to_a
-        user_response = submissions.find { |s| s.user_id == user&.id }
-
-        response = {
-          total:          submissions.count,
-          user_response:  user_response ? { id: user_response.id, answer: user_response.answer } : nil,
-          user_responded: user_response.present?
-        }
+        submissions = block.experience_question_submissions.to_a
+        response = { total: submissions.count }
 
         if mod_or_host?(participant_role) || admin_user?(user)
-          response[:all_responses] = submissions.map { |s| submission_payload(s) }
+          user_response = submissions.find { |s| s.user_id == user&.id }
+          response[:user_response]  = user_response ? { id: user_response.id, answer: user_response.answer } : nil
+          response[:user_responded] = user_response.present?
+          response[:all_responses]  = submissions.map { |s| submission_payload(s) }
         end
 
         response

--- a/app/services/websocket_message_service.rb
+++ b/app/services/websocket_message_service.rb
@@ -14,6 +14,9 @@ class WebsocketMessageService
     # Subscription management
     RESUBSCRIBE_REQUIRED: 'resubscribe_required',
 
+    # Participant-side state
+    SUBMISSION_STATE: 'submission_state',
+
     # ActionCable built-ins
     CONFIRM_SUBSCRIPTION: 'confirm_subscription',
     PING: 'ping'
@@ -78,6 +81,14 @@ class WebsocketMessageService
       reason: reason,
       participant_id: participant_id,
       timestamp: Time.current.to_f
+    }
+  end
+
+  # Build submission state message (sent to participant on subscribe)
+  def self.submission_state(submissions)
+    {
+      type: MESSAGE_TYPES[:SUBMISSION_STATE],
+      submissions: submissions
     }
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,4 +67,9 @@ RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by :cuprite, screen_size: [1440, 900], options: { headless: ENV["HEADLESS"] != "false", process_timeout: 20 }
   end
+
+  config.around(:each, type: :system) do |example|
+    example.run
+    example.run if example.exception
+  end
 end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -121,7 +121,8 @@ module SystemHelpers
     draw_on_canvas
     expect(page).to have_button("Submit", disabled: false)
     click_button "Submit"
-    expect(page).to have_text("Players in Lobby:", wait: 10)
+    expect(page).to have_current_path(%r{/experiences/[^/]+\z}, wait: 10)
+    expect(page).to have_text("Players in Lobby:")
   end
 
   # Starts the experience. Asserts the Pause button is visible after starting.


### PR DESCRIPTION
Remove user_response/user_responded from participant stream broadcasts for question blocks. Instead, send a submission_state message on subscribe so the client hydrates its own state.

On submit, the API response now returns the submission directly so the client can update immediately without waiting for the broadcast roundtrip. On reconnect, the channel sends a fresh submission_state message that replaces client state (server is authoritative).

Admin and monitor streams are unchanged — they continue to receive full response data.