### PR TITLE
Move submission state to client (Phase 2)

### DIFF
--- a/app/channels/experience_subscription_channel.rb
+++ b/app/channels/experience_subscription_channel.rb
@@ -273,17 +273,47 @@ class ExperienceSubscriptionChannel < ApplicationCable::Channel
   end
 
   def build_submission_state(participant)
-    question_block_ids = @experience.experience_blocks
-      .where(kind: ExperienceBlock::QUESTION)
-      .pluck(:id)
+    result = {}
 
-    return {} if question_block_ids.empty?
+    blocks_by_kind = @experience.experience_blocks
+      .where(kind: [ExperienceBlock::QUESTION, ExperienceBlock::POLL, ExperienceBlock::BUZZER, ExperienceBlock::PHOTO_UPLOAD])
+      .pluck(:id, :kind)
+      .group_by { |_, kind| kind }
+      .transform_values { |pairs| pairs.map { |id, _| id } }
 
-    ExperienceQuestionSubmission
-      .where(experience_block_id: question_block_ids, user_id: participant.user_id)
-      .each_with_object({}) do |s, hash|
-        hash[s.experience_block_id.to_s] = { id: s.id, answer: s.answer }
-      end
+    question_ids = blocks_by_kind[ExperienceBlock::QUESTION] || []
+    unless question_ids.empty?
+      ExperienceQuestionSubmission
+        .where(experience_block_id: question_ids, user_id: participant.user_id)
+        .each { |s| result[s.experience_block_id.to_s] = { id: s.id, answer: s.answer } }
+    end
+
+    poll_ids = blocks_by_kind[ExperienceBlock::POLL] || []
+    unless poll_ids.empty?
+      ExperiencePollSubmission
+        .where(experience_block_id: poll_ids, user_id: participant.user_id)
+        .each { |s| result[s.experience_block_id.to_s] = { id: s.id, answer: s.answer } }
+    end
+
+    buzzer_ids = blocks_by_kind[ExperienceBlock::BUZZER] || []
+    unless buzzer_ids.empty?
+      ExperienceBuzzerSubmission
+        .where(experience_block_id: buzzer_ids, user_id: participant.user_id)
+        .each { |s| result[s.experience_block_id.to_s] = { id: s.id, answer: s.answer } }
+    end
+
+    photo_ids = blocks_by_kind[ExperienceBlock::PHOTO_UPLOAD] || []
+    unless photo_ids.empty?
+      ExperiencePhotoUploadSubmission
+        .where(experience_block_id: photo_ids, user_id: participant.user_id)
+        .includes(photo_attachment: :blob)
+        .each do |s|
+          photo_url = s.photo.attached? ? ActiveStorageUrlService.blob_url(s.photo.blob) : nil
+          result[s.experience_block_id.to_s] = { id: s.id, answer: s.answer, photo_url: photo_url }
+        end
+    end
+
+    result
   end
 
   def find_experience_or_reject

--- a/app/channels/experience_subscription_channel.rb
+++ b/app/channels/experience_subscription_channel.rb
@@ -275,43 +275,36 @@ class ExperienceSubscriptionChannel < ApplicationCable::Channel
   def build_submission_state(participant)
     result = {}
 
-    blocks_by_kind = @experience.experience_blocks
-      .where(kind: [ExperienceBlock::QUESTION, ExperienceBlock::POLL, ExperienceBlock::BUZZER, ExperienceBlock::PHOTO_UPLOAD])
-      .pluck(:id, :kind)
-      .group_by { |_, kind| kind }
-      .transform_values { |pairs| pairs.map { |id, _| id } }
+    # block_scope is a SQL subquery — no Ruby round-trip to fetch block IDs.
+    # Each submission query below resolves to a single
+    # WHERE experience_block_id IN (SELECT id FROM experience_blocks WHERE experience_id = ?)
+    # AND user_id = ? rather than two sequential queries.
+    #
+    # If reconnect load becomes a bottleneck, the next step is to collapse
+    # question/poll/buzzer into a single UNION ALL (they share the same
+    # id/experience_block_id/answer columns), with photo handled separately
+    # for the blob join. That reduces 4 queries to 2.
+    block_scope = @experience.experience_blocks.select(:id)
 
-    question_ids = blocks_by_kind[ExperienceBlock::QUESTION] || []
-    unless question_ids.empty?
-      ExperienceQuestionSubmission
-        .where(experience_block_id: question_ids, user_id: participant.user_id)
-        .each { |s| result[s.experience_block_id.to_s] = { id: s.id, answer: s.answer } }
-    end
+    ExperienceQuestionSubmission
+      .where(experience_block_id: block_scope, user_id: participant.user_id)
+      .each { |s| result[s.experience_block_id.to_s] = { id: s.id, answer: s.answer } }
 
