### PR TITLE
Add 3D ticket-rip animation on join

### DIFF
--- a/app/controllers/api/experiences_controller.rb
+++ b/app/controllers/api/experiences_controller.rb
@@ -203,14 +203,18 @@ class Api::ExperiencesController < Api::BaseController
       render json: {
         type: 'success',
         url: experience_lobby_path(code: experience.code_slug),
-        status: "registered"
+        status: "registered",
+        experience_name: experience.name,
+        experience_code_slug: experience.code_slug
       }
     else
       render json: {
         type: 'needs_registration',
         experience_code: code,
         status: "needs_registration",
-        url: experience_register_path(code: experience.code_slug)
+        url: experience_register_path(code: experience.code_slug),
+        experience_name: experience.name,
+        experience_code_slug: experience.code_slug
       }
     end
   end

--- a/app/frontend/Hooks/useJoinExperience.ts
+++ b/app/frontend/Hooks/useJoinExperience.ts
@@ -3,19 +3,23 @@ import { qaLogger } from '@cctv/utils';
 
 import { usePost } from './usePost';
 
+export interface JoinExperienceResult {
+  url: string;
+  status: 'registered' | 'needs_registration';
+  experienceName: string;
+}
+
 export function useJoinExperience() {
   const { post, isLoading, error, setError } = usePost<JoinExperienceApiResponse>({
     url: '/api/experiences/join',
   });
 
-  const joinExperience = async (code: string) => {
-    // Validate code
+  const joinExperience = async (code: string): Promise<JoinExperienceResult | null> => {
     if (!code || code.trim() === '') {
       setError('Please enter a code');
-      return;
+      return null;
     }
 
-    // Make the API request
     const response = await post(
       JSON.stringify({
         code: code.trim(),
@@ -24,27 +28,32 @@ export function useJoinExperience() {
 
     if (!response) {
       setError('Failed to join experience');
-      return;
+      return null;
     }
 
-    // Handle different response types
     switch (response.type) {
       case 'success':
         qaLogger(`User already registrated, redirecting to: ${response.url}`);
         sessionStorage.setItem('cctv_last_join_code', code.trim());
-        window.location.href = response.url;
-        break;
+        return {
+          url: response.url,
+          status: 'registered',
+          experienceName: response.experience_name,
+        };
       case 'needs_registration':
         qaLogger(`User needs registration, redirecting to: ${response.url}`);
         sessionStorage.setItem('cctv_last_join_code', code.trim());
-        window.location.href = response.url;
-        break;
+        return {
+          url: response.url,
+          status: 'needs_registration',
+          experienceName: response.experience_name,
+        };
       case 'error':
         setError(response.error || 'Failed to join experience');
-        break;
+        return null;
       default:
         console.error(`Unknown response type encountered: ${response}`);
-        break;
+        return null;
     }
   };
 

--- a/app/frontend/Pages/TicketRip.module.scss
+++ b/app/frontend/Pages/TicketRip.module.scss
@@ -1,0 +1,98 @@
+.root {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  overflow: hidden;
+  background: radial-gradient(
+    ellipse at 50% 40%,
+    rgba(200, 240, 96, 0.08) 0%,
+    #0d0d0f 45%,
+    #080808 100%
+  );
+  font-family: 'Bebas Neue', Impact, sans-serif;
+  color: var(--hot-white);
+  animation: fadeIn 0.25s ease-out;
+  cursor: pointer;
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+  outline: none;
+}
+
+.grain {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(255, 255, 255, 0.012) 0 1px,
+    transparent 1px 3px
+  );
+  mix-blend-mode: overlay;
+}
+
+.vignette {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  box-shadow: inset 0 0 180px 40px rgba(0, 0, 0, 0.75);
+}
+
+.canvas {
+  position: absolute;
+  inset: 0;
+}
+
+.caption {
+  position: absolute;
+  bottom: max(48px, env(safe-area-inset-bottom));
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: 'Bebas Neue', Impact, sans-serif;
+  font-size: 14px;
+  letter-spacing: 5px;
+  color: var(--hot-white);
+  opacity: 0.55;
+  pointer-events: none;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.captionReady {
+  color: var(--phosphor);
+  text-shadow:
+    0 0 6px rgba(200, 240, 96, 0.5),
+    0 0 14px rgba(200, 240, 96, 0.25);
+  opacity: 0;
+  animation:
+    fadeInCaption 3s ease-out forwards,
+    pulseCaption 3s ease-in-out 3s infinite;
+}
+
+@keyframes fadeInCaption {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 0.85;
+  }
+}
+
+@keyframes pulseCaption {
+  0%,
+  100% {
+    opacity: 0.85;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}

--- a/app/frontend/Pages/TicketRip.tsx
+++ b/app/frontend/Pages/TicketRip.tsx
@@ -741,7 +741,8 @@ export default function TicketRip({ code, experienceName = '', onComplete }: Tic
         blending: THREE.AdditiveBlending,
       }),
     );
-    glow.position.set(0, vOffset, -0.15);
+    glow.position.set(0, vOffset, -0.9);
+    glow.renderOrder = -10;
     scene.add(glow);
 
     threeRef.current = {
@@ -914,10 +915,9 @@ export default function TicketRip({ code, experienceName = '', onComplete }: Tic
         topHalf.rotation.z = 0;
         topHalf.rotation.x = -0.05 + settle * 0.05;
         const pulse = 0.5 + 0.5 * Math.sin(tt * 6);
-        topHalf.material.emissive = new THREE.Color(colors.phosphor);
-        topHalf.material.emissiveIntensity = settle * 0.12 * (0.6 + pulse * 0.4);
         glow.material.opacity = easeOutCubic(t) * 0.55 * (0.65 + pulse * 0.35);
         glow.scale.setScalar(0.85 + easeOutCubic(t) * 0.2);
+        glow.position.y = ticketGroup.position.y + topHalf.position.y;
         const g = 11;
         const fy = -0.22 - 0.5 * g * tt * tt;
         const fx = Math.sin(tt * 2.2) * 0.35 + tt * 0.1;
@@ -954,9 +954,8 @@ export default function TicketRip({ code, experienceName = '', onComplete }: Tic
         ticketGroup.rotation.x = -0.03 + Math.sin(tt * 1.8) * 0.02;
         ticketGroup.rotation.z = Math.sin(tt * 0.8) * 0.02;
         const pulse = 0.5 + 0.5 * Math.sin(tt * 3);
-        topHalf.material.emissive = new THREE.Color(colors.phosphor);
-        topHalf.material.emissiveIntensity = 0.08 + pulse * 0.06;
         glow.material.opacity = 0.35 + pulse * 0.15;
+        glow.position.y = ticketGroup.position.y + topHalf.position.y;
         shadow.material.opacity = 0.35;
         camera.position.z = baseCameraZ - 0.25;
         if (!onCompleteFiredRef.current && tt >= SUCCESS_HOLD_DURATION) {

--- a/app/frontend/Pages/TicketRip.tsx
+++ b/app/frontend/Pages/TicketRip.tsx
@@ -5,10 +5,26 @@ import * as Tone from 'tone';
 
 import styles from './TicketRip.module.scss';
 
-const PAPER = '#f0ede4';
 const PAPER_DK = '#dcd7c2';
-const INK = '#080808';
-const PHOSPHOR = '#c8f060';
+
+interface TicketColors {
+  paper: string;
+  ink: string;
+  phosphor: string;
+}
+
+function resolveCssVar(name: string, fallback: string): string {
+  const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  return v || fallback;
+}
+
+function resolveTicketColors(): TicketColors {
+  return {
+    paper: resolveCssVar('--hot-white', '#f0ede4'),
+    ink: resolveCssVar('--black', '#080808'),
+    phosphor: resolveCssVar('--phosphor', '#c8f060'),
+  };
+}
 
 const FONT_LINK_ID = 'cctv-ticket-fonts';
 
@@ -76,8 +92,8 @@ function punchCornerNotches(
   ctx.restore();
 }
 
-function drawPerfDots(ctx: CanvasRenderingContext2D, y: number, W: number) {
-  ctx.fillStyle = INK;
+function drawPerfDots(ctx: CanvasRenderingContext2D, y: number, W: number, ink: string) {
+  ctx.fillStyle = ink;
   for (let x = 18; x < W - 18; x += 24) {
     ctx.beginPath();
     ctx.arc(x, y, 2.8, 0, Math.PI * 2);
@@ -85,11 +101,16 @@ function drawPerfDots(ctx: CanvasRenderingContext2D, y: number, W: number) {
   }
 }
 
-function drawAdmitOneBand(ctx: CanvasRenderingContext2D, H: number, bandX: number) {
-  ctx.fillStyle = PHOSPHOR;
+function drawAdmitOneBand(
+  ctx: CanvasRenderingContext2D,
+  H: number,
+  bandX: number,
+  colors: TicketColors,
+) {
+  ctx.fillStyle = colors.phosphor;
   ctx.fillRect(0, 0, bandX, H);
 
-  ctx.strokeStyle = INK;
+  ctx.strokeStyle = colors.ink;
   ctx.lineWidth = 2;
   ctx.setLineDash([6, 5]);
   ctx.beginPath();
@@ -101,7 +122,7 @@ function drawAdmitOneBand(ctx: CanvasRenderingContext2D, H: number, bandX: numbe
   ctx.save();
   ctx.translate(bandX / 2, H / 2);
   ctx.rotate(-Math.PI / 2);
-  ctx.fillStyle = INK;
+  ctx.fillStyle = colors.ink;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
   ctx.font = '700 36px "Alfa Slab One", Georgia, serif';
@@ -109,7 +130,7 @@ function drawAdmitOneBand(ctx: CanvasRenderingContext2D, H: number, bandX: numbe
   ctx.restore();
 }
 
-function createTopHalfTexture(experienceName: string): THREE.CanvasTexture {
+function createTopHalfTexture(experienceName: string, colors: TicketColors): THREE.CanvasTexture {
   const W = 700;
   const H = 1120;
   const canvas = document.createElement('canvas');
@@ -119,16 +140,16 @@ function createTopHalfTexture(experienceName: string): THREE.CanvasTexture {
   if (!ctx) throw new Error('canvas 2d context unavailable');
 
   const bg = ctx.createLinearGradient(0, 0, 0, H);
-  bg.addColorStop(0, PAPER);
+  bg.addColorStop(0, colors.paper);
   bg.addColorStop(1, PAPER_DK);
   ctx.fillStyle = bg;
   ctx.fillRect(0, 0, W, H);
   drawPaperGrain(ctx, W, H);
 
   const bandX = 82;
-  drawAdmitOneBand(ctx, H, bandX);
+  drawAdmitOneBand(ctx, H, bandX, colors);
 
-  ctx.strokeStyle = INK;
+  ctx.strokeStyle = colors.ink;
   ctx.lineWidth = 3;
   ctx.strokeRect(bandX + 20, 24, W - bandX - 44, H - 48);
   ctx.lineWidth = 1;
@@ -140,7 +161,7 @@ function createTopHalfTexture(experienceName: string): THREE.CanvasTexture {
   const contentWidth = contentRight - contentLeft;
 
   const headerTop = 60;
-  ctx.fillStyle = INK;
+  ctx.fillStyle = colors.ink;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'top';
   ctx.font = '700 26px "Bebas Neue", Impact, sans-serif';
@@ -148,7 +169,7 @@ function createTopHalfTexture(experienceName: string): THREE.CanvasTexture {
   ctx.font = '500 14px "Bebas Neue", Impact, sans-serif';
   ctx.fillText('CHICAGO COMEDY TV', contentCenter, headerTop + 34);
 
-  ctx.strokeStyle = INK;
+  ctx.strokeStyle = colors.ink;
   ctx.lineWidth = 1.5;
   ctx.beginPath();
   ctx.moveTo(contentLeft + 60, headerTop + 64);
@@ -169,7 +190,7 @@ function createTopHalfTexture(experienceName: string): THREE.CanvasTexture {
   const dateColCenterX = contentRight - dateColWidth / 2;
   const dividerX = contentLeft + titleColWidth + columnGap / 2;
 
-  ctx.strokeStyle = INK;
+  ctx.strokeStyle = colors.ink;
   ctx.lineWidth = 1.2;
   ctx.setLineDash([5, 6]);
   ctx.beginPath();
@@ -237,7 +258,7 @@ function createTopHalfTexture(experienceName: string): THREE.CanvasTexture {
   ctx.save();
   ctx.translate(titleColCenterX, titleAreaBottom - 16);
   ctx.rotate(-Math.PI / 2);
-  ctx.fillStyle = INK;
+  ctx.fillStyle = colors.ink;
   ctx.textAlign = 'left';
   ctx.textBaseline = 'middle';
   ctx.font = `700 ${titleFontSize}px ${titleFontFamily}`;
@@ -290,7 +311,7 @@ function createTopHalfTexture(experienceName: string): THREE.CanvasTexture {
   ctx.save();
   ctx.translate(dateColCenterX, titleAreaCenterY);
   ctx.rotate(-Math.PI / 2);
-  ctx.fillStyle = INK;
+  ctx.fillStyle = colors.ink;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
 
@@ -302,7 +323,7 @@ function createTopHalfTexture(experienceName: string): THREE.CanvasTexture {
 
   ctx.restore();
 
-  drawPerfDots(ctx, H - 14, W);
+  drawPerfDots(ctx, H - 14, W, colors.ink);
 
   punchCornerNotches(ctx, W, H, 22, { tl: true, tr: true });
 
@@ -346,7 +367,7 @@ function wrapCodeIntoLines(
   return chunks;
 }
 
-function createBottomHalfTexture(code: string): THREE.CanvasTexture {
+function createBottomHalfTexture(code: string, colors: TicketColors): THREE.CanvasTexture {
   const W = 700;
   const H = 440;
   const canvas = document.createElement('canvas');
@@ -357,17 +378,17 @@ function createBottomHalfTexture(code: string): THREE.CanvasTexture {
 
   const bg = ctx.createLinearGradient(0, 0, 0, H);
   bg.addColorStop(0, PAPER_DK);
-  bg.addColorStop(1, PAPER);
+  bg.addColorStop(1, colors.paper);
   ctx.fillStyle = bg;
   ctx.fillRect(0, 0, W, H);
   drawPaperGrain(ctx, W, H);
 
-  drawPerfDots(ctx, 14, W);
+  drawPerfDots(ctx, 14, W, colors.ink);
 
   const bandX = 82;
-  drawAdmitOneBand(ctx, H, bandX);
+  drawAdmitOneBand(ctx, H, bandX, colors);
 
-  ctx.strokeStyle = INK;
+  ctx.strokeStyle = colors.ink;
   ctx.lineWidth = 3;
   ctx.strokeRect(bandX + 20, 28, W - bandX - 44, H - 48);
 
@@ -380,7 +401,7 @@ function createBottomHalfTexture(code: string): THREE.CanvasTexture {
   const codeMaxWidth = contentWidth - 20;
   const codeFontFamily = '"IBM Plex Mono", "Courier New", monospace';
 
-  ctx.fillStyle = INK;
+  ctx.fillStyle = colors.ink;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'top';
   ctx.font = '700 14px "Bebas Neue", Impact, sans-serif';
@@ -400,7 +421,7 @@ function createBottomHalfTexture(code: string): THREE.CanvasTexture {
   }
 
   ctx.font = `700 ${codeSize}px ${codeFontFamily}`;
-  ctx.fillStyle = INK;
+  ctx.fillStyle = colors.ink;
   const codeLineHeight = codeSize * 1.15;
   const codeBlockHeight = codeLines.length * codeLineHeight;
   const codeAreaTop = 82;
@@ -410,7 +431,7 @@ function createBottomHalfTexture(code: string): THREE.CanvasTexture {
     ctx.fillText(line, contentCenter, codeTop + i * codeLineHeight);
   });
 
-  ctx.fillStyle = INK;
+  ctx.fillStyle = colors.ink;
   let bx = contentLeft + 20;
   const barY = H - 120;
   while (bx < contentRight - 20) {
@@ -421,7 +442,7 @@ function createBottomHalfTexture(code: string): THREE.CanvasTexture {
 
   ctx.textAlign = 'center';
   ctx.font = '700 13px "Bebas Neue", Impact, sans-serif';
-  ctx.fillStyle = INK;
+  ctx.fillStyle = colors.ink;
   ctx.fillText('KEEP THIS STUB', contentCenter, H - 50);
 
   punchCornerNotches(ctx, W, H, 22, { bl: true, br: true });
@@ -570,6 +591,8 @@ export default function TicketRip({ code, experienceName = '', onComplete }: Tic
     const mount = mountRef.current;
     if (!mount) return;
 
+    const colors = resolveTicketColors();
+
     const initAudio = async () => {
       try {
         await Tone.start();
@@ -598,10 +621,10 @@ export default function TicketRip({ code, experienceName = '', onComplete }: Tic
     mount.appendChild(renderer.domElement);
 
     scene.add(new THREE.AmbientLight(0xffffff, 0.72));
-    const key = new THREE.DirectionalLight(0xf0ede4, 0.7);
+    const key = new THREE.DirectionalLight(colors.paper, 0.7);
     key.position.set(4, 5, 6);
     scene.add(key);
-    const rim = new THREE.DirectionalLight(0xc8f060, 0.32);
+    const rim = new THREE.DirectionalLight(colors.phosphor, 0.32);
     rim.position.set(-5, 2, -3);
     scene.add(rim);
     const fill = new THREE.DirectionalLight(0xf5a623, 0.15);
@@ -612,8 +635,8 @@ export default function TicketRip({ code, experienceName = '', onComplete }: Tic
     const TOP_H = 3.84;
     const BOT_H = 1.5;
 
-    const topTex = createTopHalfTexture(experienceName);
-    const botTex = createBottomHalfTexture(code);
+    const topTex = createTopHalfTexture(experienceName, colors);
+    const botTex = createBottomHalfTexture(code, colors);
 
     const topGeom = new THREE.PlaneGeometry(TW, TOP_H, 10, 20);
     const topMat = new THREE.MeshStandardMaterial({
@@ -673,7 +696,7 @@ export default function TicketRip({ code, experienceName = '', onComplete }: Tic
     const particles: Particle[] = [];
     for (let i = 0; i < MAX_P; i++) {
       const mat = new THREE.MeshBasicMaterial({
-        color: i % 3 === 0 ? 0xc8f060 : 0xf0ede4,
+        color: i % 3 === 0 ? colors.phosphor : colors.paper,
         side: THREE.DoubleSide,
         transparent: true,
         opacity: 0,
@@ -891,7 +914,7 @@ export default function TicketRip({ code, experienceName = '', onComplete }: Tic
         topHalf.rotation.z = 0;
         topHalf.rotation.x = -0.05 + settle * 0.05;
         const pulse = 0.5 + 0.5 * Math.sin(tt * 6);
-        topHalf.material.emissive = new THREE.Color(0xc8f060);
+        topHalf.material.emissive = new THREE.Color(colors.phosphor);
         topHalf.material.emissiveIntensity = settle * 0.12 * (0.6 + pulse * 0.4);
         glow.material.opacity = easeOutCubic(t) * 0.55 * (0.65 + pulse * 0.35);
         glow.scale.setScalar(0.85 + easeOutCubic(t) * 0.2);
@@ -931,7 +954,7 @@ export default function TicketRip({ code, experienceName = '', onComplete }: Tic
         ticketGroup.rotation.x = -0.03 + Math.sin(tt * 1.8) * 0.02;
         ticketGroup.rotation.z = Math.sin(tt * 0.8) * 0.02;
         const pulse = 0.5 + 0.5 * Math.sin(tt * 3);
-        topHalf.material.emissive = new THREE.Color(0xc8f060);
+        topHalf.material.emissive = new THREE.Color(colors.phosphor);
         topHalf.material.emissiveIntensity = 0.08 + pulse * 0.06;
         glow.material.opacity = 0.35 + pulse * 0.15;
         shadow.material.opacity = 0.35;

--- a/app/frontend/Pages/TicketRip.tsx
+++ b/app/frontend/Pages/TicketRip.tsx
@@ -1,0 +1,1021 @@
+import { PointerEvent, useCallback, useEffect, useRef, useState } from 'react';
+
+import * as THREE from 'three';
+import * as Tone from 'tone';
+
+import styles from './TicketRip.module.scss';
+
+const PAPER = '#f0ede4';
+const PAPER_DK = '#dcd7c2';
+const INK = '#080808';
+const PHOSPHOR = '#c8f060';
+
+const FONT_LINK_ID = 'cctv-ticket-fonts';
+
+function ensureFontsLoaded(): Promise<FontFaceSet | void> {
+  if (!document.getElementById(FONT_LINK_ID)) {
+    const link = document.createElement('link');
+    link.id = FONT_LINK_ID;
+    link.rel = 'stylesheet';
+    link.href =
+      'https://fonts.googleapis.com/css2?family=Alfa+Slab+One&family=IBM+Plex+Mono:wght@500;700&family=Fraunces:ital,wght@0,400;0,700;1,400&family=Dela+Gothic+One&display=swap';
+    document.head.appendChild(link);
+  }
+  return document.fonts ? document.fonts.ready : Promise.resolve();
+}
+
+function drawPaperGrain(ctx: CanvasRenderingContext2D, W: number, H: number) {
+  for (let i = 0; i < (W * H) / 400; i++) {
+    const x = Math.random() * W;
+    const y = Math.random() * H;
+    const a = Math.random() * 0.09;
+    ctx.fillStyle = `rgba(30, 28, 20, ${a})`;
+    ctx.fillRect(x, y, 1 + Math.random() * 1.3, 1);
+  }
+  for (let i = 0; i < 5; i++) {
+    const g = ctx.createRadialGradient(
+      Math.random() * W,
+      Math.random() * H,
+      0,
+      Math.random() * W,
+      Math.random() * H,
+      120 + Math.random() * 200,
+    );
+    g.addColorStop(0, 'rgba(120, 110, 80, 0.06)');
+    g.addColorStop(1, 'rgba(120, 110, 80, 0)');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, W, H);
+  }
+}
+
+function punchCornerNotches(
+  ctx: CanvasRenderingContext2D,
+  W: number,
+  H: number,
+  radius: number,
+  corners: { tl?: boolean; tr?: boolean; bl?: boolean; br?: boolean },
+) {
+  ctx.save();
+  ctx.globalCompositeOperation = 'destination-out';
+  ctx.fillStyle = '#000';
+  ctx.beginPath();
+  if (corners.tl) ctx.arc(0, 0, radius, 0, Math.PI * 2);
+  if (corners.tr) {
+    ctx.moveTo(W + radius, 0);
+    ctx.arc(W, 0, radius, 0, Math.PI * 2);
+  }
+  if (corners.bl) {
+    ctx.moveTo(radius, H);
+    ctx.arc(0, H, radius, 0, Math.PI * 2);
+  }
+  if (corners.br) {
+    ctx.moveTo(W + radius, H);
+    ctx.arc(W, H, radius, 0, Math.PI * 2);
+  }
+  ctx.fill();
+  ctx.restore();
+}
+
+function drawPerfDots(ctx: CanvasRenderingContext2D, y: number, W: number) {
+  ctx.fillStyle = INK;
+  for (let x = 18; x < W - 18; x += 24) {
+    ctx.beginPath();
+    ctx.arc(x, y, 2.8, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function drawAdmitOneBand(ctx: CanvasRenderingContext2D, H: number, bandX: number) {
+  ctx.fillStyle = PHOSPHOR;
+  ctx.fillRect(0, 0, bandX, H);
+
+  ctx.strokeStyle = INK;
+  ctx.lineWidth = 2;
+  ctx.setLineDash([6, 5]);
+  ctx.beginPath();
+  ctx.moveTo(bandX, 24);
+  ctx.lineTo(bandX, H - 24);
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  ctx.save();
+  ctx.translate(bandX / 2, H / 2);
+  ctx.rotate(-Math.PI / 2);
+  ctx.fillStyle = INK;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.font = '700 36px "Alfa Slab One", Georgia, serif';
+  ctx.fillText('ADMIT ONE', 0, 0);
+  ctx.restore();
+}
+
+function createTopHalfTexture(experienceName: string): THREE.CanvasTexture {
+  const W = 700;
+  const H = 1120;
+  const canvas = document.createElement('canvas');
+  canvas.width = W;
+  canvas.height = H;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('canvas 2d context unavailable');
+
+  const bg = ctx.createLinearGradient(0, 0, 0, H);
+  bg.addColorStop(0, PAPER);
+  bg.addColorStop(1, PAPER_DK);
+  ctx.fillStyle = bg;
+  ctx.fillRect(0, 0, W, H);
+  drawPaperGrain(ctx, W, H);
+
+  const bandX = 82;
+  drawAdmitOneBand(ctx, H, bandX);
+
+  ctx.strokeStyle = INK;
+  ctx.lineWidth = 3;
+  ctx.strokeRect(bandX + 20, 24, W - bandX - 44, H - 48);
+  ctx.lineWidth = 1;
+  ctx.strokeRect(bandX + 30, 34, W - bandX - 64, H - 68);
+
+  const contentLeft = bandX + 48;
+  const contentRight = W - 48;
+  const contentCenter = (contentLeft + contentRight) / 2;
+  const contentWidth = contentRight - contentLeft;
+
+  const headerTop = 60;
+  ctx.fillStyle = INK;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+  ctx.font = '700 26px "Bebas Neue", Impact, sans-serif';
+  ctx.fillText('★  CCTV  ★', contentCenter, headerTop);
+  ctx.font = '500 14px "Bebas Neue", Impact, sans-serif';
+  ctx.fillText('CHICAGO COMEDY TV', contentCenter, headerTop + 34);
+
+  ctx.strokeStyle = INK;
+  ctx.lineWidth = 1.5;
+  ctx.beginPath();
+  ctx.moveTo(contentLeft + 60, headerTop + 64);
+  ctx.lineTo(contentRight - 60, headerTop + 64);
+  ctx.stroke();
+
+  const showName = (experienceName || 'The Show').trim();
+
+  const titleAreaTop = headerTop + 90;
+  const titleAreaBottom = H - 60;
+  const titleAreaHeight = titleAreaBottom - titleAreaTop;
+  const titleAreaCenterY = (titleAreaTop + titleAreaBottom) / 2;
+
+  const dateColWidth = 110;
+  const columnGap = 14;
+  const titleColWidth = contentWidth - dateColWidth - columnGap;
+  const titleColCenterX = contentLeft + titleColWidth / 2;
+  const dateColCenterX = contentRight - dateColWidth / 2;
+  const dividerX = contentLeft + titleColWidth + columnGap / 2;
+
+  ctx.strokeStyle = INK;
+  ctx.lineWidth = 1.2;
+  ctx.setLineDash([5, 6]);
+  ctx.beginPath();
+  ctx.moveTo(dividerX, titleAreaTop);
+  ctx.lineTo(dividerX, titleAreaBottom);
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  const titleFontFamily = '"Alfa Slab One", Georgia, serif';
+  const titleBaseSize = 150;
+  const titleMinSize = 50;
+  const titleMaxTextHeight = titleAreaHeight - 24;
+  const titleMaxStackWidth = titleColWidth - 24;
+
+  const tokens = showName.split(/\s+/).filter(Boolean);
+  let titleLines: string[] = [showName];
+  let titleFontSize = titleBaseSize;
+
+  const measureLongestLine = (lines: string[], size: number): number => {
+    ctx.font = `700 ${size}px ${titleFontFamily}`;
+    return Math.max(...lines.map((l) => ctx.measureText(l).width));
+  };
+
+  const fitsRotated = (lines: string[], size: number): boolean => {
+    const longest = measureLongestLine(lines, size);
+    const stackWidth = lines.length * size * 1.05;
+    return longest <= titleMaxTextHeight && stackWidth <= titleMaxStackWidth;
+  };
+
+  const groupIntoLines = (count: number): string[] => {
+    if (count <= 1 || tokens.length <= count) return [showName];
+    const lines: string[] = [];
+    const perLine = Math.ceil(tokens.length / count);
+    for (let i = 0; i < tokens.length; i += perLine) {
+      lines.push(tokens.slice(i, i + perLine).join(' '));
+    }
+    return lines;
+  };
+
+  const lineOptions: string[][] = [[showName]];
+  if (tokens.length > 1) lineOptions.push(groupIntoLines(2));
+  if (tokens.length > 3) lineOptions.push(groupIntoLines(3));
+
+  let chosen: { lines: string[]; size: number } | null = null;
+  for (const option of lineOptions) {
+    let size = titleBaseSize;
+    while (size >= titleMinSize) {
+      if (fitsRotated(option, size)) {
+        if (!chosen || size > chosen.size) chosen = { lines: option, size };
+        break;
+      }
+      size -= 4;
+    }
+    if (chosen && chosen.size >= 100) break;
+  }
+
+  if (chosen) {
+    titleLines = chosen.lines;
+    titleFontSize = chosen.size;
+  } else {
+    titleLines = [showName];
+    titleFontSize = titleMinSize;
+  }
+
+  ctx.save();
+  ctx.translate(titleColCenterX, titleAreaBottom - 16);
+  ctx.rotate(-Math.PI / 2);
+  ctx.fillStyle = INK;
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'middle';
+  ctx.font = `700 ${titleFontSize}px ${titleFontFamily}`;
+  const lineSpacing = titleFontSize * 1.05;
+  const totalWidth = (titleLines.length - 1) * lineSpacing;
+  titleLines.forEach((line, i) => {
+    const offset = -totalWidth / 2 + i * lineSpacing;
+    ctx.fillText(line, 0, offset);
+  });
+  ctx.restore();
+
+  const now = new Date();
+  const monthNames = [
+    'JAN',
+    'FEB',
+    'MAR',
+    'APR',
+    'MAY',
+    'JUN',
+    'JUL',
+    'AUG',
+    'SEP',
+    'OCT',
+    'NOV',
+    'DEC',
+  ];
+  const dateStr = `${monthNames[now.getMonth()]} ${now.getDate()}, ${now.getFullYear()}`;
+  const liveStr = 'LIVE';
+
+  const dateMaxTextHeight = titleAreaHeight - 24;
+  const dateFontFamily = '"Fraunces", Georgia, serif';
+  let dateFontSize = 40;
+  ctx.font = `700 ${dateFontSize}px ${dateFontFamily}`;
+  while (ctx.measureText(dateStr).width > dateMaxTextHeight && dateFontSize > 20) {
+    dateFontSize -= 2;
+    ctx.font = `700 ${dateFontSize}px ${dateFontFamily}`;
+  }
+
+  const liveFontFamily = '"Bebas Neue", Impact, sans-serif';
+  const liveFontSize = 22;
+  ctx.font = `700 ${liveFontSize}px ${liveFontFamily}`;
+  const liveMeasuredWidth = ctx.measureText(liveStr).width;
+  ctx.font = `700 ${dateFontSize}px ${dateFontFamily}`;
+  const dateMeasuredWidth = ctx.measureText(dateStr).width;
+
+  const dateGap = 40;
+  const totalRotatedLen = liveMeasuredWidth + dateGap + dateMeasuredWidth;
+  const startOffset = -totalRotatedLen / 2;
+
+  ctx.save();
+  ctx.translate(dateColCenterX, titleAreaCenterY);
+  ctx.rotate(-Math.PI / 2);
+  ctx.fillStyle = INK;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+
+  ctx.font = `700 ${liveFontSize}px ${liveFontFamily}`;
+  ctx.fillText(liveStr, startOffset + liveMeasuredWidth / 2, 0);
+
+  ctx.font = `700 ${dateFontSize}px ${dateFontFamily}`;
+  ctx.fillText(dateStr, startOffset + liveMeasuredWidth + dateGap + dateMeasuredWidth / 2, 0);
+
+  ctx.restore();
+
+  drawPerfDots(ctx, H - 14, W);
+
+  punchCornerNotches(ctx, W, H, 22, { tl: true, tr: true });
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.anisotropy = 16;
+  return texture;
+}
+
+function wrapCodeIntoLines(
+  ctx: CanvasRenderingContext2D,
+  code: string,
+  maxWidth: number,
+  fontSize: number,
+  fontFamily: string,
+): string[] {
+  ctx.font = `700 ${fontSize}px ${fontFamily}`;
+  if (ctx.measureText(code).width <= maxWidth) return [code];
+
+  if (code.includes('-')) {
+    const parts = code.split('-').filter((p) => p.length > 0);
+    const lines: string[] = [];
+    let cur = '';
+    for (const part of parts) {
+      const trial = cur ? `${cur}-${part}` : part;
+      if (cur && ctx.measureText(trial).width > maxWidth) {
+        lines.push(cur);
+        cur = part;
+      } else {
+        cur = trial;
+      }
+    }
+    if (cur) lines.push(cur);
+    const anyOverflow = lines.some((l) => ctx.measureText(l).width > maxWidth);
+    if (!anyOverflow) return lines;
+  }
+
+  const charW = ctx.measureText('M').width;
+  const perLine = Math.max(1, Math.floor(maxWidth / charW));
+  const chunks: string[] = [];
+  for (let i = 0; i < code.length; i += perLine) chunks.push(code.slice(i, i + perLine));
+  return chunks;
+}
+
+function createBottomHalfTexture(code: string): THREE.CanvasTexture {
+  const W = 700;
+  const H = 440;
+  const canvas = document.createElement('canvas');
+  canvas.width = W;
+  canvas.height = H;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('canvas 2d context unavailable');
+
+  const bg = ctx.createLinearGradient(0, 0, 0, H);
+  bg.addColorStop(0, PAPER_DK);
+  bg.addColorStop(1, PAPER);
+  ctx.fillStyle = bg;
+  ctx.fillRect(0, 0, W, H);
+  drawPaperGrain(ctx, W, H);
+
+  drawPerfDots(ctx, 14, W);
+
+  const bandX = 82;
+  drawAdmitOneBand(ctx, H, bandX);
+
+  ctx.strokeStyle = INK;
+  ctx.lineWidth = 3;
+  ctx.strokeRect(bandX + 20, 28, W - bandX - 44, H - 48);
+
+  const contentLeft = bandX + 48;
+  const contentRight = W - 48;
+  const contentWidth = contentRight - contentLeft;
+  const contentCenter = (contentLeft + contentRight) / 2;
+
+  const displayCode = (code || 'XXXX').toUpperCase();
+  const codeMaxWidth = contentWidth - 20;
+  const codeFontFamily = '"IBM Plex Mono", "Courier New", monospace';
+
+  ctx.fillStyle = INK;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+  ctx.font = '700 14px "Bebas Neue", Impact, sans-serif';
+  ctx.fillText('SHOW CODE', contentCenter, 54);
+
+  let codeSize = 44;
+  const minCodeSize = 18;
+  const maxLines = 4;
+  let codeLines: string[] = [displayCode];
+  while (codeSize >= minCodeSize) {
+    codeLines = wrapCodeIntoLines(ctx, displayCode, codeMaxWidth, codeSize, codeFontFamily);
+    if (codeLines.length <= maxLines) break;
+    codeSize -= 4;
+  }
+  if (codeLines.length > maxLines) {
+    codeLines = codeLines.slice(0, maxLines);
+  }
+
+  ctx.font = `700 ${codeSize}px ${codeFontFamily}`;
+  ctx.fillStyle = INK;
+  const codeLineHeight = codeSize * 1.15;
+  const codeBlockHeight = codeLines.length * codeLineHeight;
+  const codeAreaTop = 82;
+  const codeAreaBottom = H - 140;
+  const codeTop = codeAreaTop + (codeAreaBottom - codeAreaTop - codeBlockHeight) / 2;
+  codeLines.forEach((line, i) => {
+    ctx.fillText(line, contentCenter, codeTop + i * codeLineHeight);
+  });
+
+  ctx.fillStyle = INK;
+  let bx = contentLeft + 20;
+  const barY = H - 120;
+  while (bx < contentRight - 20) {
+    const w = 2 + Math.random() * 4;
+    ctx.fillRect(bx, barY, w, 50);
+    bx += w + 2 + Math.random() * 3;
+  }
+
+  ctx.textAlign = 'center';
+  ctx.font = '700 13px "Bebas Neue", Impact, sans-serif';
+  ctx.fillStyle = INK;
+  ctx.fillText('KEEP THIS STUB', contentCenter, H - 50);
+
+  punchCornerNotches(ctx, W, H, 22, { bl: true, br: true });
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.anisotropy = 16;
+  return texture;
+}
+
+interface SoundKit {
+  rip: Tone.NoiseSynth;
+  thud: Tone.MembraneSynth;
+  whoosh: Tone.NoiseSynth;
+  chime: Tone.PolySynth;
+}
+
+function createSounds(): SoundKit {
+  const ripHP = new Tone.Filter(1600, 'highpass').toDestination();
+  const ripComp = new Tone.Compressor(-18, 4).connect(ripHP);
+  const rip = new Tone.NoiseSynth({
+    noise: { type: 'white' },
+    envelope: { attack: 0.002, decay: 0.22, sustain: 0, release: 0.06 },
+  }).connect(ripComp);
+  rip.volume.value = -6;
+
+  const thud = new Tone.MembraneSynth({
+    pitchDecay: 0.08,
+    octaves: 6,
+    envelope: { attack: 0.001, decay: 0.35, sustain: 0 },
+  }).toDestination();
+  thud.volume.value = -10;
+
+  const whooshLP = new Tone.Filter(900, 'lowpass').toDestination();
+  const whoosh = new Tone.NoiseSynth({
+    noise: { type: 'pink' },
+    envelope: { attack: 0.09, decay: 0.28, sustain: 0, release: 0.05 },
+  }).connect(whooshLP);
+  whoosh.volume.value = -16;
+
+  const chimeRev = new Tone.Reverb({ decay: 1.2, wet: 0.25 }).toDestination();
+  const chime = new Tone.PolySynth(Tone.Synth, {
+    oscillator: { type: 'triangle' },
+    envelope: { attack: 0.01, decay: 0.3, sustain: 0.1, release: 0.6 },
+  }).connect(chimeRev);
+  chime.volume.value = -10;
+
+  return { rip, thud, whoosh, chime };
+}
+
+const easeOutBack = (t: number) => {
+  const c1 = 1.70158;
+  const c3 = c1 + 1;
+  return 1 + c3 * Math.pow(t - 1, 3) + c1 * Math.pow(t - 1, 2);
+};
+const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3);
+const easeInCubic = (t: number) => t * t * t;
+const easeOutQuart = (t: number) => 1 - Math.pow(1 - t, 4);
+const clamp01 = (v: number) => Math.max(0, Math.min(1, v));
+
+type Phase = 'idle' | 'entering' | 'hovering' | 'shaking' | 'tearing' | 'falling' | 'success';
+
+interface Particle {
+  mesh: THREE.Mesh<THREE.PlaneGeometry, THREE.MeshBasicMaterial>;
+  active: boolean;
+  vx: number;
+  vy: number;
+  vz: number;
+  vrx: number;
+  vry: number;
+  vrz: number;
+  life: number;
+  maxLife: number;
+}
+
+interface ThreeRefs {
+  scene: THREE.Scene;
+  camera: THREE.PerspectiveCamera;
+  renderer: THREE.WebGLRenderer;
+  topHalf: THREE.Mesh<THREE.PlaneGeometry, THREE.MeshStandardMaterial>;
+  botHalf: THREE.Mesh<THREE.PlaneGeometry, THREE.MeshStandardMaterial>;
+  ticketGroup: THREE.Group;
+  shadow: THREE.Mesh<THREE.PlaneGeometry, THREE.MeshBasicMaterial>;
+  glow: THREE.Mesh<THREE.PlaneGeometry, THREE.MeshBasicMaterial>;
+  particles: Particle[];
+}
+
+interface TicketRipProps {
+  code: string;
+  experienceName?: string;
+  onComplete: () => void;
+}
+
+const SUCCESS_HOLD_DURATION = 7.1;
+
+export default function TicketRip({ code, experienceName = '', onComplete }: TicketRipProps) {
+  const mountRef = useRef<HTMLDivElement | null>(null);
+  const threeRef = useRef<ThreeRefs | null>(null);
+  const soundRef = useRef<{ kit: SoundKit | null; ready: boolean }>({ kit: null, ready: false });
+  const animRef = useRef<{ phase: Phase; time: number }>({ phase: 'idle', time: 0 });
+  const onCompleteFiredRef = useRef(false);
+  const onCompleteRef = useRef(onComplete);
+  const [fontsReady, setFontsReady] = useState(false);
+  const [caption, setCaption] = useState<'hidden' | 'tap-rip' | 'validating' | 'tap-continue'>(
+    'hidden',
+  );
+
+  useEffect(() => {
+    onCompleteRef.current = onComplete;
+  }, [onComplete]);
+
+  useEffect(() => {
+    let cancelled = false;
+    ensureFontsLoaded().then(() => {
+      if (!cancelled) setFontsReady(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const fireComplete = useCallback(() => {
+    if (onCompleteFiredRef.current) return;
+    onCompleteFiredRef.current = true;
+    onCompleteRef.current();
+  }, []);
+
+  const handlePointerDown = useCallback(
+    (e: PointerEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      const phase = animRef.current.phase;
+      if (phase === 'hovering') {
+        animRef.current.phase = 'shaking';
+        animRef.current.time = 0;
+        setCaption('validating');
+        return;
+      }
+      if (phase === 'success') {
+        fireComplete();
+      }
+    },
+    [fireComplete],
+  );
+
+  useEffect(() => {
+    if (!fontsReady) return;
+    const mount = mountRef.current;
+    if (!mount) return;
+
+    const initAudio = async () => {
+      try {
+        await Tone.start();
+        soundRef.current = { kit: createSounds(), ready: true };
+      } catch {
+        soundRef.current = { kit: null, ready: false };
+      }
+    };
+    initAudio();
+
+    const w = mount.clientWidth;
+    const h = mount.clientHeight;
+
+    const scene = new THREE.Scene();
+
+    const camera = new THREE.PerspectiveCamera(38, w / h, 0.1, 100);
+    const isPortrait = h >= w;
+    const baseCameraZ = isPortrait ? 11.5 : 13;
+    camera.position.set(0, 0.1, baseCameraZ);
+    camera.lookAt(0, 0, 0);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setSize(w, h);
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setClearColor(0x000000, 0);
+    mount.appendChild(renderer.domElement);
+
+    scene.add(new THREE.AmbientLight(0xffffff, 0.72));
+    const key = new THREE.DirectionalLight(0xf0ede4, 0.7);
+    key.position.set(4, 5, 6);
+    scene.add(key);
+    const rim = new THREE.DirectionalLight(0xc8f060, 0.32);
+    rim.position.set(-5, 2, -3);
+    scene.add(rim);
+    const fill = new THREE.DirectionalLight(0xf5a623, 0.15);
+    fill.position.set(0, -3, 4);
+    scene.add(fill);
+
+    const TW = 2.4;
+    const TOP_H = 3.84;
+    const BOT_H = 1.5;
+
+    const topTex = createTopHalfTexture(experienceName);
+    const botTex = createBottomHalfTexture(code);
+
+    const topGeom = new THREE.PlaneGeometry(TW, TOP_H, 10, 20);
+    const topMat = new THREE.MeshStandardMaterial({
+      map: topTex,
+      side: THREE.DoubleSide,
+      roughness: 0.82,
+      metalness: 0.02,
+      transparent: true,
+      alphaTest: 0.01,
+    });
+    const topHalf = new THREE.Mesh(topGeom, topMat);
+    topHalf.position.y = TOP_H / 2;
+
+    const botGeom = new THREE.PlaneGeometry(TW, BOT_H, 10, 8);
+    const botMat = new THREE.MeshStandardMaterial({
+      map: botTex,
+      side: THREE.DoubleSide,
+      roughness: 0.82,
+      metalness: 0.02,
+      transparent: true,
+      alphaTest: 0.01,
+    });
+    const botHalf = new THREE.Mesh(botGeom, botMat);
+    botHalf.position.y = -BOT_H / 2;
+
+    const shadowCanvas = document.createElement('canvas');
+    shadowCanvas.width = 256;
+    shadowCanvas.height = 256;
+    const shadowCtx = shadowCanvas.getContext('2d');
+    if (shadowCtx) {
+      const grad = shadowCtx.createRadialGradient(128, 128, 10, 128, 128, 128);
+      grad.addColorStop(0, 'rgba(0,0,0,0.55)');
+      grad.addColorStop(1, 'rgba(0,0,0,0)');
+      shadowCtx.fillStyle = grad;
+      shadowCtx.fillRect(0, 0, 256, 256);
+    }
+    const shadowTex = new THREE.CanvasTexture(shadowCanvas);
+    const shadow = new THREE.Mesh(
+      new THREE.PlaneGeometry(TW * 1.6, TW * 1.6),
+      new THREE.MeshBasicMaterial({ map: shadowTex, transparent: true, depthWrite: false }),
+    );
+    shadow.position.set(0, -(TOP_H + BOT_H) / 2 - 0.3, -0.1);
+
+    const ticketGroup = new THREE.Group();
+    ticketGroup.add(topHalf);
+    ticketGroup.add(botHalf);
+    const DOWN_SHIFT = 0.7;
+    const vOffset = -(TOP_H - BOT_H) / 4 - DOWN_SHIFT;
+    ticketGroup.position.y = vOffset;
+    ticketGroup.visible = false;
+    scene.add(shadow);
+    shadow.visible = false;
+    scene.add(ticketGroup);
+
+    const MAX_P = 90;
+    const pGeom = new THREE.PlaneGeometry(0.09, 0.09);
+    const particles: Particle[] = [];
+    for (let i = 0; i < MAX_P; i++) {
+      const mat = new THREE.MeshBasicMaterial({
+        color: i % 3 === 0 ? 0xc8f060 : 0xf0ede4,
+        side: THREE.DoubleSide,
+        transparent: true,
+        opacity: 0,
+      });
+      const mesh = new THREE.Mesh(pGeom, mat);
+      mesh.visible = false;
+      scene.add(mesh);
+      particles.push({
+        mesh,
+        active: false,
+        vx: 0,
+        vy: 0,
+        vz: 0,
+        vrx: 0,
+        vry: 0,
+        vrz: 0,
+        life: 0,
+        maxLife: 1,
+      });
+    }
+
+    const glowCanvas = document.createElement('canvas');
+    glowCanvas.width = 256;
+    glowCanvas.height = 256;
+    const glowCtx = glowCanvas.getContext('2d');
+    if (glowCtx) {
+      const grad = glowCtx.createRadialGradient(128, 128, 20, 128, 128, 128);
+      grad.addColorStop(0, 'rgba(200, 240, 96, 0.85)');
+      grad.addColorStop(0.5, 'rgba(200, 240, 96, 0.35)');
+      grad.addColorStop(1, 'rgba(200, 240, 96, 0)');
+      glowCtx.fillStyle = grad;
+      glowCtx.fillRect(0, 0, 256, 256);
+    }
+    const glowTex = new THREE.CanvasTexture(glowCanvas);
+    const glow = new THREE.Mesh(
+      new THREE.PlaneGeometry(5, 7),
+      new THREE.MeshBasicMaterial({
+        map: glowTex,
+        transparent: true,
+        opacity: 0,
+        depthWrite: false,
+        blending: THREE.AdditiveBlending,
+      }),
+    );
+    glow.position.set(0, vOffset, -0.15);
+    scene.add(glow);
+
+    threeRef.current = {
+      scene,
+      camera,
+      renderer,
+      topHalf,
+      botHalf,
+      ticketGroup,
+      shadow,
+      glow,
+      particles,
+    };
+
+    animRef.current = { phase: 'entering', time: 0 };
+
+    if (soundRef.current.ready && soundRef.current.kit) {
+      soundRef.current.kit.whoosh.triggerAttackRelease(0.3);
+    } else {
+      setTimeout(() => {
+        if (soundRef.current.ready && soundRef.current.kit) {
+          soundRef.current.kit.whoosh.triggerAttackRelease(0.3);
+        }
+      }, 100);
+    }
+
+    const clock = new THREE.Clock();
+    let frameId = 0;
+
+    const spawnParticles = () => {
+      const groupWorldY = ticketGroup.position.y;
+      particles.forEach((p) => {
+        p.active = true;
+        p.mesh.visible = true;
+        const spread = TW * 0.9;
+        p.mesh.position.x = (Math.random() - 0.5) * spread;
+        p.mesh.position.y = groupWorldY + (Math.random() - 0.5) * 0.1;
+        p.mesh.position.z = 0.05 + Math.random() * 0.25;
+        p.vx = (Math.random() - 0.5) * 2.0;
+        p.vy = 0.6 + Math.random() * 2.2;
+        p.vz = (Math.random() - 0.5) * 1.6;
+        p.vrx = (Math.random() - 0.5) * 14;
+        p.vry = (Math.random() - 0.5) * 14;
+        p.vrz = (Math.random() - 0.5) * 14;
+        p.life = 0;
+        p.maxLife = 0.7 + Math.random() * 0.8;
+        p.mesh.material.opacity = 1;
+        p.mesh.scale.setScalar(0.6 + Math.random() * 0.8);
+      });
+    };
+
+    const updateParticles = (dt: number) => {
+      particles.forEach((p) => {
+        if (!p.active) return;
+        p.life += dt;
+        if (p.life >= p.maxLife) {
+          p.active = false;
+          p.mesh.visible = false;
+          return;
+        }
+        p.vy -= 9 * dt;
+        p.vx *= 0.985;
+        p.vz *= 0.985;
+        p.mesh.position.x += p.vx * dt;
+        p.mesh.position.y += p.vy * dt;
+        p.mesh.position.z += p.vz * dt;
+        p.mesh.rotation.x += p.vrx * dt;
+        p.mesh.rotation.y += p.vry * dt;
+        p.mesh.rotation.z += p.vrz * dt;
+        const f = p.life / p.maxLife;
+        p.mesh.material.opacity = 1 - f * f;
+      });
+    };
+
+    const runFrame = (dt: number) => {
+      const baseTopY = TOP_H / 2;
+      const baseBotY = -BOT_H / 2;
+
+      updateParticles(dt);
+
+      const ph = animRef.current.phase;
+      const tt = animRef.current.time;
+
+      if (ph === 'idle') {
+        ticketGroup.visible = false;
+        shadow.visible = false;
+        glow.material.opacity = 0;
+        return;
+      }
+
+      ticketGroup.visible = true;
+      shadow.visible = true;
+      botHalf.material.opacity = 1;
+
+      if (ph === 'entering') {
+        const dur = 0.7;
+        const t = clamp01(tt / dur);
+        const e = easeOutBack(t);
+        ticketGroup.position.x = 0;
+        ticketGroup.position.y = vOffset + (1 - e) * -7;
+        ticketGroup.rotation.x = (1 - e) * 0.55;
+        ticketGroup.rotation.z = (1 - e) * -0.35;
+        ticketGroup.rotation.y = (1 - e) * 0.2;
+        ticketGroup.scale.setScalar(0.55 + 0.45 * e);
+        topHalf.position.set(0, baseTopY, 0);
+        botHalf.position.set(0, baseBotY, 0);
+        topHalf.rotation.set(0, 0, 0);
+        botHalf.rotation.set(0, 0, 0);
+        shadow.material.opacity = e * 0.45;
+        shadow.scale.setScalar(0.7 + 0.3 * e);
+        if (t >= 1) {
+          animRef.current.phase = 'hovering';
+          animRef.current.time = 0;
+          setCaption('tap-rip');
+        }
+      } else if (ph === 'hovering') {
+        ticketGroup.position.x = 0;
+        ticketGroup.position.y = vOffset + Math.sin(tt * 3.2) * 0.05;
+        ticketGroup.rotation.x = Math.sin(tt * 2) * 0.04 - 0.03;
+        ticketGroup.rotation.y = Math.sin(tt * 1.6 + 0.8) * 0.08;
+        ticketGroup.rotation.z = Math.sin(tt * 2.2) * 0.02;
+        ticketGroup.scale.setScalar(1);
+        shadow.material.opacity = 0.45 + Math.sin(tt * 3.2) * 0.05;
+      } else if (ph === 'shaking') {
+        const dur = 0.32;
+        const t = clamp01(tt / dur);
+        const intensity = easeInCubic(t) * 0.07;
+        ticketGroup.position.x = (Math.random() - 0.5) * intensity;
+        ticketGroup.position.y = vOffset + (Math.random() - 0.5) * intensity;
+        ticketGroup.rotation.z = (Math.random() - 0.5) * intensity * 2.5;
+        ticketGroup.rotation.y = Math.sin(tt * 1.6) * 0.06;
+        ticketGroup.rotation.x = -0.03;
+        ticketGroup.scale.setScalar(1 + easeInCubic(t) * 0.03);
+        shadow.material.opacity = 0.45;
+        if (t >= 1) {
+          animRef.current.phase = 'tearing';
+          animRef.current.time = 0;
+          if (soundRef.current.ready && soundRef.current.kit) {
+            soundRef.current.kit.rip.triggerAttackRelease(0.22);
+            soundRef.current.kit.thud.triggerAttackRelease('C2', 0.3);
+          }
+          spawnParticles();
+        }
+      } else if (ph === 'tearing') {
+        const dur = 0.24;
+        const t = clamp01(tt / dur);
+        const e = easeOutQuart(t);
+        topHalf.position.y = baseTopY + e * 0.18;
+        topHalf.rotation.z = Math.sin(tt * 40) * 0.02 * (1 - e);
+        topHalf.rotation.x = -e * 0.05;
+        botHalf.position.y = baseBotY - e * 0.22;
+        botHalf.rotation.z = -e * 0.09;
+        botHalf.rotation.x = e * 0.08;
+        ticketGroup.position.x = (1 - e) * 0.09 * Math.sin(tt * 70);
+        ticketGroup.position.y = vOffset + (1 - e) * 0.06 * Math.sin(tt * 55);
+        ticketGroup.rotation.y = Math.sin(tt * 1.6) * 0.06;
+        ticketGroup.rotation.x = -0.03;
+        ticketGroup.scale.setScalar(1 + (1 - e) * 0.025);
+        shadow.material.opacity = 0.5;
+        camera.position.z = baseCameraZ - e * 0.25;
+        if (t >= 1) {
+          animRef.current.phase = 'falling';
+          animRef.current.time = 0;
+        }
+      } else if (ph === 'falling') {
+        const dur = 1.2;
+        const t = clamp01(tt / dur);
+        const settle = easeOutCubic(clamp01(t * 2.5));
+        topHalf.position.y = baseTopY + 0.18 - settle * 0.18;
+        topHalf.rotation.z = 0;
+        topHalf.rotation.x = -0.05 + settle * 0.05;
+        const pulse = 0.5 + 0.5 * Math.sin(tt * 6);
+        topHalf.material.emissive = new THREE.Color(0xc8f060);
+        topHalf.material.emissiveIntensity = settle * 0.12 * (0.6 + pulse * 0.4);
+        glow.material.opacity = easeOutCubic(t) * 0.55 * (0.65 + pulse * 0.35);
+        glow.scale.setScalar(0.85 + easeOutCubic(t) * 0.2);
+        const g = 11;
+        const fy = -0.22 - 0.5 * g * tt * tt;
+        const fx = Math.sin(tt * 2.2) * 0.35 + tt * 0.1;
+        botHalf.position.y = baseBotY + fy;
+        botHalf.position.x = fx;
+        botHalf.position.z = Math.sin(tt * 3) * 0.25;
+        botHalf.rotation.z = -0.09 - tt * 2.4;
+        botHalf.rotation.x = tt * 1.9;
+        botHalf.rotation.y = tt * 1.2;
+        botHalf.material.opacity = clamp01(1 - Math.max(0, t - 0.55) * 2.5);
+        ticketGroup.position.x = 0;
+        ticketGroup.position.y = vOffset + Math.sin(tt * 2) * 0.025;
+        ticketGroup.rotation.x = -0.03;
+        ticketGroup.rotation.y = Math.sin(tt * 1.5) * 0.06;
+        ticketGroup.rotation.z = 0;
+        ticketGroup.scale.setScalar(1);
+        shadow.material.opacity = 0.45;
+        camera.position.z = baseCameraZ - 0.25;
+        if (t >= 1) {
+          animRef.current.phase = 'success';
+          animRef.current.time = 0;
+          botHalf.visible = false;
+          setCaption('tap-continue');
+          if (soundRef.current.ready && soundRef.current.kit) {
+            const now = Tone.now();
+            soundRef.current.kit.chime.triggerAttackRelease('E5', '8n', now);
+            soundRef.current.kit.chime.triggerAttackRelease('G5', '8n', now + 0.09);
+            soundRef.current.kit.chime.triggerAttackRelease('C6', '4n', now + 0.19);
+          }
+        }
+      } else if (ph === 'success') {
+        ticketGroup.position.y = vOffset + 0.35 + Math.sin(tt * 2) * 0.05;
+        ticketGroup.rotation.y = Math.sin(tt * 1.2) * 0.1;
+        ticketGroup.rotation.x = -0.03 + Math.sin(tt * 1.8) * 0.02;
+        ticketGroup.rotation.z = Math.sin(tt * 0.8) * 0.02;
+        const pulse = 0.5 + 0.5 * Math.sin(tt * 3);
+        topHalf.material.emissive = new THREE.Color(0xc8f060);
+        topHalf.material.emissiveIntensity = 0.08 + pulse * 0.06;
+        glow.material.opacity = 0.35 + pulse * 0.15;
+        shadow.material.opacity = 0.35;
+        camera.position.z = baseCameraZ - 0.25;
+        if (!onCompleteFiredRef.current && tt >= SUCCESS_HOLD_DURATION) {
+          fireComplete();
+        }
+      }
+    };
+
+    const tick = () => {
+      const dt = Math.min(clock.getDelta(), 1 / 30);
+      animRef.current.time += dt;
+      runFrame(dt);
+      renderer.render(scene, camera);
+      frameId = requestAnimationFrame(tick);
+    };
+    tick();
+
+    const onResize = () => {
+      const nw = mount.clientWidth;
+      const nh = mount.clientHeight;
+      camera.aspect = nw / nh;
+      camera.updateProjectionMatrix();
+      renderer.setSize(nw, nh);
+    };
+    window.addEventListener('resize', onResize);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      window.removeEventListener('resize', onResize);
+      if (mount.contains(renderer.domElement)) mount.removeChild(renderer.domElement);
+      renderer.dispose();
+      topGeom.dispose();
+      botGeom.dispose();
+      topMat.dispose();
+      botMat.dispose();
+      pGeom.dispose();
+      shadowTex.dispose();
+      glowTex.dispose();
+      topTex.dispose();
+      botTex.dispose();
+      shadow.geometry.dispose();
+      shadow.material.dispose();
+      glow.geometry.dispose();
+      glow.material.dispose();
+      particles.forEach((p) => p.mesh.material.dispose());
+      if (soundRef.current.kit) {
+        const kit = soundRef.current.kit;
+        kit.rip.dispose();
+        kit.thud.dispose();
+        kit.whoosh.dispose();
+        kit.chime.dispose();
+        soundRef.current = { kit: null, ready: false };
+      }
+    };
+  }, [fontsReady, code, experienceName, fireComplete]);
+
+  const captionText =
+    caption === 'tap-rip'
+      ? 'TAP TO TEAR'
+      : caption === 'validating'
+        ? 'VALIDATING TICKET…'
+        : caption === 'tap-continue'
+          ? 'TAP TO CONTINUE'
+          : '';
+  const captionActive = caption === 'tap-rip' || caption === 'tap-continue';
+
+  return (
+    <div
+      className={styles.root}
+      onPointerDown={handlePointerDown}
+      role="button"
+      tabIndex={0}
+      aria-label={caption === 'tap-rip' ? 'Tap to tear ticket' : 'Tap to continue'}
+    >
+      <div className={styles.grain} />
+      <div className={styles.vignette} />
+      <div ref={mountRef} className={styles.canvas} />
+      {caption !== 'hidden' && (
+        <div className={`${styles.caption} ${captionActive ? styles.captionReady : ''}`}>
+          {captionText}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/frontend/Pages/join.tsx
+++ b/app/frontend/Pages/join.tsx
@@ -72,9 +72,12 @@ export default function Join() {
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const result = await joinExperience(actualCode);
-    if (result) {
-      setJoined({ url: result.url, experienceName: result.experienceName });
+    if (!result) return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      window.location.href = result.url;
+      return;
     }
+    setJoined({ url: result.url, experienceName: result.experienceName });
   };
 
   const handleCodeChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/app/frontend/Pages/join.tsx
+++ b/app/frontend/Pages/join.tsx
@@ -1,4 +1,13 @@
-import { ChangeEvent, FormEvent, useCallback, useEffect, useRef, useState } from 'react';
+import {
+  ChangeEvent,
+  FormEvent,
+  Suspense,
+  lazy,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import { useSearchParams } from 'react-router-dom';
 
@@ -10,6 +19,8 @@ import { useGet } from '@cctv/hooks/useGet';
 import { useJoinExperience } from '@cctv/hooks/useJoinExperience';
 
 import styles from './Join.module.scss';
+
+const TicketRip = lazy(() => import('./TicketRip'));
 
 const SESSION_KEY = 'cctv_last_join_code';
 
@@ -45,6 +56,7 @@ export default function Join() {
   const [code, setCode] = useState(slugFromUrl || savedCode);
   const [scanning, setScanning] = useState(false);
   const [cameraSupported, setCameraSupported] = useState(true);
+  const [joined, setJoined] = useState<{ url: string; experienceName: string } | null>(null);
   const scannerRef = useRef<Html5Qrcode | null>(null);
   const readerRef = useRef<HTMLDivElement>(null);
 
@@ -59,7 +71,10 @@ export default function Join() {
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    await joinExperience(actualCode);
+    const result = await joinExperience(actualCode);
+    if (result) {
+      setJoined({ url: result.url, experienceName: result.experienceName });
+    }
   };
 
   const handleCodeChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -130,6 +145,24 @@ export default function Join() {
       }
     };
   }, []);
+
+  const handleAnimationComplete = useCallback(() => {
+    if (joined) {
+      window.location.href = joined.url;
+    }
+  }, [joined]);
+
+  if (joined) {
+    return (
+      <Suspense fallback={null}>
+        <TicketRip
+          code={actualCode}
+          experienceName={joined.experienceName || registrationInfo?.experience?.name}
+          onComplete={handleAnimationComplete}
+        />
+      </Suspense>
+    );
+  }
 
   return (
     <section className="page flex-centered">

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -479,6 +479,8 @@ export interface JoinExperienceRegisteredResponse {
   type: 'success';
   url: string;
   status: 'registered';
+  experience_name: string;
+  experience_code_slug: string;
 }
 
 export interface JoinExperienceNeedsRegistrationResponse {
@@ -486,6 +488,8 @@ export interface JoinExperienceNeedsRegistrationResponse {
   experience_code: string;
   status: 'needs_registration';
   url: string;
+  experience_name: string;
+  experience_code_slug: string;
 }
 
 export interface JoinExperienceErrorResponse {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "shadcn": "^3.5.0",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.17",
+    "three": "^0.184.0",
+    "tone": "^15.1.22",
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
@@ -67,6 +69,7 @@
     "@types/node": "^24.3.3",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
+    "@types/three": "^0.184.0",
     "@vitejs/plugin-react": "^4.0.2",
     "concurrently": "^9.2.1",
     "husky": "^9.1.7",

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,7 +65,11 @@ Capybara.enable_aria_label = true
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do
-    driven_by :cuprite, screen_size: [1440, 900], options: { headless: ENV["HEADLESS"] != "false", process_timeout: 20 }
+    driven_by :cuprite, screen_size: [1440, 900], options: {
+      headless: ENV["HEADLESS"] != "false",
+      process_timeout: 20,
+      browser_options: { "force-prefers-reduced-motion" => nil }
+    }
   end
 
   config.around(:each, type: :system) do |example|

--- a/yarn.lock
+++ b/yarn.lock
@@ -305,6 +305,11 @@
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.6.tgz#d267a43cb1836dc4d182cce93ae75ba954ef6d2b"
   integrity sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==
 
+"@babel/runtime@^7.25.6", "@babel/runtime@^7.29.2":
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
+  integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
+
 "@babel/runtime@^7.26.7":
   version "7.28.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.4.tgz#a70226016fabe25c5783b2f22d3e1c9bc5ca3326"
@@ -409,6 +414,11 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz#798a33950d11226a0ebb6acafa60f5594424967f"
   integrity sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==
+
+"@dimforge/rapier3d-compat@~0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz#7b3365e1dfdc5cd957b45afe920b4ac06c7cd389"
+  integrity sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==
 
 "@dotenvx/dotenvx@^1.48.4":
   version "1.51.1"
@@ -1925,6 +1935,11 @@
     minimatch "^10.0.1"
     path-browserify "^1.0.1"
 
+"@tweenjs/tween.js@~23.1.3":
+  version "23.1.3"
+  resolved "https://registry.yarnpkg.com/@tweenjs/tween.js/-/tween.js-23.1.3.tgz#eff0245735c04a928bb19c026b58c2a56460539d"
+  integrity sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==
+
 "@tybys/wasm-util@^0.10.1":
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz#ecddd3205cf1e2d5274649ff0eedd2991ed7f414"
@@ -2037,15 +2052,37 @@
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.20.6.tgz#e6e60dad29c2c8c206c026e6dd8d6d1bdda850b8"
   integrity sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==
 
+"@types/stats.js@*":
+  version "0.17.4"
+  resolved "https://registry.yarnpkg.com/@types/stats.js/-/stats.js-0.17.4.tgz#1933e5ff153a23c7664487833198d685c22e791e"
+  integrity sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==
+
 "@types/statuses@^2.0.4", "@types/statuses@^2.0.6":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/statuses/-/statuses-2.0.6.tgz#66748315cc9a96d63403baa8671b2c124f8633aa"
   integrity sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==
 
+"@types/three@^0.184.0":
+  version "0.184.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.184.0.tgz#f6a3ea283bebb65e5de6ff4dbf18ef57bdcf5bcc"
+  integrity sha512-4mY2tZAu0y0B0567w7013BBXSpsP0+Z48NJvmNo4Y/Pf76yCyz6Jw4P3tUVs10WuYNXXZ+wmHyGWpCek3amJxA==
+  dependencies:
+    "@dimforge/rapier3d-compat" "~0.12.0"
+    "@tweenjs/tween.js" "~23.1.3"
+    "@types/stats.js" "*"
+    "@types/webxr" ">=0.5.17"
+    fflate "~0.8.2"
+    meshoptimizer "~1.1.1"
+
 "@types/use-sync-external-store@^0.0.6":
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz#60be8d21baab8c305132eb9cb912ed497852aadc"
   integrity sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==
+
+"@types/webxr@>=0.5.17":
+  version "0.5.24"
+  resolved "https://registry.yarnpkg.com/@types/webxr/-/webxr-0.5.24.tgz#734d5d90dadc5809a53e422726c60337fa2f4a44"
+  integrity sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==
 
 "@vitejs/plugin-react@^4.0.2":
   version "4.7.0"
@@ -2310,6 +2347,14 @@ ast-types@^0.16.1:
   integrity sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==
   dependencies:
     tslib "^2.0.1"
+
+automation-events@^7.0.9:
+  version "7.1.19"
+  resolved "https://registry.yarnpkg.com/automation-events/-/automation-events-7.1.19.tgz#9323849f1f8d0e6019b4658dc7a1592346197b08"
+  integrity sha512-cD+TLhJTI0q4AI3ktd353lrGZiVa9AchowSDzQzzGjSoYe22js4vlS32VUtWuaulghi1Yq0KYNWKk9wWuGymPA==
+  dependencies:
+    "@babel/runtime" "^7.29.2"
+    tslib "^2.8.1"
 
 axe-core@^4.2.0:
   version "4.11.1"
@@ -3093,6 +3138,11 @@ fetch-blob@^3.1.2, fetch-blob@^3.1.4:
     node-domexception "^1.0.0"
     web-streams-polyfill "^3.0.3"
 
+fflate@~0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.8.2.tgz#fc8631f5347812ad6028bbe4a2308b2792aa1dea"
+  integrity sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==
+
 figures@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-6.1.0.tgz#935479f51865fa7479f6fa94fc6fc7ac14e62c4a"
@@ -3823,6 +3873,11 @@ merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+meshoptimizer@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/meshoptimizer/-/meshoptimizer-1.1.1.tgz#20c7d050d59bdc573154814f6a37d47d89908cca"
+  integrity sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==
 
 micromatch@^4.0.5, micromatch@^4.0.8:
   version "4.0.8"
@@ -4766,6 +4821,15 @@ stackback@0.0.2:
   resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
   integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
 
+standardized-audio-context@^25.3.70:
+  version "25.3.77"
+  resolved "https://registry.yarnpkg.com/standardized-audio-context/-/standardized-audio-context-25.3.77.tgz#9502c40f3860f0877ce5c53a161f819f23c978f4"
+  integrity sha512-Ki9zNz6pKcC5Pi+QPjPyVsD9GwJIJWgryji0XL9cAJXMGyn+dPOf6Qik1AHei0+UNVcc4BOCa0hWLBzlwqsW/A==
+  dependencies:
+    "@babel/runtime" "^7.25.6"
+    automation-events "^7.0.9"
+    tslib "^2.7.0"
+
 statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
@@ -4939,6 +5003,11 @@ tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.3.0.tgz#7e3ea6d5ca31ba8e078b560f0d83ce9a14aa8be6"
   integrity sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==
 
+three@^0.184.0:
+  version "0.184.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.184.0.tgz#5bca0a3851eea5345e4c205567b40dfa49b791b5"
+  integrity sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==
+
 tiny-invariant@^1.0.6, tiny-invariant@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
@@ -5011,6 +5080,14 @@ toidentifier@1.0.1, toidentifier@~1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
+tone@^15.1.22:
+  version "15.1.22"
+  resolved "https://registry.yarnpkg.com/tone/-/tone-15.1.22.tgz#77581c7e8347a969872ca4f90f3532cd1e307dc8"
+  integrity sha512-TCScAGD4sLsama5DjvTUXlLDXSqPealhL64nsdV1hhr6frPWve0DeSo63AKnSJwgfg55fhvxj0iPPRwPN5o0ag==
+  dependencies:
+    standardized-audio-context "^25.3.70"
+    tslib "^2.3.1"
+
 tough-cookie@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-6.0.0.tgz#11e418b7864a2c0d874702bc8ce0f011261940e5"
@@ -5052,7 +5129,7 @@ tsconfig-paths@^4.2.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.4.0:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.7.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
## Summary
- Plays a full-screen three.js animation of a vertical ADMIT ONE ticket when a user submits a code on `/join`. The user taps to tear the stub off, then gets redirected to the lobby/registration page.
- Uses the site's CRT palette — phosphor green ADMIT ONE band, cream paper, ink text — on a phosphor-bloom dark overlay. tone.js provides the whoosh/rip/thud/chime sound design.
- Three + tone are lazy-loaded so the ticket chunk (~758 KB) stays out of the main bundle; it only loads after the user hits submit.
- Backend `POST /api/experiences/join` now returns `experience_name` + `experience_code_slug` so the ticket renders the real show title without a second round-trip.

## Test plan
- [x] Visit `/join`, enter a valid code, submit: ticket should animate in, hold in a gentle hover until tapped, rip cleanly on tap, then redirect after the stub falls.
- [x] Try a short show name (e.g. "Test") — title should anchor at the bottom-left of its column with empty space above.
- [x] Try a long hyphenated code (e.g. `experience-show-name-the-musical`) — code should wrap onto up to 4 lines on the stub instead of overflowing.
- [x] Tap anywhere during the success state (floating retained half) — should redirect immediately; otherwise redirects automatically around 10s.
- [x] Verify on mobile portrait, mobile landscape, and desktop.
- [x] Audio: first tap/submit should also start the Tone.js context (required by browser gesture policy). Confirm the rip/chime sounds play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)