### PR TITLE
Add /timeline view, unplug static background, auto-slug Create form

### DIFF
--- a/app/controllers/api/experience_blocks_controller.rb
+++ b/app/controllers/api/experience_blocks_controller.rb
@@ -1,6 +1,6 @@
 class Api::ExperienceBlocksController < Api::BaseController
   MANAGEMENT_ACTIONS = %i[
-    create update reorder open close hide clear_buzzer_responses
+    create update reorder set_column open close hide clear_buzzer_responses
     add_bucket rename_bucket delete_bucket assign_answer auto_categorize
     start_playing reveal_bucket show_x next_question restart_playing
     restart_categorizing restart_everything
@@ -110,6 +110,26 @@ class Api::ExperienceBlocksController < Api::BaseController
       ).reorder_block!(
         block_id: params[:id],
         position: params[:position].to_i
+      )
+
+      @experience.reload
+      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      render json: {
+        success: true,
+        data: block,
+      }, status: 200
+    end
+  end
+
+  # POST /api/experiences/:experience_id/blocks/:id/set_column
+  def set_column
+    with_experience_orchestration do
+      block = Experiences::Orchestrator.new(
+        experience: @experience, actor: @user
+      ).set_block_column!(
+        block_id: params[:id],
+        column: params[:column].to_i
       )
 
       @experience.reload

--- a/app/frontend/App.tsx
+++ b/app/frontend/App.tsx
@@ -2,7 +2,7 @@ import { Suspense, lazy, useEffect, useState } from 'react';
 
 import { Outlet, Route, useLocation } from 'react-router-dom';
 
-import { BackgroundStatic, RouteWink, TopNav } from '@cctv/components';
+import { RouteWink, TopNav } from '@cctv/components';
 import { ExperienceProvider } from '@cctv/contexts/ExperienceContext';
 import { UserProvider } from '@cctv/contexts/UserContext';
 import Create from '@cctv/pages/Create/Create';
@@ -30,6 +30,7 @@ const BlockPage = lazy(() =>
 );
 const ManageCreateBlock = lazy(() => import('@cctv/pages/ManageCreateBlock/ManageCreateBlock'));
 const ManageViewer = lazy(() => import('@cctv/pages/Manage/Viewer/ManageViewer'));