-    poll_ids = blocks_by_kind[ExperienceBlock::POLL] || []
-    unless poll_ids.empty?
-      ExperiencePollSubmission
-        .where(experience_block_id: poll_ids, user_id: participant.user_id)
-        .each { |s| result[s.experience_block_id.to_s] = { id: s.id, answer: s.answer } }
-    end
+    ExperiencePollSubmission
+      .where(experience_block_id: block_scope, user_id: participant.user_id)
+      .each { |s| result[s.experience_block_id.to_s] = { id: s.id, answer: s.answer } }
 
-    buzzer_ids = blocks_by_kind[ExperienceBlock::BUZZER] || []
-    unless buzzer_ids.empty?
-      ExperienceBuzzerSubmission
-        .where(experience_block_id: buzzer_ids, user_id: participant.user_id)
-        .each { |s| result[s.experience_block_id.to_s] = { id: s.id, answer: s.answer } }
-    end
+    ExperienceBuzzerSubmission
+      .where(experience_block_id: block_scope, user_id: participant.user_id)
+      .each { |s| result[s.experience_block_id.to_s] = { id: s.id, answer: s.answer } }
 
-    photo_ids = blocks_by_kind[ExperienceBlock::PHOTO_UPLOAD] || []
-    unless photo_ids.empty?
-      ExperiencePhotoUploadSubmission
-        .where(experience_block_id: photo_ids, user_id: participant.user_id)
-        .includes(photo_attachment: :blob)
-        .each do |s|
-          photo_url = s.photo.attached? ? ActiveStorageUrlService.blob_url(s.photo.blob) : nil
-          result[s.experience_block_id.to_s] = { id: s.id, answer: s.answer, photo_url: photo_url }
-        end
-    end
+    ExperiencePhotoUploadSubmission
+      .where(experience_block_id: block_scope, user_id: participant.user_id)
+      .includes(photo_attachment: :blob)
+      .each do |s|
+        photo_url = s.photo.attached? ? ActiveStorageUrlService.blob_url(s.photo.blob) : nil
+        result[s.experience_block_id.to_s] = { id: s.id, answer: s.answer, photo_url: photo_url }
+      end
 
     result
   end

--- a/app/controllers/api/experience_blocks_controller.rb
+++ b/app/controllers/api/experience_blocks_controller.rb
@@ -182,7 +182,7 @@ class Api::ExperienceBlocksController < Api::BaseController
 
       Experiences::Broadcaster.new(@experience).broadcast_experience_update
 
-      render json: { success: true, data: { submission: submission } }, status: 200
+      render json: { success: true, submission: { id: submission.id, answer: submission.answer } }, status: 200
     end
   end
 
@@ -238,7 +238,7 @@ class Api::ExperienceBlocksController < Api::BaseController
   # POST /api/experiences/:experience_id/blocks/:id/submit_buzzer_response
   def submit_buzzer_response
     with_experience_orchestration do
-      Experiences::Orchestrator.new(
+      submission = Experiences::Orchestrator.new(
         experience: @experience, actor: @user
       ).submit_buzzer_response!(
         block_id: params[:id],
@@ -247,7 +247,7 @@ class Api::ExperienceBlocksController < Api::BaseController
 
       Experiences::Broadcaster.new(@experience).broadcast_experience_update
 
-      render json: { success: true }, status: 200
+      render json: { success: true, submission: { id: submission.id, answer: submission.answer } }, status: 200
     end
   end
 
@@ -283,7 +283,7 @@ class Api::ExperienceBlocksController < Api::BaseController
   # POST /api/experiences/:experience_id/blocks/:id/submit_photo_upload_response
   def submit_photo_upload_response
     with_experience_orchestration do
-      Experiences::Orchestrator.new(
+      submission = Experiences::Orchestrator.new(
         experience: @experience, actor: @user
       ).submit_photo_upload_response!(
         block_id: params[:id],
@@ -293,7 +293,8 @@ class Api::ExperienceBlocksController < Api::BaseController
 
       Experiences::Broadcaster.new(@experience).broadcast_experience_update
 
-      render json: { success: true }, status: 200
+      photo_url = submission.photo.attached? ? ActiveStorageUrlService.blob_url(submission.photo.blob) : nil
+      render json: { success: true, submission: { id: submission.id, answer: submission.answer, photo_url: photo_url } }, status: 200
     end
   end
 

--- a/app/frontend/Experiences/Buzzer/Buzzer.tsx
+++ b/app/frontend/Experiences/Buzzer/Buzzer.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Layer, Line, Stage } from 'react-konva';
 
 import { useExperience } from '@cctv/contexts/ExperienceContext';
+import { useExperienceState } from '@cctv/contexts/ExperienceStateContext';
 import { useSubmitBuzzerResponse } from '@cctv/hooks/useSubmitBuzzerResponse';
 import { BuzzerBlock } from '@cctv/types';
 
@@ -68,9 +69,13 @@ interface BuzzerProps {
 
 export default function Buzzer({ block, viewContext = 'participant' }: BuzzerProps) {
   const { experience, monitorView } = useExperience();
+  const { submissionState } = useExperienceState();
   const { submitBuzzerResponse, isLoading } = useSubmitBuzzerResponse();
-  const [buzzed, setBuzzed] = useState(block.responses?.user_responded ?? false);
-  const [showBuzzed, setShowBuzzed] = useState(block.responses?.user_responded ?? false);
+  const priorSubmission = submissionState[block.id];
+  const [buzzed, setBuzzed] = useState(false);
+  const [showBuzzed, setShowBuzzed] = useState(false);
+  const hasBuzzed = !!priorSubmission || buzzed;
+  const shouldShowBuzzed = !!priorSubmission || showBuzzed;
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const particlesRef = useRef<Particle[]>([]);
   const animRef = useRef<number>(0);
@@ -79,13 +84,12 @@ export default function Buzzer({ block, viewContext = 'participant' }: BuzzerPro
   const firstResponse = allResponses[0] ?? null;
 
   const handleBuzz = async () => {
-    if (buzzed || isLoading) return;
+    if (hasBuzzed || isLoading) return;
     playBuzzerSound();
     setBuzzed(true);
     const result = await submitBuzzerResponse(block.id);
     if (!result?.success) {
       setBuzzed(false);
-      setShowBuzzed(false);
     } else {
       setTimeout(() => setShowBuzzed(true), 800);
     }
@@ -184,7 +188,7 @@ export default function Buzzer({ block, viewContext = 'participant' }: BuzzerPro
     );
   }
 
-  if (showBuzzed) {
+  if (shouldShowBuzzed) {
     return (
       <div className={styles.buzzedState}>
         <p className={styles.buzzedText}>Buzzed!</p>
@@ -203,7 +207,7 @@ export default function Buzzer({ block, viewContext = 'participant' }: BuzzerPro
             spawnExplosion(rect.left + rect.width / 2, rect.top + rect.height / 2);
             handleBuzz();
           }}
-          disabled={isLoading}
+          disabled={hasBuzzed || isLoading}
           aria-label="Buzz in"
         />
         <canvas ref={canvasRef} className={styles.particleLayer} />

--- a/app/frontend/Experiences/PhotoUpload/PhotoUpload.tsx
+++ b/app/frontend/Experiences/PhotoUpload/PhotoUpload.tsx
@@ -2,6 +2,7 @@ import { useCallback, useRef, useState } from 'react';
 
 import { Camera, Check } from 'lucide-react';
 
+import { useExperienceState } from '@cctv/contexts/ExperienceStateContext';
 import { Button } from '@cctv/core';
 import { useDirectUpload, useSubmitPhotoUploadResponse } from '@cctv/hooks';
 import { PhotoUploadBlock } from '@cctv/types';
@@ -23,13 +24,15 @@ export default function PhotoUpload({
 }: PhotoUploadProps) {
   const { upload, isUploading, progress } = useDirectUpload();
   const { submitPhotoUploadResponse, isLoading: isSubmitting } = useSubmitPhotoUploadResponse();
+  const { submissionState } = useExperienceState();
   const [signedId, setSignedId] = useState<string | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
-  const hasResponded = responses?.user_responded;
-  const userResponse = responses?.user_response;
+  const submission = submissionState[blockId];
+  const hasResponded = !!submission || !!responses?.user_responded;
+  const photoUrl = submission?.photo_url ?? responses?.user_response?.photo_url;
 
   const handleFileSelect = useCallback(
     async (file: File) => {
@@ -62,7 +65,7 @@ export default function PhotoUpload({
     }
   }, [blockId, signedId, submitPhotoUploadResponse]);
 
-  if (hasResponded && userResponse) {
+  if (hasResponded) {
     return (
       <div className={styles.container}>
         <p className={styles.prompt}>{prompt}</p>
@@ -71,12 +74,8 @@ export default function PhotoUpload({
             <Check size={16} />
             <span>Photo submitted</span>
           </div>
-          {userResponse.photo_url && (
-            <img
-              src={userResponse.photo_url}
-              alt="Your submission"
-              className={styles.submittedPhoto}
-            />
+          {photoUrl && (
+            <img src={photoUrl} alt="Your submission" className={styles.submittedPhoto} />
           )}
         </div>
       </div>

--- a/app/frontend/Experiences/Poll/Poll.tsx
+++ b/app/frontend/Experiences/Poll/Poll.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useState } from 'react';
 
+import { useExperienceState } from '@cctv/contexts/ExperienceStateContext';
 import { Button } from '@cctv/core/Button/Button';
 import { Option } from '@cctv/core/Option/Option';
 import { useSubmitPollResponse } from '@cctv/hooks/useSubmitPollResponse';
@@ -12,7 +13,7 @@ interface PollProps extends PollPayload {
   blockId?: string;
   responses?: {
     total: number;
-    user_responded: boolean;
+    user_responded?: boolean;
     user_response?: {
       id: string;
       answer: any;
@@ -34,6 +35,9 @@ export default function Poll({
 }: PollProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { submitPollResponse, error } = useSubmitPollResponse();
+  const { submissionState } = useExperienceState();
+  const submission = blockId ? submissionState[blockId] : undefined;
+  const userResponded = !!submission || !!responses?.user_responded;
 
   const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -67,10 +71,11 @@ export default function Poll({
     }
   };
 
-  if (responses?.user_responded) {
-    const displayValue =
-      responses?.user_response?.answer?.selectedOptions?.join(', ') ||
-      'You have already responded to this poll.';
+  if (userResponded) {
+    const selectedOptions =
+      (submission?.answer?.selectedOptions as string[] | undefined) ??
+      responses?.user_response?.answer?.selectedOptions;
+    const displayValue = selectedOptions?.join(', ') || 'You have already responded to this poll.';
 
     return (
       <div className={styles.submittedValue}>

--- a/app/frontend/Experiences/Poll/Poll.tsx
+++ b/app/frontend/Experiences/Poll/Poll.tsx
@@ -72,10 +72,12 @@ export default function Poll({
   };
 
   if (userResponded) {
-    const selectedOptions =
-      (submission?.answer?.selectedOptions as string[] | undefined) ??
-      responses?.user_response?.answer?.selectedOptions;
-    const displayValue = selectedOptions?.join(', ') || 'You have already responded to this poll.';
+    const rawSelected =
+      (submission?.answer?.selectedOptions as string | string[] | undefined) ??
+      (responses?.user_response?.answer?.selectedOptions as string | string[] | undefined);
+    const displayValue = rawSelected
+      ? ([] as string[]).concat(rawSelected).join(', ')
+      : 'You have already responded to this poll.';
 
     return (
       <div className={styles.submittedValue}>

--- a/app/frontend/Hooks/useSubmitBuzzerResponse.ts
+++ b/app/frontend/Hooks/useSubmitBuzzerResponse.ts
@@ -1,9 +1,11 @@
 import { useCallback, useState } from 'react';
 
 import { useExperience } from '@cctv/contexts/ExperienceContext';
+import { useExperienceState } from '@cctv/contexts/ExperienceStateContext';
 
 export function useSubmitBuzzerResponse() {
   const { code, experienceFetch } = useExperience();
+  const { setSubmissionState } = useExperienceState();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -31,6 +33,13 @@ export function useSubmitBuzzerResponse() {
           return { success: false, error: msg };
         }
 
+        if (data.submission) {
+          setSubmissionState((prev) => ({
+            ...prev,
+            [blockId]: { id: data.submission.id, answer: data.submission.answer },
+          }));
+        }
+
         return { success: true };
       } catch (e: unknown) {
         const msg =
@@ -43,7 +52,7 @@ export function useSubmitBuzzerResponse() {
         setIsLoading(false);
       }
     },
-    [code, experienceFetch],
+    [code, experienceFetch, setSubmissionState],
   );
 
   return { submitBuzzerResponse, isLoading, error };

--- a/app/frontend/Hooks/useSubmitPhotoUploadResponse.ts
+++ b/app/frontend/Hooks/useSubmitPhotoUploadResponse.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 
 import { useExperience } from '@cctv/contexts/ExperienceContext';
+import { useExperienceState } from '@cctv/contexts/ExperienceStateContext';
 
 export interface SubmitPhotoUploadResponseParams {
   blockId: string;
@@ -10,6 +11,7 @@ export interface SubmitPhotoUploadResponseParams {
 
 export function useSubmitPhotoUploadResponse() {
   const { code, experienceFetch } = useExperience();
+  const { setSubmissionState } = useExperienceState();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -48,6 +50,17 @@ export function useSubmitPhotoUploadResponse() {
           return { success: false, error: msg };
         }
 
+        if (data.submission) {
+          setSubmissionState((prev) => ({
+            ...prev,
+            [blockId]: {
+              id: data.submission.id,
+              answer: data.submission.answer,
+              photo_url: data.submission.photo_url,
+            },
+          }));
+        }
+
         return data;
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : 'Connection error. Please try again.';
@@ -57,7 +70,7 @@ export function useSubmitPhotoUploadResponse() {
         setIsLoading(false);
       }
     },
-    [code, experienceFetch],
+    [code, experienceFetch, setSubmissionState],
   );
 
   return {

--- a/app/frontend/Hooks/useSubmitPollResponse.ts
+++ b/app/frontend/Hooks/useSubmitPollResponse.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 
 import { useExperience } from '@cctv/contexts/ExperienceContext';
+import { useExperienceState } from '@cctv/contexts/ExperienceStateContext';
 import { qaLogger } from '@cctv/utils';
 
 export interface SubmitPollResponseParams {
@@ -18,6 +19,7 @@ export interface SubmitPollResponseResult {
 
 export function useSubmitPollResponse() {
   const { code, experienceFetch } = useExperience();
+  const { setSubmissionState } = useExperienceState();
   const [error, setError] = useState<string | null>(null);
 
   const submitPollResponse = useCallback(
@@ -53,6 +55,13 @@ export function useSubmitPollResponse() {
           return { success: false, error: msg };
         }
 
+        if (data.submission) {
+          setSubmissionState((prev) => ({
+            ...prev,
+            [blockId]: { id: data.submission.id, answer: data.submission.answer },
+          }));
+        }
+
         qaLogger('Successfully submitted poll response');
         return { success: true };
       } catch (e: any) {
@@ -64,7 +73,7 @@ export function useSubmitPollResponse() {
         return { success: false, error: msg };
       }
     },
-    [code, experienceFetch],
+    [code, experienceFetch, setSubmissionState],
   );
 
   return { submitPollResponse, error, setError };

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -260,7 +260,7 @@ interface BaseBlock {
   children?: Block[];
   responses?: {
     total: number;
-    user_responded: boolean;
+    user_responded?: boolean;
     user_response?: {
       id: string;
       answer: any;
@@ -308,7 +308,7 @@ export interface PhotoUploadBlock extends BaseBlock {
   payload: PhotoUploadPayload;
   responses?: {
     total: number;
-    user_responded: boolean;
+    user_responded?: boolean;
     user_response?: {
       id: string;
       answer: Record<string, unknown>;
@@ -329,7 +329,7 @@ export interface BuzzerBlock extends BaseBlock {
   payload: BuzzerPayload;
   responses?: {
     total: number;
-    user_responded: boolean;
+    user_responded?: boolean;
     user_response?: { id: string; answer: { buzzed_at: string } } | null;
     all_responses?: Array<{
       id: string;
@@ -644,7 +644,10 @@ export interface FamilyFeudUpdatedMessage
   data: FamilyFeudDispatchPayload;
 }
 
-export type SubmissionState = Record<string, { id: string; answer: Record<string, unknown> }>;
+export type SubmissionState = Record<
+  string,
+  { id: string; answer: Record<string, unknown>; photo_url?: string }
+>;
 
 export interface SubmissionStateMessage {
   type: 'submission_state';

--- a/app/services/experiences/visibility.rb
+++ b/app/services/experiences/visibility.rb
@@ -183,23 +183,17 @@ module Experiences
     def serialize_response_data(block, participant_role, user)
       case block.kind
       when ExperienceBlock::POLL
-        submissions  = block.experience_poll_submissions.to_a
-        user_response = submissions.find { |s| s.user_id == user&.id }
-
-        response = {
-          total:          submissions.count,
-          user_response:  format_poll_response(user_response),
-          user_responded: user_response.present?
-        }
-
-        if mod_or_host?(participant_role) && submissions.any?
-          response[:aggregate] = calculate_poll_aggregate(submissions)
-        else
-          response[:aggregate] = mod_or_host?(participant_role) ? {} : nil
-        end
+        submissions = block.experience_poll_submissions.to_a
+        response    = { total: submissions.count }
 
         if mod_or_host?(participant_role) || admin_user?(user)
-          response[:all_responses] = submissions.map { |s| submission_payload(s) }
+          user_response = submissions.find { |s| s.user_id == user&.id }
+          response[:user_response]  = format_poll_response(user_response)
+          response[:user_responded] = user_response.present?
+          response[:aggregate]      = submissions.any? ? calculate_poll_aggregate(submissions) : {}
+          response[:all_responses]  = submissions.map { |s| submission_payload(s) }
+        else
+          response[:aggregate] = nil
         end
 
         response
@@ -228,37 +222,37 @@ module Experiences
         { total: total, user_response: nil, user_responded: false, resolved_variables: resolved_vars }
 
       when ExperienceBlock::PHOTO_UPLOAD
-        submissions   = block.experience_photo_upload_submissions.includes(photo_attachment: :blob).to_a
-        user_response = submissions.find { |s| s.user_id == user&.id }
-
-        response = {
-          total:          submissions.count,
-          user_response:  user_response && { id: user_response.id, answer: user_response.answer, photo_url: attachment_url(user_response.photo) },
-          user_responded: user_response.present?
-        }
+        submissions = block.experience_photo_upload_submissions.includes(photo_attachment: :blob).to_a
+        response    = { total: submissions.count }
 
         if mod_or_host?(participant_role) || admin_user?(user)
-          response[:all_responses] = submissions.map { |s| submission_payload(s).merge(photo_url: attachment_url(s.photo)) }
+          user_response = submissions.find { |s| s.user_id == user&.id }
+          response[:user_response]  = user_response && { id: user_response.id, answer: user_response.answer, photo_url: attachment_url(user_response.photo) }
+          response[:user_responded] = user_response.present?
+          response[:all_responses]  = submissions.map { |s| submission_payload(s).merge(photo_url: attachment_url(s.photo)) }
         end
 
         response
 
       when ExperienceBlock::BUZZER
-        submissions   = block.experience_buzzer_submissions.order(Arel.sql("answer->>'buzzed_at' ASC")).to_a
-        user_response = submissions.find { |s| s.user_id == user&.id }
-        winner        = submissions.first
-        winner_avatar = winner && @experience.experience_participants.find_by(user_id: winner.user_id)&.avatar&.presence
+        submissions = block.experience_buzzer_submissions.order(Arel.sql("answer->>'buzzed_at' ASC")).to_a
+        response    = { total: submissions.count }
 
-        {
-          total:          submissions.count,
-          user_response:  user_response ? { id: user_response.id, answer: user_response.answer } : nil,
-          user_responded: user_response.present?,
-          all_responses:  submissions.map.with_index do |s, i|
+        if mod_or_host?(participant_role) || admin_user?(user)
+          user_response = submissions.find { |s| s.user_id == user&.id }
+          winner        = submissions.first
+          winner_avatar = winner && @experience.experience_participants.find_by(user_id: winner.user_id)&.avatar&.presence
+
+          response[:user_response]  = user_response ? { id: user_response.id, answer: user_response.answer } : nil
+          response[:user_responded] = user_response.present?
+          response[:all_responses]  = submissions.map.with_index do |s, i|
             entry = submission_payload(s)
             entry[:avatar] = winner_avatar if i == 0 && winner_avatar
             entry
           end
-        }
+        end
+
+        response
 
       else
         {}

--- a/spec/channels/experience_subscription_channel_spec.rb
+++ b/spec/channels/experience_subscription_channel_spec.rb
@@ -120,6 +120,50 @@ RSpec.describe ExperienceSubscriptionChannel, type: :channel do
         "experience_#{experience.id}_participant_#{participant.id}"
       )
     end
+
+    it "transmits a submission_state message after the experience state" do
+      subscribe(code: experience.code_slug, token: token)
+
+      submission_state_msg = transmissions.find { |t| t["type"] == "submission_state" }
+      expect(submission_state_msg).to be_present
+      expect(submission_state_msg["submissions"]).to be_a(Hash)
+    end
+
+    context "with prior question and poll submissions" do
+      let!(:question_block) { create(:experience_block, experience: experience, kind: ExperienceBlock::QUESTION, status: :open) }
+      let!(:poll_block) { create(:experience_block, experience: experience, kind: ExperienceBlock::POLL, status: :open) }
+      let!(:question_submission) do
+        create(:experience_question_submission, experience_block: question_block, user: regular_user,
+               answer: { "value" => "my answer" })
+      end
+      let!(:poll_submission) do
+        create(:experience_poll_submission, experience_block: poll_block, user: regular_user,
+               answer: { "selectedOptions" => ["option_a"] })
+      end
+
+      it "includes question and poll submissions in submission_state keyed by block id" do
+        subscribe(code: experience.code_slug, token: token)
+
+        msg = transmissions.find { |t| t["type"] == "submission_state" }
+        submissions = msg["submissions"]
+        expect(submissions[question_block.id.to_s]["id"]).to eq(question_submission.id)
+        expect(submissions[poll_block.id.to_s]["id"]).to eq(poll_submission.id)
+      end
+    end
+
+    context "with a prior buzzer submission" do
+      let!(:buzzer_block) { create(:experience_block, experience: experience, kind: ExperienceBlock::BUZZER, status: :open) }
+      let!(:buzzer_submission) do
+        create(:experience_buzzer_submission, experience_block: buzzer_block, user: regular_user)
+      end
+
+      it "includes the buzzer submission in submission_state" do
+        subscribe(code: experience.code_slug, token: token)
+
+        msg = transmissions.find { |t| t["type"] == "submission_state" }
+        expect(msg["submissions"][buzzer_block.id.to_s]["id"]).to eq(buzzer_submission.id)
+      end
+    end
   end
 
   describe "subscribing as a host with a valid participant JWT" do

--- a/spec/controllers/api/experience_blocks_controller_spec.rb
+++ b/spec/controllers/api/experience_blocks_controller_spec.rb
@@ -537,12 +537,17 @@ RSpec.describe Api::ExperienceBlocksController, type: :controller do
       request.headers["Authorization"] = "Bearer #{jwt}"
     end
 
-    it "returns 200 when participant submits to an open block" do
+    it "returns the submission in the response" do
       broadcaster = instance_double(Experiences::Broadcaster, broadcast_experience_update: true)
       allow(Experiences::Broadcaster).to receive(:new).and_return(broadcaster)
 
       subject
+
+      json = JSON.parse(response.body)
       expect(response.status).to eql(200)
+      expect(json["success"]).to be(true)
+      expect(json["submission"]["id"]).to be_present
+      expect(json["submission"]["answer"]["selectedOptions"]).to eq(["option_a"])
     end
 
     context "when the block is closed" do
@@ -569,6 +574,42 @@ RSpec.describe Api::ExperienceBlocksController, type: :controller do
         subject
         expect(response.status).to eql(403)
       end
+    end
+  end
+
+  describe "POST #submit_buzzer_response" do
+    let(:audience_user) { create(:user, :user) }
+    let!(:audience_participant) { create(:experience_participant, user: audience_user, experience: experience, role: :audience) }
+    let!(:block) { create(:experience_block, experience: experience, kind: ExperienceBlock::BUZZER, status: :open) }
+
+    subject do
+      post(
+        :submit_buzzer_response,
+        params: {
+          experience_id: experience.code_slug,
+          id: block.id,
+          answer: { "buzzed_at" => Time.current.iso8601 }
+        },
+        format: :json
+      )
+    end
+
+    before do
+      jwt = Experiences::AuthService.jwt_for_participant(experience: experience, user: audience_user)
+      request.headers["Authorization"] = "Bearer #{jwt}"
+    end
+
+    it "returns the submission in the response" do
+      broadcaster = instance_double(Experiences::Broadcaster, broadcast_experience_update: true)
+      allow(Experiences::Broadcaster).to receive(:new).and_return(broadcaster)
+
+      subject
+
+      json = JSON.parse(response.body)
+      expect(response.status).to eql(200)
+      expect(json["success"]).to be(true)
+      expect(json["submission"]["id"]).to be_present
+      expect(json["submission"]["answer"]["buzzed_at"]).to be_present
     end
   end
 end

--- a/spec/factories/experience_buzzer_submissions_factory.rb
+++ b/spec/factories/experience_buzzer_submissions_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :experience_buzzer_submission do
+    association :experience_block
+    association :user
+    answer { { "buzzed_at" => Time.current.iso8601 } }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -70,6 +70,9 @@ RSpec.configure do |config|
 
   config.around(:each, type: :system) do |example|
     example.run
-    example.run if example.exception
+
+    if ENV["CI"].present?
+      example.run if example.exception
+    end
   end
 end

--- a/spec/services/experiences/visibility_spec.rb
+++ b/spec/services/experiences/visibility_spec.rb
@@ -204,6 +204,98 @@ RSpec.describe Experiences::Visibility do
     end
   end
 
+  describe "response data serialization" do
+    let(:user) { create(:user, :user) }
+    let(:other_user) { create(:user, :user) }
+
+    context "POLL block" do
+      let!(:participant) { create(:experience_participant, user: user, experience: experience, role: :player) }
+      let!(:host_participant) { create(:experience_participant, user: other_user, experience: experience, role: :host) }
+      let!(:block) { create(:experience_block, experience: experience, kind: ExperienceBlock::POLL, status: :open) }
+
+      before do
+        create(:experience_poll_submission, experience_block: block, user: user,
+               answer: { "selectedOptions" => ["option_a"] })
+      end
+
+      it "omits user_response and user_responded for regular participants" do
+        result = described_class.for_participant(experience, participant)
+        responses = result[:blocks].first[:responses]
+        expect(responses).not_to have_key(:user_response)
+        expect(responses).not_to have_key(:user_responded)
+      end
+
+      it "includes total and aggregate for regular participants" do
+        result = described_class.for_participant(experience, participant)
+        responses = result[:blocks].first[:responses]
+        expect(responses[:total]).to eq(1)
+        expect(responses).to have_key(:aggregate)
+      end
+
+      it "includes user_response, user_responded, aggregate, and all_responses for hosts" do
+        create(:experience_poll_submission, experience_block: block, user: other_user,
+               answer: { "selectedOptions" => ["option_a"] })
+
+        result = described_class.for_participant(experience, host_participant)
+        responses = result[:blocks].first[:responses]
+        expect(responses[:user_responded]).to be true
+        expect(responses[:user_response]).to include(id: be_a(String))
+        expect(responses[:aggregate]).to eq({ "option_a" => 2 })
+        expect(responses[:all_responses]).to be_an(Array).and have_attributes(length: 2)
+      end
+    end
+
+    context "BUZZER block" do
+      let!(:participant) { create(:experience_participant, user: user, experience: experience, role: :player) }
+      let!(:host_participant) { create(:experience_participant, user: other_user, experience: experience, role: :host) }
+      let!(:block) { create(:experience_block, experience: experience, kind: ExperienceBlock::BUZZER, status: :open) }
+
+      before do
+        create(:experience_buzzer_submission, experience_block: block, user: user)
+      end
+
+      it "omits user_response and user_responded for regular participants" do
+        result = described_class.for_participant(experience, participant)
+        responses = result[:blocks].first[:responses]
+        expect(responses).not_to have_key(:user_response)
+        expect(responses).not_to have_key(:user_responded)
+      end
+
+      it "includes total for regular participants" do
+        result = described_class.for_participant(experience, participant)
+        responses = result[:blocks].first[:responses]
+        expect(responses[:total]).to eq(1)
+      end
+
+      it "includes user_response, user_responded, and all_responses for hosts" do
+        result = described_class.for_participant(experience, host_participant)
+        responses = result[:blocks].first[:responses]
+        expect(responses[:user_responded]).to be false
+        expect(responses[:user_response]).to be_nil
+        expect(responses[:all_responses]).to be_an(Array).and have_attributes(length: 1)
+      end
+    end
+
+    context "PHOTO_UPLOAD block" do
+      let!(:participant) { create(:experience_participant, user: user, experience: experience, role: :player) }
+      let!(:host_participant) { create(:experience_participant, user: other_user, experience: experience, role: :host) }
+      let!(:block) { create(:experience_block, experience: experience, kind: ExperienceBlock::PHOTO_UPLOAD, status: :open) }
+
+      it "includes only total for regular participants with no submission" do
+        result = described_class.for_participant(experience, participant)
+        responses = result[:blocks].first[:responses]
+        expect(responses).to eq({ total: 0 })
+      end
+
+      it "includes user_response and user_responded for hosts" do
+        result = described_class.for_participant(experience, host_participant)
+        responses = result[:blocks].first[:responses]
+        expect(responses).to have_key(:user_response)
+        expect(responses).to have_key(:user_responded)
+      end
+    end
+  end
+
   describe ".block_visible_to_user?" do
     let(:user) { create(:user, :user) }
     let!(:participant) { create(:experience_participant, user: user, experience: experience, role: :audience) }


### PR DESCRIPTION
Extends the pattern established for Question blocks to Poll, Buzzer, and PhotoUpload:

- Participant stream broadcasts no longer include user_response or user_responded for these block types — only total (and aggregate for Poll) is sent
- submission_state message on subscribe now includes prior Poll, Buzzer, and PhotoUpload submissions, with photo_url included for photo uploads
- Submit endpoints return { submission: { id, answer } } so the client can update local state immediately without waiting for the broadcast roundtrip
- Frontend hooks update submissionState in context on success
- Block components derive responded state from submissionState rather than responses.user_responded