+const Timeline = lazy(() => import('@cctv/pages/Timeline/Timeline'));
 
 function App() {
   const [booting, setBooting] = useState(true);
@@ -43,7 +44,6 @@ function App() {
   return (
     <UserProvider>
       <div className={`app${booting ? ' app--booting' : ''}`}>
-        <BackgroundStatic />
         {!currentRoute.pathname.includes('/monitor') &&
           !currentRoute.pathname.includes('/playbill') && <TopNav />}
         <div className={styles.root}>
@@ -83,6 +83,7 @@ function App() {
                     <Route path="manage" element={<ManageViewer />} />
                     <Route path="manage/blocks/new" element={<ManageCreateBlock />} />
                     <Route path="manage/blocks/:blockId" element={<BlockPage />} />
+                    <Route path="timeline" element={<Timeline />} />
                   </Route>
                 </Route>
               </Route>

--- a/app/frontend/Components/navigation/TopNav.tsx
+++ b/app/frontend/Components/navigation/TopNav.tsx
@@ -17,7 +17,7 @@ export const TopNav = () => {
   const [activePanel, setActivePanel] = useState<MobilePanel>(null);
   const { user, logOut, isLoading } = useUser();
   const isAdmin = user?.role === 'admin' || user?.role === 'superadmin';
-  const { theme, setTheme, bgAnimated, setBgAnimated } = useTheme();
+  const { theme, setTheme } = useTheme();
   const adminExperiences = getSessionCreatedExperiences();
   const location = useLocation();
 
@@ -105,16 +105,6 @@ export const TopNav = () => {
               </span>
               <div className={styles.dropdownMenu} role="menu">
                 <div className={styles.topnav__controlRow}>
-                  <span className={styles.switchLabel}>Background</span>
-                  <Switch
-                    className={styles.switch}
-                    checked={bgAnimated}
-                    onCheckedChange={(checked) => setBgAnimated(!!checked)}
-                    aria-label={bgAnimated ? 'Animated background' : 'Solid background'}
-                    title={bgAnimated ? 'Animated background' : 'Solid background'}
-                  />
-                </div>
-                <div className={styles.topnav__controlRow}>
                   <span className={styles.switchLabel}>{theme === 'dark' ? 'Dark' : 'Light'}</span>
                   <Switch
                     withIcons
@@ -176,16 +166,6 @@ export const TopNav = () => {
 
       {activePanel === 'settings' && (
         <div className={styles.bottomPanel}>
-          <div className={styles.topnav__controlRow}>
-            <span className={styles.switchLabel}>Background</span>
-            <Switch
-              className={styles.switch}
-              checked={bgAnimated}
-              onCheckedChange={(checked) => setBgAnimated(!!checked)}
-              aria-label={bgAnimated ? 'Animated background' : 'Solid background'}
-              title={bgAnimated ? 'Animated background' : 'Solid background'}
-            />
-          </div>
           <div className={styles.topnav__controlRow}>
             <span className={styles.switchLabel}>{theme === 'dark' ? 'Dark' : 'Light'}</span>
             <Switch

--- a/app/frontend/Hooks/useExperienceRoute.ts
+++ b/app/frontend/Hooks/useExperienceRoute.ts
@@ -6,7 +6,7 @@ export function useExperienceRoute() {
   const { pathname } = useLocation();
   return {
     code: code ?? '',
-    isManagePage: pathname.includes('/manage'),
+    isManagePage: pathname.includes('/manage') || pathname.includes('/timeline'),
     isMonitorPage: pathname.includes('/monitor'),
   };
 }

--- a/app/frontend/Hooks/useSetBlockColumn.ts
+++ b/app/frontend/Hooks/useSetBlockColumn.ts
@@ -1,0 +1,52 @@
+import { useCallback, useState } from 'react';
+
+import { useAdminAuth } from '@cctv/contexts/AdminAuthContext';
+import { useExperience } from '@cctv/contexts/ExperienceContext';
+
+export function useSetBlockColumn() {
+  const { code } = useExperience();
+  const { adminFetch } = useAdminAuth();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const setColumn = useCallback(
+    async (blockId: string, column: number): Promise<{ success: boolean; error?: string }> => {
+      if (!code) {
+        setError('Missing experience code');
+        return { success: false, error: 'Missing experience code' };
+      }
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const res = await adminFetch(
+          `/api/experiences/${encodeURIComponent(code)}/blocks/${encodeURIComponent(blockId)}/set_column`,
+          {
+            method: 'POST',
+            body: JSON.stringify({ column }),
+          },
+        );
+        const data = await res.json();
+        if (!res.ok || data?.success === false) {
+          const msg = data?.error || 'Failed to move block';
+          setError(msg);
+          return { success: false, error: msg };
+        }
+        return { success: true };
+      } catch (e: unknown) {
+        const msg =
+          e instanceof Error && e.message === 'Authentication expired'
+            ? 'Authentication expired'
+            : 'Connection error. Please try again.';
+        setError(msg);
+        return { success: false, error: msg };
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [code, adminFetch],
+  );
+
+  return { setColumn, isLoading, error };
+}

--- a/app/frontend/Pages/Create/Create.tsx
+++ b/app/frontend/Pages/Create/Create.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useMemo, useRef, useState } from 'react';
+import { ChangeEvent, FormEvent, useMemo, useRef, useState } from 'react';
 
 import { Button } from '@cctv/core/Button/Button';
 import { Panel } from '@cctv/core/Panel/Panel';
@@ -9,15 +9,39 @@ import { addSessionCreatedExperience, getFormData } from '@cctv/utils';
 
 import styles from './Create.module.scss';
 
+function slugifyName(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
 /** Form page for creating a new experience */
 export default function Create() {
   const [experienceUrl, setExperienceUrl] = useState<string>();
   const [experienceName, setExperienceName] = useState<string>();
+  const [nameValue, setNameValue] = useState('');
+  const [codeValue, setCodeValue] = useState('');
+  const codeTouchedRef = useRef(false);
   const nameRef = useRef<HTMLInputElement>(null);
 
   const { post, isLoading, error, setError } = usePost<CreateExperienceApiResponse>({
     url: '/api/experiences',
   });
+
+  const handleNameChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const next = e.target.value;
+    setNameValue(next);
+    if (!codeTouchedRef.current) {
+      setCodeValue(slugifyName(next));
+    }
+  };
+
+  const handleCodeChange = (e: ChangeEvent<HTMLInputElement>) => {
+    codeTouchedRef.current = true;
+    setCodeValue(e.target.value);
+  };
 
   const handleCreate = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -88,8 +112,21 @@ export default function Create() {
       <Panel className={styles.container}>
         <h1 className={styles.title}>{'Create Experience'}</h1>
         <form className={styles.form} onSubmit={handleCreate}>
-          <TextInput ref={nameRef} label="Name" name="name" type="text" />
-          <TextInput label="Code" name="code" type="text" />
+          <TextInput
+            ref={nameRef}
+            label="Name"
+            name="name"
+            type="text"
+            value={nameValue}
+            onChange={handleNameChange}
+          />
+          <TextInput
+            label="Code"
+            name="code"
+            type="text"
+            value={codeValue}
+            onChange={handleCodeChange}
+          />
           {error && <p className={styles.error}>{error}</p>}
           <Button type="submit" loading={isLoading} loadingText="Creating...">
             {'Create'}

--- a/app/frontend/Pages/Manage/Viewer/ManageViewer.tsx
+++ b/app/frontend/Pages/Manage/Viewer/ManageViewer.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { BookOpen, Bug, Pause, Play, X } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+import { BookOpen, Bug, Columns3, Pause, Play, X } from 'lucide-react';
 
 import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { Dialog, DialogContent } from '@cctv/core';
@@ -225,6 +227,14 @@ export default function ManageViewer() {
             </div>
             <div className="flex items-center gap-2">
               <ExperienceActionButton />
+              <Link
+                to={`/experiences/${experience?.code}/timeline`}
+                className="px-3 py-1.5 text-sm rounded-md border border-[hsl(var(--border))] hover:bg-[hsl(var(--muted))] transition-colors inline-flex items-center gap-1.5"
+                title="Timeline view"
+              >
+                <Columns3 size={16} />
+                <span>Timeline</span>
+              </Link>
               <button
                 onClick={() => setShowDebugPanel((prev) => !prev)}
                 className={`px-3 py-1.5 text-sm rounded-md border transition-colors ${

--- a/app/frontend/Pages/Timeline/Timeline.module.scss
+++ b/app/frontend/Pages/Timeline/Timeline.module.scss
@@ -1,0 +1,415 @@
+.page {
+  position: relative;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  height: calc(100dvh - var(--nav-h));
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  overflow: hidden;
+  --row-h: 5.5rem;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem;
+  height: 5rem;
+  border-bottom: 1px solid hsl(var(--border));
+  flex-shrink: 0;
+}
+
+.headerLeft {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: hsl(var(--foreground));
+}
+
+.headerRight {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.navToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.875rem;
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.375rem;
+  color: hsl(var(--foreground));
+  background: transparent;
+  cursor: pointer;
+  transition: background 0.15s;
+
+  &:hover {
+    background: hsl(var(--muted));
+  }
+}
+
+.board {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.trackLabelCol {
+  width: 10rem;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid hsl(var(--border));
+  background: hsl(var(--card));
+}
+
+.trackLabelHeader {
+  height: 2.5rem;
+  border-bottom: 1px solid hsl(var(--border));
+  display: flex;
+  align-items: center;
+  padding: 0 0.75rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: hsl(var(--muted-foreground));
+}
+
+.trackLabel {
+  flex: 0 0 var(--row-h);
+  height: var(--row-h);
+  padding: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-bottom: 1px solid hsl(var(--border));
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: hsl(var(--card-foreground));
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.trackLabelAudience {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+  color: hsl(var(--muted-foreground));
+}
+
+.trackLabelSegment {
+  padding-left: 1.75rem;
+  font-size: 0.8125rem;
+  font-weight: 400;
+  color: hsl(var(--muted-foreground));
+}
+
+.segmentSwatch {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 0.25rem;
+  flex-shrink: 0;
+}
+
+.scroll {
+  flex: 1;
+  overflow-x: auto;
+  overflow-y: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.columnHeaderRow {
+  display: flex;
+  height: 2.5rem;
+  border-bottom: 1px solid hsl(var(--border));
+  flex-shrink: 0;
+}
+
+.columnHeader {
+  min-width: 12rem;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: hsl(var(--muted-foreground));
+  border-right: 1px solid hsl(var(--border));
+  cursor: pointer;
+  background: transparent;
+  border-top: none;
+  border-bottom: none;
+  border-left: none;
+  transition: background 0.15s;
+
+  &:hover {
+    background: hsl(var(--muted) / 0.4);
+    color: hsl(var(--foreground));
+  }
+}
+
+.columnHeaderSelected {
+  background: hsl(var(--muted));
+  color: hsl(var(--foreground));
+}
+
+.cellSelected {
+  background: hsl(var(--muted) / 0.25);
+}
+
+.rows {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.row {
+  display: flex;
+  flex: 0 0 var(--row-h);
+  height: var(--row-h);
+  border-bottom: 1px solid hsl(var(--border));
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.cell {
+  min-width: 12rem;
+  flex-shrink: 0;
+  border-right: 1px solid hsl(var(--border));
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  transition: background 0.15s;
+}
+
+.cellDroppableOver {
+  background: hsl(var(--muted) / 0.5);
+}
+
+.placeholder {
+  flex: 1;
+  border: 1px dashed hsl(var(--border));
+  border-radius: 0.375rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  color: hsl(var(--muted-foreground));
+  opacity: 0.5;
+}
+
+.blockCard {
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--card));
+  color: hsl(var(--card-foreground));
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.625rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  cursor: grab;
+  user-select: none;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s,
+    transform 0.15s;
+
+  &:hover {
+    border-color: hsl(var(--primary));
+  }
+
+  &:active {
+    cursor: grabbing;
+  }
+}
+
+.blockCardDragging {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  border-color: hsl(var(--primary));
+}
+
+.blockCardGhost {
+  opacity: 0.6;
+  border-style: dashed;
+  cursor: default;
+
+  &:hover {
+    border-color: hsl(var(--border));
+  }
+}
+
+.blockCardActive {
+  border-color: hsl(var(--primary));
+  box-shadow: 0 0 0 1px hsl(var(--primary));
+}
+
+.blockHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: hsl(var(--muted-foreground));
+}
+
+.blockKind {
+  font-weight: 600;
+}
+
+.blockStatusDot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: hsl(var(--muted-foreground));
+
+  &.statusOpen {
+    background: hsl(var(--primary));
+  }
+
+  &.statusClosed {
+    background: hsl(var(--destructive, 0 72% 51%));
+  }
+}
+
+.blockLabel {
+  font-size: 0.875rem;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.blockChildren {
+  display: flex;
+  gap: 0.25rem;
+  margin-top: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.childChip {
+  font-size: 0.6875rem;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  border: 1px solid hsl(var(--border));
+}
+
+.emptyState {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: hsl(var(--muted-foreground));
+  font-size: 0.875rem;
+}
+
+.previewCol {
+  width: 16rem;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid hsl(var(--border));
+  background: hsl(var(--card));
+}
+
+.previewHeader {
+  height: 2.5rem;
+  padding: 0 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid hsl(var(--border));
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: hsl(var(--muted-foreground));
+}
+
+.previewColumnLabel {
+  color: hsl(var(--foreground));
+  font-weight: 600;
+}
+
+.previewRows {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.previewRow {
+  flex: 0 0 var(--row-h);
+  height: var(--row-h);
+  padding: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-bottom: 1px solid hsl(var(--border));
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.previewFrame {
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--background));
+  border-radius: 0.25rem;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.375rem;
+  font-size: 0.6875rem;
+  text-align: center;
+  line-height: 1.2;
+  color: hsl(var(--card-foreground));
+}
+
+.previewFrameLandscape {
+  width: 85%;
+  aspect-ratio: 16 / 9;
+}
+
+.previewFramePortrait {
+  height: 90%;
+  aspect-ratio: 9 / 16;
+}
+
+.previewEmpty {
+  opacity: 0.4;
+  font-style: italic;
+}
+
+.previewKind {
+  font-size: 0.625rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: hsl(var(--muted-foreground));
+  margin-bottom: 0.125rem;
+}

--- a/app/frontend/Pages/Timeline/Timeline.tsx
+++ b/app/frontend/Pages/Timeline/Timeline.tsx
@@ -1,0 +1,415 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { Link } from 'react-router-dom';
+
+import { DragDropContext, Draggable, type DropResult, Droppable } from '@hello-pangea/dnd';
+import classNames from 'classnames';
+import { Layers, LayoutList, Monitor as MonitorIcon, Plus, Users } from 'lucide-react';
+
+import { useExperience } from '@cctv/contexts/ExperienceContext';
+import { Dialog, DialogContent } from '@cctv/core';
+import { useBlockPresentation } from '@cctv/hooks/useBlockPresentation';
+import { useReorderBlock } from '@cctv/hooks/useReorderBlock';
+import { Block, BlockStatus, ExperienceSegment, ParticipantSummary } from '@cctv/types';
+
+import CreateBlock from '../Manage/CreateBlock/CreateBlock';
+import SegmentManager from '../Manage/ParticipantsTab/SegmentManager/SegmentManager';
+
+import styles from './Timeline.module.scss';
+
+const MONITOR_TRACK_ID = '__monitor__';
+const AUDIENCE_TRACK_ID = '__audience__';
+
+type Track =
+  | { id: typeof MONITOR_TRACK_ID; label: 'Monitor'; kind: 'monitor' }
+  | { id: typeof AUDIENCE_TRACK_ID; label: 'Audience'; kind: 'audience' }
+  | { id: string; label: string; kind: 'segment'; segment: ExperienceSegment };
+
+function buildTracks(segments: ExperienceSegment[]): Track[] {
+  const sorted = [...segments].sort((a, b) => a.position - b.position);
+  return [
+    { id: MONITOR_TRACK_ID, label: 'Monitor', kind: 'monitor' },
+    { id: AUDIENCE_TRACK_ID, label: 'Audience', kind: 'audience' },
+    ...sorted.map<Track>((segment) => ({
+      id: segment.id,
+      label: segment.name,
+      kind: 'segment',
+      segment,
+    })),
+  ];
+}
+
+function blockIsVisibleOnTrack(block: Block, track: Track): boolean {
+  const blockSegments = block.visible_to_segments || [];
+  const hasSegmentTargeting = blockSegments.length > 0;
+
+  switch (track.kind) {
+    case 'monitor':
+      return true;
+    case 'audience':
+      return !hasSegmentTargeting;
+    case 'segment':
+      if (!hasSegmentTargeting) return true;
+      return blockSegments.includes(track.segment.name);
+  }
+}
+
+function blockColumn(block: Block): number {
+  const pos = Number(block.position);
+  return Number.isFinite(pos) && pos >= 0 ? Math.floor(pos) : 0;
+}
+
+function buildColumns(topLevelBlocks: Block[]): number[] {
+  if (topLevelBlocks.length === 0) return [0];
+  const positions = topLevelBlocks.map(blockColumn);
+  const max = Math.max(0, ...positions);
+  const columns: number[] = [];
+  for (let i = 0; i <= max; i += 1) columns.push(i);
+  columns.push(max + 1);
+  return columns;
+}
+
+function statusDotClass(status: BlockStatus): string {
+  if (status === 'open') return styles.statusOpen;
+  if (status === 'closed') return styles.statusClosed;
+  return '';
+}
+
+function blockLabel(block: Block): string {
+  const payload = block.payload as Record<string, unknown> | undefined;
+  if (!payload) return block.kind;
+  const candidate =
+    (payload.question as string | undefined) ||
+    (payload.title as string | undefined) ||
+    (payload.message as string | undefined) ||
+    (payload.prompt as string | undefined);
+  return candidate && candidate.length > 0 ? candidate : block.kind;
+}
+
+interface BlockCardProps {
+  block: Block;
+  ghost?: boolean;
+  dragging?: boolean;
+}
+
+function BlockCard({ block, ghost, dragging }: BlockCardProps) {
+  return (
+    <div
+      className={classNames(styles.blockCard, {
+        [styles.blockCardGhost]: ghost,
+        [styles.blockCardDragging]: dragging,
+        [styles.blockCardActive]: block.status === 'open',
+      })}
+    >
+      <div className={styles.blockHeader}>
+        <span className={classNames(styles.blockStatusDot, statusDotClass(block.status))} />
+        <span className={styles.blockKind}>{block.kind.replace(/_/g, ' ')}</span>
+      </div>
+      <div className={styles.blockLabel}>{blockLabel(block)}</div>
+      {block.children && block.children.length > 0 && (
+        <div className={styles.blockChildren}>
+          {block.children.map((child) => (
+            <span key={child.id} className={styles.childChip}>
+              {child.kind.replace(/_/g, ' ')}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function Timeline() {
+  const { experience, code, wsReady, isLoading } = useExperience();
+  const { reorder } = useReorderBlock();
+  const { closeBlock } = useBlockPresentation();
+  const [isCreateBlockOpen, setIsCreateBlockOpen] = useState(false);
+  const [isSegmentsOpen, setIsSegmentsOpen] = useState(false);
+  const [selectedColumn, setSelectedColumn] = useState<number | null>(null);
+
+  const segments = useMemo<ExperienceSegment[]>(
+    () => experience?.segments || [],
+    [experience?.segments],
+  );
+  const tracks = useMemo(() => buildTracks(segments), [segments]);
+
+  const topLevelBlocks = useMemo<Block[]>(
+    () => (experience?.blocks || []).filter((b) => !b.parent_block_id),
+    [experience?.blocks],
+  );
+
+  const participantsCombined: ParticipantSummary[] = useMemo(
+    () => [...(experience?.hosts || []), ...(experience?.participants || [])],
+    [experience?.hosts, experience?.participants],
+  );
+
+  const currentOpenBlock = useMemo(
+    () => (experience?.blocks || []).find((b) => b.status === 'open'),
+    [experience?.blocks],
+  );
+
+  const columns = useMemo(() => buildColumns(topLevelBlocks), [topLevelBlocks]);
+
+  const blocksByColumn = useMemo(() => {
+    const map = new Map<number, Block[]>();
+    topLevelBlocks.forEach((block) => {
+      const col = blockColumn(block);
+      const list = map.get(col) || [];
+      list.push(block);
+      map.set(col, list);
+    });
+    map.forEach((list) =>
+      list.sort((a, b) => (a.created_at || '').localeCompare(b.created_at || '')),
+    );
+    return map;
+  }, [topLevelBlocks]);
+
+  const handleDragEnd = useCallback(
+    (result: DropResult) => {
+      if (!result.destination) return;
+      const destinationId = result.destination.droppableId;
+      const match = /^col-(\d+)$/.exec(destinationId);
+      if (!match) return;
+      const targetColumn = Number(match[1]);
+      const blockId = result.draggableId;
+
+      const block = topLevelBlocks.find((b) => b.id === blockId);
+      if (!block || blockColumn(block) === targetColumn) return;
+
+      reorder(blockId, targetColumn);
+    },
+    [reorder, topLevelBlocks],
+  );
+
+  if (isLoading || !wsReady) {
+    return <section className="page flex-centered">Loading...</section>;
+  }
+
+  return (
+    <section className={styles.page}>
+      <div className={styles.header}>
+        <div className={styles.headerLeft}>
+          <div className={styles.title}>{experience?.name || 'Experience'} — Timeline</div>
+        </div>
+        <div className={styles.headerRight}>
+          <button
+            type="button"
+            onClick={() => setIsCreateBlockOpen(true)}
+            className={styles.navToggle}
+          >
+            <Plus size={14} />
+            <span>Add block</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => setIsSegmentsOpen(true)}
+            className={styles.navToggle}
+          >
+            <Layers size={14} />
+            <span>Segments</span>
+          </button>
+          <Link to={`/experiences/${code}/manage`} className={styles.navToggle}>
+            <LayoutList size={14} />
+            <span>Manage view</span>
+          </Link>
+        </div>
+      </div>
+
+      <DragDropContext onDragEnd={handleDragEnd}>
+        <div className={styles.board}>
+          <div className={styles.trackLabelCol}>
+            <div className={styles.trackLabelHeader}>Tracks</div>
+            {tracks.map((track) => (
+              <div
+                key={track.id}
+                className={classNames(styles.trackLabel, {
+                  [styles.trackLabelAudience]: track.kind === 'audience',
+                  [styles.trackLabelSegment]: track.kind === 'segment',
+                })}
+              >
+                {track.kind === 'monitor' && (
+                  <>
+                    <MonitorIcon size={14} />
+                    <span>{track.label}</span>
+                  </>
+                )}
+                {track.kind === 'audience' && (
+                  <>
+                    <Users size={14} />
+                    <span>{track.label}</span>
+                  </>
+                )}
+                {track.kind === 'segment' && (
+                  <>
+                    <span
+                      className={styles.segmentSwatch}
+                      style={{ background: track.segment.color }}
+                    />
+                    <span>{track.label}</span>
+                  </>
+                )}
+              </div>
+            ))}
+          </div>
+
+          <div className={styles.scroll}>
+            <div className={styles.columnHeaderRow}>
+              {columns.map((col) => (
+                <button
+                  type="button"
+                  key={`h-${col}`}
+                  onClick={() => setSelectedColumn(col)}
+                  className={classNames(styles.columnHeader, {
+                    [styles.columnHeaderSelected]: selectedColumn === col,
+                  })}
+                >
+                  {col + 1}
+                </button>
+              ))}
+            </div>
+
+            <div className={styles.rows}>
+              {tracks.map((track) => (
+                <div key={track.id} className={styles.row}>
+                  {columns.map((col) => {
+                    const blocksAtCol = blocksByColumn.get(col) || [];
+                    const visibleBlocks = blocksAtCol.filter((b) =>
+                      blockIsVisibleOnTrack(b, track),
+                    );
+                    const droppableId = `col-${col}`;
+
+                    const isSelected = selectedColumn === col;
+
+                    if (track.kind === 'monitor') {
+                      return (
+                        <Droppable droppableId={droppableId} key={droppableId}>
+                          {(provided, snapshot) => (
+                            <div
+                              ref={provided.innerRef}
+                              {...provided.droppableProps}
+                              onClick={() => setSelectedColumn(col)}
+                              className={classNames(styles.cell, {
+                                [styles.cellDroppableOver]: snapshot.isDraggingOver,
+                                [styles.cellSelected]: isSelected,
+                              })}
+                            >
+                              {visibleBlocks.length === 0 && (
+                                <div className={styles.placeholder}>—</div>
+                              )}
+                              {visibleBlocks.map((block, idx) => (
+                                <Draggable key={block.id} draggableId={block.id} index={idx}>
+                                  {(dragProvided, dragSnapshot) => (
+                                    <div
+                                      ref={dragProvided.innerRef}
+                                      {...dragProvided.draggableProps}
+                                      {...dragProvided.dragHandleProps}
+                                    >
+                                      <BlockCard block={block} dragging={dragSnapshot.isDragging} />
+                                    </div>
+                                  )}
+                                </Draggable>
+                              ))}
+                              {provided.placeholder}
+                            </div>
+                          )}
+                        </Droppable>
+                      );
+                    }
+
+                    return (
+                      <div
+                        key={`${track.id}-${col}`}
+                        onClick={() => setSelectedColumn(col)}
+                        className={classNames(styles.cell, {
+                          [styles.cellSelected]: isSelected,
+                        })}
+                      >
+                        {visibleBlocks.length === 0 ? (
+                          <div className={styles.placeholder}>—</div>
+                        ) : (
+                          visibleBlocks.map((block) => (
+                            <BlockCard key={block.id} block={block} ghost />
+                          ))
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+
+            {topLevelBlocks.length === 0 && (
+              <div className={styles.emptyState}>
+                <div>No blocks yet.</div>
+                <Link to={`/experiences/${code}/manage`} className={styles.navToggle}>
+                  Create blocks in Manage view
+                </Link>
+              </div>
+            )}
+          </div>
+
+          <div className={styles.previewCol}>
+            <div className={styles.previewHeader}>
+              <span>Preview</span>
+              {selectedColumn !== null && (
+                <span className={styles.previewColumnLabel}>Col {selectedColumn + 1}</span>
+              )}
+            </div>
+            <div className={styles.previewRows}>
+              {tracks.map((track) => {
+                const blocksAtCol =
+                  selectedColumn === null ? [] : blocksByColumn.get(selectedColumn) || [];
+                const visibleBlocks = blocksAtCol.filter((b) => blockIsVisibleOnTrack(b, track));
+                const previewBlock = visibleBlocks[0];
+                const isLandscape = track.kind === 'monitor';
+                return (
+                  <div key={track.id} className={styles.previewRow}>
+                    <div
+                      className={classNames(styles.previewFrame, {
+                        [styles.previewFrameLandscape]: isLandscape,
+                        [styles.previewFramePortrait]: !isLandscape,
+                        [styles.previewEmpty]: !previewBlock,
+                      })}
+                    >
+                      {selectedColumn === null ? (
+                        <span>Select a column</span>
+                      ) : previewBlock ? (
+                        <div>
+                          <div className={styles.previewKind}>
+                            {previewBlock.kind.replace(/_/g, ' ')}
+                          </div>
+                          <div>{blockLabel(previewBlock)}</div>
+                        </div>
+                      ) : (
+                        <span>—</span>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </DragDropContext>
+
+      <Dialog open={isCreateBlockOpen} onOpenChange={setIsCreateBlockOpen}>
+        <DialogContent style={{ maxWidth: '48rem', width: '100%' }}>
+          <CreateBlock
+            onClose={() => setIsCreateBlockOpen(false)}
+            participants={participantsCombined}
+            onEndCurrentBlock={async () => {
+              if (!currentOpenBlock) return;
+              await closeBlock(currentOpenBlock);
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={isSegmentsOpen} onOpenChange={setIsSegmentsOpen}>
+        <DialogContent style={{ maxWidth: '32rem', width: '100%' }}>
+          <SegmentManager segments={segments} />
+        </DialogContent>
+      </Dialog>
+    </section>
+  );
+}

--- a/app/models/experience_block.rb
+++ b/app/models/experience_block.rb
@@ -62,7 +62,6 @@ class ExperienceBlock < ApplicationRecord
   validates :position,
     presence: true,
     numericality: { only_integer: true, greater_than_or_equal_to: 0 }
-  validate :position_unique_within_scope
 
   after_create :sync_parent_from_links
 
@@ -213,18 +212,6 @@ class ExperienceBlock < ApplicationRecord
     if parent_links.any? && parent_block_id.nil?
       link = parent_links.first
       update_column(:parent_block_id, link.parent_block_id)
-    end
-  end
-
-  def position_unique_within_scope
-    scope = if parent_block_id.nil?
-      experience.experience_blocks.where(parent_block_id: nil)
-    else
-      ExperienceBlock.where(parent_block_id: parent_block_id)
-    end
-
-    if scope.where(position: position).where.not(id: id).exists?
-      errors.add(:position, :taken)
     end
   end
 

--- a/app/services/experiences/orchestrator.rb
+++ b/app/services/experiences/orchestrator.rb
@@ -61,7 +61,7 @@ module Experiences
       transaction do
         block = experience.experience_blocks.find(block_id)
 
-        ids = block.siblings(include_self: true).order(:position).pluck(:id)
+        ids = block.siblings(include_self: true).order(:position, :created_at).pluck(:id)
         old_index = ids.index(block.id)
         new_index = position.clamp(0, ids.length - 1)
 
@@ -75,6 +75,27 @@ module Experiences
         end
 
         block.reload
+      end
+    end
+
+    def set_block_column!(block_id:, column:)
+      transaction do
+        block = experience.experience_blocks.find(block_id)
+        target = [column.to_i, 0].max
+        block.update!(position: target) unless block.position == target
+        block.reload
+      end
+    end
+
+    def insert_block_column!(at_column:)
+      transaction do
+        bump_from = at_column.to_i
+        experience
+          .experience_blocks
+          .parent_blocks
+          .where("position >= ?", bump_from)
+          .order(position: :desc)
+          .each { |b| b.update!(position: b.position + 1) }
       end
     end
 

--- a/app/services/experiences/visibility.rb
+++ b/app/services/experiences/visibility.rb
@@ -157,10 +157,11 @@ module Experiences
 
     def serialize_block(block, participant_role:, user: nil, depth: 0)
       {
-        id:      block.id,
-        kind:    block.kind,
-        status:  block.status,
-        payload: block.payload
+        id:       block.id,
+        kind:     block.kind,
+        status:   block.status,
+        payload:  block.payload,
+        position: block.position
       }
         .merge(responses: serialize_response_data(block, participant_role, user))
         .merge(visibility_metadata(block, participant_role, user))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
           post :close
           post :hide
           post :reorder
+          post :set_column
           post :submit_poll_response
           post :submit_question_response
           post :submit_multistep_form_response

--- a/db/migrate/20260324000002_drop_old_position_indexes.rb
+++ b/db/migrate/20260324000002_drop_old_position_indexes.rb
@@ -1,7 +1,7 @@
 class DropOldPositionIndexes < ActiveRecord::Migration[7.2]
   def up
-    remove_index :experience_blocks, name: "index_parent_blocks_unique_position"
-    remove_index :experience_blocks, name: "index_child_blocks_unique_position"
+    remove_index :experience_blocks, name: "index_parent_blocks_unique_position", if_exists: true
+    remove_index :experience_blocks, name: "index_child_blocks_unique_position", if_exists: true
   end
 
   def down

--- a/db/migrate/20260417000001_allow_duplicate_block_positions.rb
+++ b/db/migrate/20260417000001_allow_duplicate_block_positions.rb
@@ -1,0 +1,24 @@
+class AllowDuplicateBlockPositions < ActiveRecord::Migration[7.2]
+  def up
+    execute <<~SQL
+      ALTER TABLE experience_blocks DROP CONSTRAINT IF EXISTS unique_position_in_scope;
+    SQL
+
+    add_index :experience_blocks,
+      [:position_scope, :position],
+      name: "index_experience_blocks_on_position_scope_and_position"
+  end
+
+  def down
+    remove_index :experience_blocks,
+      name: "index_experience_blocks_on_position_scope_and_position",
+      if_exists: true
+
+    execute <<~SQL
+      ALTER TABLE experience_blocks
+        ADD CONSTRAINT unique_position_in_scope
+        UNIQUE (position_scope, position)
+        DEFERRABLE INITIALLY DEFERRED;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_26_000001) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_17_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -115,9 +115,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_26_000001) do
     t.index ["experience_id"], name: "index_experience_blocks_on_experience_id"
     t.index ["kind"], name: "index_experience_blocks_on_kind"
     t.index ["parent_block_id"], name: "index_experience_blocks_on_parent_block_id"
+    t.index ["position_scope", "position"], name: "index_experience_blocks_on_position_scope_and_position"
     t.index ["target_user_ids"], name: "index_experience_blocks_on_target_user_ids", using: :gin
     t.index ["visible_to_roles"], name: "index_experience_blocks_on_visible_to_roles", using: :gin
-    t.unique_constraint ["position_scope", "position"], deferrable: :deferred, name: "unique_position_in_scope"
   end
 
   create_table "experience_buzzer_submissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/controllers/api/experience_blocks_controller_spec.rb
+++ b/spec/controllers/api/experience_blocks_controller_spec.rb
@@ -310,6 +310,44 @@ RSpec.describe Api::ExperienceBlocksController, type: :controller do
     end
   end
 
+  describe "POST #set_column" do
+    let!(:block_a) { create(:experience_block, :announcement, experience: experience, position: 0) }
+    let!(:block_b) { create(:experience_block, :announcement, experience: experience, position: 1) }
+
+    subject do
+      post(
+        :set_column,
+        params: {
+          experience_id: experience.code_slug,
+          id: block_a.id,
+          column: 1,
+        },
+        format: :json
+      )
+    end
+
+    it "moves only the target block without disturbing siblings" do
+      broadcaster = instance_double(Experiences::Broadcaster, broadcast_experience_update: true)
+      allow(Experiences::Broadcaster).to receive(:new).and_return(broadcaster)
+
+      subject
+
+      expect(block_a.reload.position).to eq(1)
+      expect(block_b.reload.position).to eq(1)
+    end
+
+    it "broadcasts the update and returns 200" do
+      broadcaster = instance_double(Experiences::Broadcaster, broadcast_experience_update: true)
+      allow(Experiences::Broadcaster).to receive(:new).and_return(broadcaster)
+
+      subject
+
+      expect(broadcaster).to have_received(:broadcast_experience_update)
+      expect(response.status).to eql(200)
+      expect(JSON.parse(response.body)["success"]).to be(true)
+    end
+  end
+
   describe "PATCH #update" do
     let(:player) { create(:experience_participant, :player, experience: experience) }
 

--- a/spec/models/experience_block_spec.rb
+++ b/spec/models/experience_block_spec.rb
@@ -3,81 +3,26 @@ require "rails_helper"
 RSpec.describe ExperienceBlock do
   let(:experience) { create(:experience) }
 
-  describe "position validations" do
-    context "when the block is a parent" do
-      before do
-        create(:experience_block, experience: experience, position: 0)
-      end
-
-      it "is invalid with a duplicate position in the same experience" do
-        duplicate = build(:experience_block, experience: experience, position: 0)
-        expect(duplicate).not_to be_valid
-        expect(duplicate.errors[:position]).to include("has already been taken")
-      end
+  describe "position" do
+    it "requires a non-negative integer" do
+      block = build(:experience_block, experience: experience, position: -1)
+      expect(block).not_to be_valid
+      expect(block.errors[:position]).to be_present
     end
 
-    context "when there are children with the same position" do
-      let(:child1) do
-        build(
-          :experience_block,
-          experience: experience,
-          parent_block: parent1,
-          position: 0
-        )
-      end
-
-      let(:child2) do
-        build(
-          :experience_block,
-          experience: experience,
-          parent_block: parent2,
-          position: 0
-        )
-      end
-
-      context "with different parents" do
-        let(:parent1) { create(:experience_block, experience: experience) }
-        let(:parent2) { create(:experience_block, experience: experience) }
-
-        it "is valid" do
-          expect(child1).to be_valid
-          expect(child2).to be_valid
-        end
-      end
-
-      context "with the same parents" do
-        let(:parent1) { create(:experience_block, experience: experience) }
-        let(:parent2) { parent1 }
-
-        it "is invalid with a duplicate position under the same parent" do
-          child1.save!
-
-          expect(child2).not_to be_valid
-          expect(child2.errors[:position]).to include("has already been taken")
-        end
-      end
+    it "allows two parent blocks to share a position (timeline simultaneity)" do
+      create(:experience_block, experience: experience, position: 0)
+      duplicate = build(:experience_block, experience: experience, position: 0)
+      expect(duplicate).to be_valid
+      expect { duplicate.save! }.not_to raise_error
     end
 
-    describe "update_all reorder" do
-      it "reorders positions in a single pass without violating the deferred index" do
-        block_a = create(:experience_block, experience: experience, position: 0)
-        block_b = create(:experience_block, experience: experience, position: 1)
-        block_c = create(:experience_block, experience: experience, position: 2)
-
-        new_order = [block_c.id, block_a.id, block_b.id]
-
-        expect {
-          ActiveRecord::Base.transaction do
-            new_order.each_with_index do |id, idx|
-              ExperienceBlock.where(id: id).update_all(position: idx)
-            end
-          end
-        }.not_to raise_error
-
-        expect(block_c.reload.position).to eq(0)
-        expect(block_a.reload.position).to eq(1)
-        expect(block_b.reload.position).to eq(2)
-      end
+    it "allows two children of the same parent to share a position" do
+      parent = create(:experience_block, experience: experience, position: 0)
+      create(:experience_block, experience: experience, parent_block: parent, position: 0)
+      duplicate = build(:experience_block, experience: experience, parent_block: parent, position: 0)
+      expect(duplicate).to be_valid
+      expect { duplicate.save! }.not_to raise_error
     end
   end
 

--- a/spec/services/experiences/orchestrator_spec.rb
+++ b/spec/services/experiences/orchestrator_spec.rb
@@ -107,6 +107,44 @@ RSpec.describe Experiences::Orchestrator do
     end
   end
 
+  describe "#set_block_column!" do
+    let(:participant_role) { ExperienceParticipant.roles[:host] }
+
+    let!(:block_a) { create(:experience_block, experience: experience, position: 0) }
+    let!(:block_b) { create(:experience_block, experience: experience, position: 1) }
+    let!(:block_c) { create(:experience_block, experience: experience, position: 2) }
+
+    it "moves only the target block's position and leaves siblings unchanged" do
+      described_class.new(actor: user, experience: experience).set_block_column!(
+        block_id: block_a.id,
+        column: 2
+      )
+
+      expect(block_a.reload.position).to eq(2)
+      expect(block_b.reload.position).to eq(1)
+      expect(block_c.reload.position).to eq(2)
+    end
+
+    it "allows two blocks to share a column (simultaneity)" do
+      described_class.new(actor: user, experience: experience).set_block_column!(
+        block_id: block_a.id,
+        column: 1
+      )
+
+      expect(block_a.reload.position).to eq(1)
+      expect(block_b.reload.position).to eq(1)
+    end
+
+    it "clamps negative columns to zero" do
+      described_class.new(actor: user, experience: experience).set_block_column!(
+        block_id: block_b.id,
+        column: -5
+      )
+
+      expect(block_b.reload.position).to eq(0)
+    end
+  end
+
   describe "#open_lobby!" do
     let(:participant_role) { ExperienceParticipant.roles[:host] }
 


### PR DESCRIPTION
Timeline view (/experiences/:code/timeline):
- Tracks-and-columns layout: Monitor + Audience group with segment sub-rows
- Column-based positions (drops unique_position_in_scope for simultaneity)
- Drag-to-reorder via existing reorder_block! (insert + shift semantics)
- set_block_column! endpoint available for future explicit stacking UX
- Column-select preview pane with landscape Monitor + portrait audience frames
- Add block / Segments modals reuse existing CreateBlock + SegmentManager
- websocket admin stream opens on /timeline (useExperienceRoute fix)

Background static:
- Unplugged BackgroundStatic render + TopNav toggle (component/CSS kept)

Create form:
- Name input auto-fills Code with a slugified value (mirrors generate_code_slug)

Broken migration fix:
- 20260324000002_drop_old_position_indexes made idempotent via if_exists