### PR TITLE
Audit pass: a11y, theming, anti-pattern fixes across pages

### DIFF
--- a/app/frontend/Components/Avatar/LobbyAvatarEditor.module.scss
+++ b/app/frontend/Components/Avatar/LobbyAvatarEditor.module.scss
@@ -72,21 +72,6 @@
   border-color: hsl(var(--foreground));
 }
 
-/* Explicit theme overrides for maximum clarity */
-:root[data-theme='light'] .modeActive,
-:root[data-theme='light'] .sizeActive {
-  background: #000;
-  color: #fff;
-  border-color: #000;
-}
-
-:root[data-theme='dark'] .modeActive,
-:root[data-theme='dark'] .sizeActive {
-  background: #fff;
-  color: #000;
-  border-color: #fff;
-}
-
 .palette {
   display: inline-flex;
   gap: var(--space-xs);

--- a/app/frontend/Components/DrawingCanvas/DrawingCanvas.module.scss
+++ b/app/frontend/Components/DrawingCanvas/DrawingCanvas.module.scss
@@ -59,18 +59,6 @@
   border-color: hsl(var(--foreground));
 }
 
-:root[data-theme='light'] .modeActive {
-  background: #000;
-  color: #fff;
-  border-color: #000;
-}
-
-:root[data-theme='dark'] .modeActive {
-  background: #fff;
-  color: #000;
-  border-color: #fff;
-}
-
 .toolbar {
   display: flex;
   flex-wrap: wrap;
@@ -102,18 +90,6 @@
   background: hsl(var(--foreground));
   color: hsl(var(--background));
   border-color: hsl(var(--foreground));
-}
-
-:root[data-theme='light'] .sizeActive {
-  background: #000;
-  color: #fff;
-  border-color: #000;
-}
-
-:root[data-theme='dark'] .sizeActive {
-  background: #fff;
-  color: #000;
-  border-color: #fff;
 }
 
 .palette {

--- a/app/frontend/Components/navigation/Navigation.module.scss
+++ b/app/frontend/Components/navigation/Navigation.module.scss
@@ -38,7 +38,7 @@
   font-family: var(--font-body);
   font-size: 10px;
   letter-spacing: 0.3em;
-  color: var(--phosphor);
+  color: hsl(var(--muted-foreground));
   text-transform: uppercase;
   opacity: 0.7;
   text-shadow: none;
@@ -67,7 +67,7 @@
 
 .navLink {
   font-family: var(--font-body);
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 400;
   letter-spacing: 0.2em;
   text-transform: uppercase;
@@ -85,7 +85,7 @@
 }
 
 .navLink:hover {
-  color: var(--phosphor);
+  color: hsl(var(--foreground));
   background: none;
 }
 
@@ -135,7 +135,6 @@
   padding: var(--space-xs);
   background: hsl(var(--popover));
   color: hsl(var(--popover-foreground));
-  backdrop-filter: blur(6px);
   border-radius: var(--radius);
   border: 1px solid hsl(var(--border));
   box-shadow: var(--shadow-1, 0 8px 16px rgba(0, 0, 0, 0.1));
@@ -143,7 +142,8 @@
   display: none;
 }
 
-.dropdown:hover .dropdownMenu {
+.dropdown:hover .dropdownMenu,
+.dropdownOpen .dropdownMenu {
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
@@ -229,8 +229,7 @@
   left: 0;
   width: 100%;
   z-index: 1000;
-  background: hsl(var(--background) / 0.92);
-  backdrop-filter: blur(10px);
+  background: hsl(var(--background));
   border-top: 1px solid hsl(var(--border));
   padding-bottom: env(safe-area-inset-bottom);
 }
@@ -257,7 +256,7 @@
   text-decoration: none;
   cursor: pointer;
   font-family: var(--font-ui);
-  font-size: 10px;
+  font-size: 12px;
   letter-spacing: 0.05em;
   text-transform: uppercase;
   transition: color 0.15s ease;
@@ -265,7 +264,7 @@
 }
 
 .bottomTab:hover {
-  color: var(--phosphor);
+  color: hsl(var(--foreground));
   background: none;
 }
 
@@ -274,7 +273,7 @@
 }
 
 .bottomTabLabel {
-  font-size: 10px;
+  font-size: 12px;
   line-height: 1;
 }
 
@@ -287,7 +286,6 @@
   z-index: 1003;
   background: hsl(var(--popover));
   color: hsl(var(--popover-foreground));
-  backdrop-filter: blur(8px);
   border: 1px solid hsl(var(--border));
   border-radius: var(--radius);
   padding: var(--space-sm);
@@ -302,7 +300,6 @@
   inset: 0;
   z-index: 1002;
   background: rgba(0, 0, 0, 0.4);
-  backdrop-filter: blur(2px);
   border: none !important;
   padding: 0 !important;
 }

--- a/app/frontend/Components/navigation/TopNav.tsx
+++ b/app/frontend/Components/navigation/TopNav.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { NavLink, useLocation } from 'react-router-dom';
 
@@ -23,11 +23,14 @@ import { getSessionCreatedExperiences } from '@cctv/utils';
 import styles from './Navigation.module.scss';
 
 type MobilePanel = 'shows' | 'settings' | null;
+type DesktopDropdown = 'shows' | 'settings' | null;
 
 const SHOWS_PATH_PREFIXES = ['/events', '/performers', '/join', '/experiences', '/create'];
 
 export const TopNav = () => {
   const [activePanel, setActivePanel] = useState<MobilePanel>(null);
+  const [openDropdown, setOpenDropdown] = useState<DesktopDropdown>(null);
+  const navRef = useRef<HTMLElement>(null);
   const { user, logOut, isLoading } = useUser();
   const isAdmin = user?.role === 'admin' || user?.role === 'superadmin';
   const { theme, setTheme } = useTheme();
@@ -40,6 +43,12 @@ export const TopNav = () => {
 
   const closePanel = () => setActivePanel(null);
 
+  const toggleDropdown = (dropdown: DesktopDropdown) => {
+    setOpenDropdown((prev) => (prev === dropdown ? null : dropdown));
+  };
+
+  const closeDropdown = () => setOpenDropdown(null);
+
   const profileHref = user?.performer_slug
     ? `/performers/${user.performer_slug}`
     : '/performers/new';
@@ -49,9 +58,25 @@ export const TopNav = () => {
     activePanel === 'shows' ||
     SHOWS_PATH_PREFIXES.some((prefix) => location.pathname.startsWith(prefix));
 
+  useEffect(() => {
+    if (!openDropdown) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (!navRef.current?.contains(e.target as Node)) setOpenDropdown(null);
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpenDropdown(null);
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [openDropdown]);
+
   return (
     <>
-      <nav className={styles.topnav}>
+      <nav className={styles.topnav} ref={navRef}>
         <div className={styles.topnav__inner}>
           <NavLink to="/" end className={styles.logoLockup}>
             <span className={styles.logoCh}>Ch. 77</span>
@@ -78,22 +103,30 @@ export const TopNav = () => {
             >
               About
             </NavLink>
-            <div className={styles.dropdown}>
+            <div
+              className={`${styles.dropdown} ${openDropdown === 'shows' ? styles.dropdownOpen : ''}`}
+            >
               <button
                 type="button"
                 className={`${styles.navLink} ${styles.dropdownTrigger}`}
                 aria-haspopup="menu"
+                aria-expanded={openDropdown === 'shows'}
+                onClick={() => toggleDropdown('shows')}
               >
                 Shows
               </button>
               <div className={styles.dropdownMenu} role="menu">
-                <NavLink to="/events" className={() => styles.dropdownItem}>
+                <NavLink to="/events" className={() => styles.dropdownItem} onClick={closeDropdown}>
                   <CalendarDays size={14} /> Browse Events
                 </NavLink>
-                <NavLink to="/performers" className={() => styles.dropdownItem}>
+                <NavLink
+                  to="/performers"
+                  className={() => styles.dropdownItem}
+                  onClick={closeDropdown}
+                >
                   <Users size={14} /> Browse Performers
                 </NavLink>
-                <NavLink to="/join" className={() => styles.dropdownItem}>
+                <NavLink to="/join" className={() => styles.dropdownItem} onClick={closeDropdown}>
                   <Ticket size={14} /> Join Show
                 </NavLink>
                 {isAdmin && (
@@ -105,6 +138,7 @@ export const TopNav = () => {
                           key={e.code}
                           to={`/experiences/${e.code}/manage`}
                           className={() => styles.dropdownItem}
+                          onClick={closeDropdown}
                         >
                           <Tv size={14} /> {e.name}
                         </NavLink>
@@ -114,10 +148,18 @@ export const TopNav = () => {
                         No recent
                       </span>
                     )}
-                    <NavLink to="/create" className={() => styles.dropdownItem}>
+                    <NavLink
+                      to="/create"
+                      className={() => styles.dropdownItem}
+                      onClick={closeDropdown}
+                    >
                       <Plus size={14} /> Create Experience
                     </NavLink>
-                    <NavLink to="/events/new" className={() => styles.dropdownItem}>
+                    <NavLink
+                      to="/events/new"
+                      className={() => styles.dropdownItem}
+                      onClick={closeDropdown}
+                    >
                       <Plus size={14} /> New Event
                     </NavLink>
                   </>
@@ -127,12 +169,16 @@ export const TopNav = () => {
           </div>
 
           <div className={styles.navRight}>
-            <div className={styles.dropdown}>
+            <div
+              className={`${styles.dropdown} ${openDropdown === 'settings' ? styles.dropdownOpen : ''}`}
+            >
               <button
                 type="button"
                 className={`${styles.navLink} ${styles.dropdownTrigger}`}
                 aria-haspopup="menu"
+                aria-expanded={openDropdown === 'settings'}
                 aria-label="Settings"
+                onClick={() => toggleDropdown('settings')}
               >
                 <Settings size={16} />
               </button>
@@ -149,7 +195,11 @@ export const TopNav = () => {
                   />
                 </div>
                 {user && (
-                  <NavLink to={profileHref} className={() => styles.dropdownItem}>
+                  <NavLink
+                    to={profileHref}
+                    className={() => styles.dropdownItem}
+                    onClick={closeDropdown}
+                  >
                     <UserIcon size={14} /> {profileLabel}
                   </NavLink>
                 )}

--- a/app/frontend/Core/Button/Button.module.scss
+++ b/app/frontend/Core/Button/Button.module.scss
@@ -22,6 +22,11 @@
     transform: scale(0.97);
     filter: brightness(0.95);
   }
+
+  &:focus-visible {
+    outline: 2px solid var(--phosphor);
+    outline-offset: 2px;
+  }
 }
 
 .button:disabled {
@@ -55,8 +60,8 @@
   text-transform: uppercase;
   letter-spacing: 0.1em;
   background: transparent;
-  color: var(--hot-white);
-  border: 1px solid var(--hot-white);
+  color: hsl(var(--foreground));
+  border: 1px solid hsl(var(--foreground));
   transition:
     border-color 0.15s ease,
     box-shadow 0.2s ease,
@@ -161,5 +166,13 @@
   }
   100% {
     transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: none;
+    border-color: currentColor;
+    opacity: 0.5;
   }
 }

--- a/app/frontend/Core/Dialog/Dialog.module.scss
+++ b/app/frontend/Core/Dialog/Dialog.module.scss
@@ -17,6 +17,7 @@
   position: fixed;
   left: 50%;
   top: 50%;
+  transform: translate(-50%, -50%);
   z-index: 50;
   display: grid;
   width: calc(100% - 2rem);

--- a/app/frontend/Core/Dialog/Dialog.module.scss
+++ b/app/frontend/Core/Dialog/Dialog.module.scss
@@ -153,3 +153,13 @@
     transform: translate(-50%, -48%) scale(0.96);
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .overlay,
+  .content {
+    &[data-state='open'],
+    &[data-state='closed'] {
+      animation: none;
+    }
+  }
+}

--- a/app/frontend/Core/DropdownMenu/DropdownMenu.module.scss
+++ b/app/frontend/Core/DropdownMenu/DropdownMenu.module.scss
@@ -83,3 +83,10 @@
     transform: scale(0.95);
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .content[data-state='open'],
+  .content[data-state='closed'] {
+    animation: none;
+  }
+}

--- a/app/frontend/Core/Panel/Panel.module.scss
+++ b/app/frontend/Core/Panel/Panel.module.scss
@@ -7,19 +7,11 @@
   color: hsl(var(--card-foreground));
   border-radius: 1rem;
   border: 1px solid hsl(var(--border));
-  border-top: 2px solid hsl(var(--primary) / 0.3);
   box-shadow: var(--shadow-1, 0 8px 12px rgba(0, 0, 0, 0.12));
   position: relative;
   z-index: 3;
   height: 100%;
   width: 100%;
-  transition:
-    border-top-color 0.3s ease,
-    box-shadow 0.3s ease;
-
-  &:hover {
-    border-top-color: hsl(var(--primary) / 0.5);
-  }
 }
 
 .header {

--- a/app/frontend/Core/Pill/Pill.module.scss
+++ b/app/frontend/Core/Pill/Pill.module.scss
@@ -32,3 +32,9 @@
     transform: scale(1);
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .pill {
+    animation: none;
+  }
+}

--- a/app/frontend/Core/SegmentBadge/SegmentBadge.module.scss
+++ b/app/frontend/Core/SegmentBadge/SegmentBadge.module.scss
@@ -9,7 +9,7 @@
   line-height: 1;
   padding: 0.25rem 0.5rem;
   border-radius: 9999px;
-  color: #fff;
+  color: var(--hot-white);
   white-space: nowrap;
   animation: badgeIn 0.15s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
@@ -46,5 +46,11 @@
   to {
     opacity: 1;
     transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .badge {
+    animation: none;
   }
 }

--- a/app/frontend/Core/Switch/Switch.module.scss
+++ b/app/frontend/Core/Switch/Switch.module.scss
@@ -32,7 +32,7 @@
   width: 1rem;
   border-radius: 9999px;
   background: hsl(var(--foreground));
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-sm);
   z-index: 10;
   transition:
     transform 0.15s cubic-bezier(0.16, 1, 0.3, 1),

--- a/app/frontend/Core/Table/Table.stories.tsx
+++ b/app/frontend/Core/Table/Table.stories.tsx
@@ -44,7 +44,7 @@ export const WithCustomCell: Story = {
         key: 'score',
         label: 'Score',
         Cell: (row: Player) => (
-          <span style={{ color: row.score > 80 ? 'var(--green)' : 'inherit' }}>{row.score}</span>
+          <span style={{ color: row.score > 80 ? 'var(--phosphor)' : 'inherit' }}>{row.score}</span>
         ),
       },
     ],

--- a/app/frontend/Experiences/Announcement/Announcement.module.scss
+++ b/app/frontend/Experiences/Announcement/Announcement.module.scss
@@ -1,34 +1,16 @@
 .announcement {
   width: 100%;
-  max-width: 600px;
+  max-width: 36rem;
   margin: 0 auto;
-}
-
-.content {
-  background: hsl(var(--card));
-  border: 2px solid hsl(var(--border));
-  border-radius: 8px;
-  padding: 1.5rem;
+  padding: var(--space-md);
   text-align: center;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .message {
-  font-size: 1.1rem;
-  line-height: 1.5;
-  color: hsl(var(--card-foreground));
-  margin: 0;
+  font-family: var(--font-body);
+  font-size: clamp(1.125rem, 3vw, 1.5rem);
+  line-height: 1.55;
+  color: hsl(var(--foreground));
   white-space: pre-wrap;
-}
-
-// Responsive design
-@media (max-width: 768px) {
-  .content {
-    padding: var(--space-sm);
-    margin: 0 var(--space-sm);
-  }
-
-  .message {
-    font-size: 1rem;
-  }
+  text-shadow: none;
 }

--- a/app/frontend/Experiences/Announcement/Announcement.tsx
+++ b/app/frontend/Experiences/Announcement/Announcement.tsx
@@ -13,9 +13,7 @@ export default function Announcement({ participant, message }: AnnouncementProps
 
   return (
     <div className={styles.announcement}>
-      <div className={styles.content}>
-        <p className={styles.message}>{processedMessage}</p>
-      </div>
+      <p className={styles.message}>{processedMessage}</p>
     </div>
   );
 }

--- a/app/frontend/Experiences/Buzzer/Buzzer.module.scss
+++ b/app/frontend/Experiences/Buzzer/Buzzer.module.scss
@@ -143,3 +143,9 @@
     transform: scale(1);
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .monitorWinner {
+    animation: none;
+  }
+}

--- a/app/frontend/Experiences/FamilyFeud/BucketCard.module.scss
+++ b/app/frontend/Experiences/FamilyFeud/BucketCard.module.scss
@@ -6,7 +6,9 @@
   border: 1px solid hsl(var(--border));
   border-radius: var(--radius);
   min-height: 80px;
-  transition: all 0.3s ease;
+  transition:
+    background 0.3s ease,
+    border-color 0.3s ease;
 }
 
 .card.revealed {
@@ -69,7 +71,13 @@
 .percentage {
   font-size: 20px;
   font-weight: 800;
-  color: hsl(var(--primary));
+  color: hsl(var(--accent));
   min-width: 4ch;
   text-align: right;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card.revealed {
+    animation: none;
+  }
 }

--- a/app/frontend/Experiences/FamilyFeud/XAnimation.module.scss
+++ b/app/frontend/Experiences/FamilyFeud/XAnimation.module.scss
@@ -44,6 +44,16 @@
 }
 
 .xIcon {
-  color: #ef4444;
-  filter: drop-shadow(0 0 20px rgba(239, 68, 68, 0.8));
+  color: var(--red);
+  filter: drop-shadow(0 0 20px color-mix(in srgb, var(--red) 80%, transparent));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .overlay {
+    animation: none;
+  }
+
+  .xContainer {
+    animation: none;
+  }
 }

--- a/app/frontend/Experiences/MadLib/MadLib.module.scss
+++ b/app/frontend/Experiences/MadLib/MadLib.module.scss
@@ -1,156 +1,29 @@
 .madLib {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  max-width: 600px;
+  gap: var(--space-md);
+  max-width: 36rem;
   margin: 0 auto;
-  padding: 1rem;
+  padding: var(--space-md);
+  text-align: center;
 }
 
 .template {
-  border: 2px solid var(--card-border, #e9ecef);
-  border-radius: 12px;
-  padding: 2rem;
-  font-size: 1.2rem;
+  font-family: var(--font-body);
+  font-size: clamp(1.125rem, 3vw, 1.5rem);
   line-height: 1.6;
-  text-align: center;
-  box-shadow: var(--card-shadow, 0 2px 4px rgba(0, 0, 0, 0.1));
+  color: hsl(var(--foreground));
+  text-shadow: none;
 }
 
 .template strong {
-  color: var(--phosphor);
-  padding: 0.25rem var(--space-xs);
-  border-radius: 6px;
-  font-weight: 600;
+  color: hsl(var(--accent));
+  font-weight: 700;
 }
 
 .template em {
-  color: var(--muted-fg, #6b7280);
-  padding: 0.25rem var(--space-xs);
-  border-radius: 6px;
+  color: hsl(var(--muted-foreground));
   font-style: normal;
-  border: 2px dashed var(--border-muted, #d1d5db);
-}
-
-.inputSection {
-  border: 1px solid var(--input-border, #e5e7eb);
-  border-radius: 12px;
-  padding: 1.5rem;
-  box-shadow: var(--card-shadow, 0 1px 3px rgba(0, 0, 0, 0.1));
-}
-
-.inputSection h3 {
-  margin: 0 0 var(--space-xs) 0;
-  color: var(--text-primary, #1f2937);
-  font-size: 1.25rem;
-}
-
-.inputSection p {
-  margin: 0 0 1rem 0;
-  color: var(--phosphor);
-}
-
-.inputGroup {
-  display: flex;
-  gap: var(--space-xs);
-  align-items: flex-end;
-}
-
-.inputGroup > div {
-  flex: 1;
-}
-
-.submitted {
-  border: 1px solid var(--success-border, #bfdbfe);
-  color: var(--success-fg, #1e40af);
-  border-radius: 12px;
-  padding: 1.5rem;
-  text-align: center;
-}
-
-.submitted p {
-  margin: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-xs);
-}
-
-.submitted strong {
-  padding: 0.25rem var(--space-xs);
-  border-radius: 6px;
-}
-
-.waiting {
-  border: 1px solid var(--info-border, #bfdbfe);
-  color: var(--info-fg, #1e40af);
-  border-radius: 12px;
-  padding: 1.5rem;
-  text-align: center;
-}
-
-.waiting p {
-  margin: 0 0 var(--space-xs) 0;
-}
-
-.waiting p:last-child {
-  margin: 0;
-  font-weight: 600;
-}
-
-.error {
-  border: 1px solid var(--error-border, #fecaca);
-  color: var(--error-fg, #991b1b);
-  border-radius: 12px;
-  padding: 1rem;
-  margin-top: 1rem;
-}
-
-.error p {
-  margin: 0;
-  font-weight: 500;
-}
-
-.progressIndicator {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-xs);
-  margin-top: 1rem;
-  padding: var(--space-xs);
-  border-radius: 8px;
-  border: 1px solid var(--border-light, #f1f3f4);
-}
-
-.progressIndicator .dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-}
-
-.progressIndicator .dot.filled {
-}
-
-@media (max-width: 640px) {
-  .madLib {
-    padding: var(--space-xs);
-  }
-
-  .template {
-    padding: 1.5rem;
-    font-size: 1.1rem;
-  }
-
-  .inputSection {
-    padding: 1rem;
-  }
-
-  .inputGroup {
-    flex-direction: column;
-    gap: var(--space-xs);
-  }
-
-  .inputGroup > div {
-    width: 100%;
-  }
+  border-bottom: 1px dashed hsl(var(--muted-foreground) / 0.5);
+  padding-bottom: 1px;
 }

--- a/app/frontend/Experiences/PhotoUpload/PhotoUpload.module.scss
+++ b/app/frontend/Experiences/PhotoUpload/PhotoUpload.module.scss
@@ -8,14 +8,18 @@
 }
 
 .prompt {
+  font-family: var(--font-body);
   font-size: 1.125rem;
   font-weight: 600;
   margin: 0;
+  text-shadow: none;
 }
 
 .error {
   color: hsl(var(--destructive));
+  font-family: var(--font-body);
   font-size: 0.875rem;
+  text-shadow: none;
 }
 
 .uploadArea {
@@ -28,15 +32,20 @@
   max-width: 20rem;
   min-height: 10rem;
   padding: var(--space-md);
-  border: 2px dashed hsl(var(--border));
-  border-radius: 0.75rem;
+  border: 1px dashed hsl(var(--border));
+  border-radius: 0;
   background: transparent;
   color: hsl(var(--muted-foreground));
   cursor: pointer;
+  font-family: var(--font-body);
   font-size: 0.875rem;
+  text-shadow: none;
+  transition:
+    border-color 0.15s ease,
+    color 0.15s ease;
 
   &:hover {
-    border-color: hsl(var(--foreground));
+    border-color: hsl(var(--foreground) / 0.45);
     color: hsl(var(--foreground));
   }
 
@@ -54,9 +63,9 @@
 
 .preview {
   width: 100%;
-  border-radius: 0.75rem;
   border: 1px solid hsl(var(--border));
   object-fit: cover;
+  display: block;
 }
 
 .progressOverlay {
@@ -66,7 +75,6 @@
   right: 0;
   height: 0.25rem;
   background: hsl(var(--muted));
-  border-radius: 0 0 0.75rem 0.75rem;
   overflow: hidden;
 }
 
@@ -87,18 +95,21 @@
   display: inline-flex;
   align-items: center;
   gap: 0.375rem;
-  padding: 0.375rem 0.75rem;
-  border-radius: 999px;
-  background: hsl(var(--primary) / 0.15);
-  color: hsl(var(--primary));
-  font-size: 0.875rem;
-  font-weight: 500;
+  padding: 0.25rem 0.625rem;
+  border: 1px solid hsl(var(--accent));
+  color: hsl(var(--accent));
+  font-family: var(--font-body);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  text-shadow: none;
 }
 
 .submittedPhoto {
   max-width: 20rem;
   width: 100%;
-  border-radius: 0.75rem;
   border: 1px solid hsl(var(--border));
   object-fit: cover;
+  display: block;
 }

--- a/app/frontend/Experiences/Poll/Poll.module.scss
+++ b/app/frontend/Experiences/Poll/Poll.module.scss
@@ -10,6 +10,7 @@
   font-size: 32px;
   padding: var(--space-xs);
   width: 100%;
+  text-align: center;
 }
 
 .value {
@@ -17,8 +18,9 @@
   z-index: 3;
   font-size: 28px;
   width: 100%;
-  color: var(--phosphor);
+  color: hsl(var(--foreground));
   padding: var(--space-xs) 0;
+  text-align: center;
 }
 
 .submit {

--- a/app/frontend/Experiences/Question/Question.module.scss
+++ b/app/frontend/Experiences/Question/Question.module.scss
@@ -22,8 +22,9 @@
   z-index: 3;
   font-size: 28px;
   width: 100%;
-  color: var(--phosphor);
+  color: hsl(var(--foreground));
   padding-top: var(--space-xs);
+  text-align: center;
 }
 
 .legend {

--- a/app/frontend/Pages/Block/Block.module.scss
+++ b/app/frontend/Pages/Block/Block.module.scss
@@ -1,36 +1,40 @@
 .root {
   max-width: 800px;
   margin: 0 auto;
-  padding: var(--spacing-xl);
+  padding: var(--space-lg);
 }
 
 .title {
-  font-size: var(--font-size-xxl);
-  font-weight: var(--font-weight-bold);
-  color: var(--color-text-primary);
-  margin-bottom: var(--spacing-xl);
+  font-family: var(--font-display);
+  font-size: clamp(2.5rem, 7vw, 4rem);
+  line-height: 1;
+  color: hsl(var(--foreground));
+  margin-bottom: var(--space-md);
 }
 
 .content {
-  background-color: var(--color-background-secondary);
-  border: 1px solid var(--color-border);
-  border-radius: var(--border-radius-md);
-  padding: var(--spacing-lg);
+  background-color: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  padding: var(--space-md);
 }
 
 .field {
   display: flex;
-  gap: var(--spacing-md);
-  padding: var(--spacing-md) 0;
+  gap: var(--space-sm);
+  padding: var(--space-sm) 0;
 }
 
 .label {
-  font-weight: var(--font-weight-bold);
-  color: var(--color-text-secondary);
+  font-family: var(--font-ui);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: hsl(var(--muted-foreground));
   min-width: 100px;
 }
 
 .value {
-  color: var(--color-text-primary);
-  font-family: monospace;
+  color: hsl(var(--foreground));
+  font-family: var(--font-body);
 }

--- a/app/frontend/Pages/Block/BuzzerManager/BuzzerManager.tsx
+++ b/app/frontend/Pages/Block/BuzzerManager/BuzzerManager.tsx
@@ -11,7 +11,7 @@ interface BuzzerManagerProps {
 }
 
 export default function BuzzerManager({ block, participants }: BuzzerManagerProps) {
-  const { clearBuzzerResponses, isLoading } = useClearBuzzerResponses();
+  const { clearBuzzerResponses } = useClearBuzzerResponses();
 
   const allResponses = block.responses?.all_responses ?? [];
   const allParticipants = participants;
@@ -49,8 +49,6 @@ export default function BuzzerManager({ block, participants }: BuzzerManagerProp
       <Button
         variant="secondary"
         onClick={() => clearBuzzerResponses(block.id)}
-        loading={isLoading}
-        loadingText="Resetting…"
         disabled={allResponses.length === 0}
       >
         Reset Buzzers

--- a/app/frontend/Pages/Calendar/Calendar.module.scss
+++ b/app/frontend/Pages/Calendar/Calendar.module.scss
@@ -69,9 +69,9 @@
   font-family: var(--font-display);
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  font-size: 1.5rem;
+  font-size: clamp(1.25rem, 5vw, 1.5rem);
   font-weight: 400;
-  min-width: 200px;
+  min-width: clamp(8rem, 50vw, 12.5rem);
   text-align: center;
   line-height: 1;
 }
@@ -122,7 +122,6 @@
   gap: var(--space-md);
   padding: var(--space-sm) var(--space-md);
   border: 1px solid hsl(var(--border));
-  border-left: 2px solid hsl(var(--border));
   border-radius: 2px;
   text-decoration: none;
   color: inherit;
@@ -133,7 +132,6 @@
 
   &:hover {
     border-color: hsl(var(--primary));
-    border-left-color: hsl(var(--primary));
     background: hsl(var(--primary) / 0.04);
     z-index: 1;
     position: relative;
@@ -221,9 +219,7 @@
   height: 0.5rem;
   border-radius: 999px;
   background: var(--phosphor);
-  box-shadow:
-    0 0 4px var(--phosphor-glow-strong),
-    0 0 10px var(--phosphor-glow-medium);
+  box-shadow: 0 0 6px var(--phosphor-glow-medium);
 }
 
 :root[data-theme='dark'] .liveTally {
@@ -239,13 +235,9 @@
 @keyframes tally-flicker {
   0%,
   100% {
-    box-shadow:
-      0 0 4px var(--phosphor-glow-strong),
-      0 0 10px var(--phosphor-glow-medium);
+    opacity: 1;
   }
   50% {
-    box-shadow:
-      0 0 6px var(--phosphor-glow-strong),
-      0 0 16px var(--phosphor-glow-strong);
+    opacity: 0.55;
   }
 }

--- a/app/frontend/Pages/Create/Create.module.scss
+++ b/app/frontend/Pages/Create/Create.module.scss
@@ -21,8 +21,8 @@
 .link {
   font-weight: 400;
   font-size: clamp(16px, 4vw, 20px);
-  color: var(--phosphor);
-  text-decoration: none;
+  color: hsl(var(--foreground));
+  text-decoration: underline;
   padding-top: 1.5rem;
 }
 

--- a/app/frontend/Pages/Events/EventDetail.module.scss
+++ b/app/frontend/Pages/Events/EventDetail.module.scss
@@ -136,12 +136,11 @@
   padding: var(--space-md);
   border: 1px solid var(--phosphor);
   border-radius: 2px;
-  background: hsl(var(--primary) / 0.04);
+  background: hsl(var(--card));
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
   align-items: center;
-  box-shadow: inset 0 0 24px var(--phosphor-glow-faint);
 }
 
 .joinSectionMarker {
@@ -167,9 +166,7 @@
   height: 0.5rem;
   border-radius: 999px;
   background: var(--phosphor);
-  box-shadow:
-    0 0 4px var(--phosphor-glow-strong),
-    0 0 10px var(--phosphor-glow-medium);
+  box-shadow: 0 0 6px var(--phosphor-glow-medium);
 }
 
 @media (prefers-reduced-motion: no-preference) {
@@ -181,14 +178,10 @@
 @keyframes tally-flicker {
   0%,
   100% {
-    box-shadow:
-      0 0 4px var(--phosphor-glow-strong),
-      0 0 10px var(--phosphor-glow-medium);
+    opacity: 1;
   }
   50% {
-    box-shadow:
-      0 0 6px var(--phosphor-glow-strong),
-      0 0 16px var(--phosphor-glow-strong);
+    opacity: 0.55;
   }
 }
 
@@ -216,7 +209,7 @@
   align-items: center;
   justify-content: center;
   border: 1px solid hsl(var(--border));
-  background: #fff;
+  background: hsl(var(--card));
   padding: 0.5rem;
   line-height: 0;
 }
@@ -235,16 +228,13 @@
   font-weight: 700;
   font-size: 1rem;
   border-radius: 2px;
-  box-shadow: 0 0 16px var(--phosphor-glow-medium);
   min-height: 2.75rem;
   transition:
     filter 0.15s,
-    transform 0.08s,
-    box-shadow 0.15s;
+    transform 0.08s;
 
   &:hover {
     filter: brightness(1.05);
-    box-shadow: 0 0 24px var(--phosphor-glow-strong);
   }
 
   &:active {

--- a/app/frontend/Pages/Experience/AdminNotification/AdminNotification.module.scss
+++ b/app/frontend/Pages/Experience/AdminNotification/AdminNotification.module.scss
@@ -9,7 +9,7 @@
 
 .adminMessage {
   margin: 0 0 1rem 0;
-  color: #fff;
+  color: hsl(var(--foreground));
   font-size: 0.95rem;
   line-height: 1.4;
 }

--- a/app/frontend/Pages/Experience/Experience.module.scss
+++ b/app/frontend/Pages/Experience/Experience.module.scss
@@ -2,16 +2,19 @@
   margin-bottom: var(--space-xs);
   font-size: 2rem;
   font-weight: 800;
+  text-align: center;
 }
 
 // Subtitle and general text styles
 .subtitle {
   opacity: 0.85;
+  text-align: center;
 }
 
 .experienceStatus {
   font-size: 0.85rem;
   opacity: 0.85;
+  text-align: center;
 }
 
 .activeExperience {
@@ -19,6 +22,7 @@
   flex-direction: column;
   align-items: center;
   min-height: calc(100dvh - var(--nav-h) - var(--space-sm) * 2);
+  text-align: center;
 }
 
 .experienceContent {
@@ -39,6 +43,7 @@
 .error {
   color: hsl(var(--destructive));
   margin-bottom: var(--space-sm);
+  text-align: center;
 }
 
 .invalidCode {
@@ -126,6 +131,7 @@
   display: flex;
   flex-direction: column;
   padding-bottom: calc(var(--bottom-nav-h) + var(--space-sm)) !important;
+  text-align: center;
 }
 
 .avatarEditor {
@@ -180,7 +186,10 @@
   min-height: 100%;
 }
 
-.avatarToggleBtn:hover,
+.avatarToggleBtn:hover {
+  border-color: hsl(var(--foreground) / 0.45);
+}
+
 .avatarToggleBtn:focus-visible {
   border-color: var(--phosphor);
   box-shadow: var(--tv-glow);
@@ -208,10 +217,10 @@
   align-items: center;
   justify-content: center;
   background: var(--phosphor);
-  color: #000;
+  color: var(--black);
   border: none;
   cursor: pointer;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-md);
   text-decoration: none;
 }
 
@@ -256,11 +265,11 @@
 }
 
 .connected {
-  color: var(--green);
+  color: var(--phosphor);
 }
 
 .disconnected {
-  color: var(--phosphor);
+  color: var(--amber);
 }
 
 // Admin manage link styling
@@ -287,6 +296,7 @@
   grid-template-rows: auto 1fr auto;
   height: calc(100dvh - var(--nav-h) - calc(var(--space-sm) * 2));
   gap: var(--space-xs);
+  text-align: center;
 }
 
 @media (max-width: 768px) {

--- a/app/frontend/Pages/Experience/Experience.tsx
+++ b/app/frontend/Pages/Experience/Experience.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { createPortal } from 'react-dom';
 
@@ -9,7 +9,15 @@ import { BookOpen } from 'lucide-react';
 import { ParticipantsList } from '@cctv/components';
 import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { useUser } from '@cctv/contexts/UserContext';
-import { Button } from '@cctv/core/Button/Button';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@cctv/core';
 import ExperienceBlockContainer from '@cctv/experiences/ExperienceBlockContainer/ExperienceBlockContainer';
 import { useClearAvatars } from '@cctv/hooks/useClearAvatars';
 import { AvatarStroke } from '@cctv/types';
@@ -77,6 +85,7 @@ export default function Experience() {
   const { experience, participant, code, isLoading, experienceStatus, error } = useExperience();
   const { isAdmin } = useUser();
   const { clearAvatars, isLoading: clearing } = useClearAvatars();
+  const [confirmClearOpen, setConfirmClearOpen] = useState(false);
 
   const participants = experience?.participants || [];
   const needsAvatar = !isAdmin && !participant?.avatar;
@@ -201,18 +210,34 @@ export default function Experience() {
           {/* Admin/Host control: clear avatars (lobby view without a current block) */}
           {(isAdmin || experience?.hosts?.some((h) => h.user_id === participant?.user_id)) && (
             <div className={styles.adminControls}>
-              <Button
-                onClick={async () => {
-                  if (
-                    confirm('Clear all participant avatars and drawings? This cannot be undone.')
-                  ) {
-                    await clearAvatars();
-                  }
-                }}
-                disabled={clearing}
-              >
+              <Button onClick={() => setConfirmClearOpen(true)} disabled={clearing}>
                 {clearing ? 'Clearing…' : 'Clear Avatars'}
               </Button>
+              <Dialog open={confirmClearOpen} onOpenChange={setConfirmClearOpen}>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Clear all avatars?</DialogTitle>
+                    <DialogDescription>
+                      This will erase every participant&apos;s avatar and drawings. It cannot be
+                      undone.
+                    </DialogDescription>
+                  </DialogHeader>
+                  <DialogFooter>
+                    <Button variant="secondary" onClick={() => setConfirmClearOpen(false)}>
+                      Cancel
+                    </Button>
+                    <Button
+                      onClick={async () => {
+                        setConfirmClearOpen(false);
+                        await clearAvatars();
+                      }}
+                      disabled={clearing}
+                    >
+                      Clear Avatars
+                    </Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
             </div>
           )}
 

--- a/app/frontend/Pages/Manage/CreateBlock/CreateAnnouncement/CreateAnnouncement.module.scss
+++ b/app/frontend/Pages/Manage/CreateBlock/CreateAnnouncement/CreateAnnouncement.module.scss
@@ -1,5 +1,5 @@
 .helpText {
   font-size: 16px;
-  color: var(--phosphor);
+  color: hsl(var(--muted-foreground));
   padding-top: 24px;
 }

--- a/app/frontend/Pages/Manage/CreateBlock/CreateBlock.module.scss
+++ b/app/frontend/Pages/Manage/CreateBlock/CreateBlock.module.scss
@@ -72,7 +72,7 @@
 
 .helpText {
   font-size: 16px;
-  color: var(--phosphor);
+  color: hsl(var(--muted-foreground));
   padding-top: 1.5rem;
 }
 
@@ -85,7 +85,7 @@
 
 .error {
   text-shadow: none;
-  color: var(--phosphor);
+  color: hsl(var(--destructive));
   padding-top: 0.75rem;
   font-size: 16px;
 }

--- a/app/frontend/Pages/Manage/CreateBlock/CreateBlock.tsx
+++ b/app/frontend/Pages/Manage/CreateBlock/CreateBlock.tsx
@@ -35,15 +35,8 @@ interface CreateBlockFormProps {
 }
 
 function CreateBlockForm({ onClose }: CreateBlockFormProps) {
-  const {
-    blockData,
-    setKind,
-    submit,
-    isSubmitting,
-    error,
-    viewAdditionalDetails,
-    setViewAdditionalDetails,
-  } = useCreateBlockContext();
+  const { blockData, setKind, submit, error, viewAdditionalDetails, setViewAdditionalDetails } =
+    useCreateBlockContext();
 
   return (
     <div className={styles.root}>
@@ -82,17 +75,10 @@ function CreateBlockForm({ onClose }: CreateBlockFormProps) {
         >
           {viewAdditionalDetails ? 'Hide Additional Details' : 'View Additional Details'}
         </Button>
-        <Button
-          variant="secondary"
-          onClick={() => submit('hidden')}
-          loading={isSubmitting}
-          loadingText="Creating..."
-        >
+        <Button variant="secondary" onClick={() => submit('hidden')}>
           Queue block
         </Button>
-        <Button onClick={() => submit('open')} loading={isSubmitting} loadingText="Creating...">
-          Play now
-        </Button>
+        <Button onClick={() => submit('open')}>Play now</Button>
       </div>
     </div>
   );

--- a/app/frontend/Pages/Manage/CreateBlock/CreateMadLib/CreateMadLib.module.scss
+++ b/app/frontend/Pages/Manage/CreateBlock/CreateMadLib/CreateMadLib.module.scss
@@ -18,9 +18,9 @@
 }
 
 .variablePart {
-  color: var(--phosphor);
+  color: hsl(var(--accent));
   font-weight: bold;
-  background: rgba(200, 240, 96, 0.1);
+  background: hsl(var(--accent) / 0.1);
   padding: 0.125rem 0.25rem;
   border-radius: 4px;
 }
@@ -67,7 +67,7 @@
 
 .variableInfo h5 {
   margin: 0;
-  color: var(--phosphor);
+  color: hsl(var(--foreground));
   font-size: 16px;
 }
 
@@ -75,10 +75,10 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  background: rgba(200, 240, 96, 0.05);
+  background: hsl(var(--muted));
   padding: 0.75rem;
   border-radius: 8px;
-  border: 1px solid rgba(200, 240, 96, 0.2);
+  border: 1px solid hsl(var(--border));
 }
 
 .partActions {

--- a/app/frontend/Pages/Manage/EditBlock/EditBlock.module.scss
+++ b/app/frontend/Pages/Manage/EditBlock/EditBlock.module.scss
@@ -79,17 +79,17 @@
 
 .error {
   text-shadow: none;
-  color: var(--phosphor);
+  color: hsl(var(--destructive));
   padding-top: 0.75rem;
   font-size: 16px;
 }
 
 .warning {
   text-shadow: none;
-  color: var(--phosphor);
+  color: var(--amber);
   padding: 0.75rem;
   font-size: 14px;
-  border: 1px solid var(--phosphor);
+  border: 1px solid var(--amber);
   border-radius: 4px;
   width: 100%;
   display: flex;

--- a/app/frontend/Pages/Manage/ParticipantsTab/ParticipantsTab.module.scss
+++ b/app/frontend/Pages/Manage/ParticipantsTab/ParticipantsTab.module.scss
@@ -33,13 +33,14 @@
 }
 
 .assignBtn {
-  width: 20px;
-  height: 20px;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+  padding: 0;
   border-radius: 9999px;
   border: 1px dashed hsl(var(--border));
   background: transparent;
   color: hsl(var(--muted-foreground));
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
@@ -52,13 +53,14 @@
 }
 
 .kickBtn {
-  width: 24px;
-  height: 24px;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+  padding: 0;
   border-radius: 4px;
   border: none;
   background: transparent;
   color: hsl(var(--muted-foreground));
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   cursor: pointer;
   display: inline-flex;
   align-items: center;

--- a/app/frontend/Pages/Manage/PlaybillTab/PlaybillTab.module.scss
+++ b/app/frontend/Pages/Manage/PlaybillTab/PlaybillTab.module.scss
@@ -51,8 +51,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 1.75rem;
-  height: 1.75rem;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
   padding: 0;
   border: none;
   border-radius: 0.25rem;
@@ -154,8 +154,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 1.5rem;
-  height: 1.5rem;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
   padding: 0;
   border: none;
   border-radius: 50%;

--- a/app/frontend/Pages/Manage/PlaybillTab/PlaybillTab.tsx
+++ b/app/frontend/Pages/Manage/PlaybillTab/PlaybillTab.tsx
@@ -131,7 +131,8 @@ export default function PlaybillTab({ playbill, playbillEnabled }: PlaybillTabPr
                 className={styles.iconBtn}
                 onClick={() => handleMoveUp(index)}
                 disabled={index === 0}
-                title="Move up"
+                title="Move section up"
+                aria-label={`Move section ${index + 1} up`}
               >
                 <ArrowUp size={14} />
               </button>
@@ -139,7 +140,8 @@ export default function PlaybillTab({ playbill, playbillEnabled }: PlaybillTabPr
                 className={styles.iconBtn}
                 onClick={() => handleMoveDown(index)}
                 disabled={index === sections.length - 1}
-                title="Move down"
+                title="Move section down"
+                aria-label={`Move section ${index + 1} down`}
               >
                 <ArrowDown size={14} />
               </button>
@@ -147,6 +149,7 @@ export default function PlaybillTab({ playbill, playbillEnabled }: PlaybillTabPr
                 className={styles.iconBtnDanger}
                 onClick={() => handleRemove(section.id)}
                 title="Remove section"
+                aria-label={`Remove section ${index + 1}`}
               >
                 <Trash2 size={14} />
               </button>
@@ -176,6 +179,7 @@ export default function PlaybillTab({ playbill, playbillEnabled }: PlaybillTabPr
                     className={styles.imageRemoveBtn}
                     onClick={() => handleRemoveImage(section.id)}
                     title="Remove image"
+                    aria-label="Remove image"
                   >
                     <X size={14} />
                   </button>

--- a/app/frontend/Pages/Manage/QRCodeDisplay/QRCodeDisplay.module.scss
+++ b/app/frontend/Pages/Manage/QRCodeDisplay/QRCodeDisplay.module.scss
@@ -15,7 +15,7 @@
 
 .code {
   font-size: clamp(16px, 4vw, 20px);
-  color: var(--phosphor);
+  color: hsl(var(--foreground));
   font-weight: 400;
 }
 

--- a/app/frontend/Pages/Manage/Viewer/BlockSidebar.module.scss
+++ b/app/frontend/Pages/Manage/Viewer/BlockSidebar.module.scss
@@ -29,7 +29,7 @@
 .headerTitle {
   font-size: 0.875rem;
   font-weight: 600;
-  color: white;
+  color: hsl(var(--foreground));
   padding-left: 0.5rem;
 }
 
@@ -61,7 +61,7 @@
 
 .iconButton {
   width: 100%;
-  height: 2.5rem;
+  min-height: 2.75rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -70,7 +70,7 @@
 
   &.selected {
     background: hsl(var(--muted));
-    box-shadow: inset 0 0 0 2px var(--green);
+    box-shadow: inset 0 0 0 2px hsl(var(--accent));
   }
 
   &.hiddenBlock {
@@ -86,7 +86,7 @@
   transition: border-color 0.15s ease;
 
   &:has(button:hover) {
-    border-color: var(--phosphor);
+    border-color: hsl(var(--foreground) / 0.45);
   }
 }
 
@@ -107,7 +107,7 @@
 
   &.selected {
     background: hsl(var(--muted));
-    box-shadow: inset 0 0 0 2px var(--green);
+    box-shadow: inset 0 0 0 2px hsl(var(--accent));
   }
 
   &.hiddenBlock {
@@ -138,7 +138,7 @@
 
   &.selected {
     background: hsl(var(--muted));
-    box-shadow: inset 0 0 0 2px var(--green);
+    box-shadow: inset 0 0 0 2px hsl(var(--accent));
   }
 
   &.hiddenBlock {
@@ -191,7 +191,7 @@
   flex-shrink: 0;
 
   &[data-status='open'] {
-    background: var(--green);
+    background: var(--phosphor);
   }
 
   &[data-status='closed'] {
@@ -199,7 +199,7 @@
   }
 
   &[data-status='hidden'] {
-    background: #4b5563;
+    background: hsl(var(--muted-foreground));
   }
 }
 
@@ -213,7 +213,7 @@
 .liveBadge {
   font-size: 0.625rem;
   font-weight: 700;
-  color: var(--green);
+  color: var(--phosphor);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   flex-shrink: 0;
@@ -250,7 +250,7 @@
   flex-shrink: 0;
 
   &[data-status='open'] {
-    background: var(--green);
+    background: var(--phosphor);
   }
 
   &[data-status='closed'] {
@@ -258,12 +258,12 @@
   }
 
   &[data-status='hidden'] {
-    background: #4b5563;
+    background: hsl(var(--muted-foreground));
   }
 }
 
 .statusBadgeIndex {
   font-size: 0.625rem;
-  color: white;
+  color: hsl(var(--foreground));
   line-height: 1;
 }

--- a/app/frontend/Pages/Manage/Viewer/BlockSidebar.tsx
+++ b/app/frontend/Pages/Manage/Viewer/BlockSidebar.tsx
@@ -80,13 +80,15 @@ export default function BlockSidebar({
           })}
         >
           {!sidebarCollapsed && (
-            <button onClick={onCreateBlock} title="Create Block">
+            <button onClick={onCreateBlock} title="Create block" aria-label="Create block">
               <Plus size={16} />
             </button>
           )}
           <button
             onClick={onToggleSidebar}
             title={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            aria-label={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            aria-expanded={!sidebarCollapsed}
           >
             {sidebarCollapsed ? <ChevronRight size={16} /> : <ChevronLeft size={16} />}
           </button>
@@ -161,7 +163,7 @@ export default function BlockSidebar({
               );
             })}
             <li>
-              <button onClick={onCreateBlock} title="Create Block">
+              <button onClick={onCreateBlock} title="Create block" aria-label="Create block">
                 <Plus size={32} />
               </button>
             </li>

--- a/app/frontend/Pages/Manage/Viewer/BlockSidebar.tsx
+++ b/app/frontend/Pages/Manage/Viewer/BlockSidebar.tsx
@@ -80,7 +80,7 @@ export default function BlockSidebar({
           })}
         >
           {!sidebarCollapsed && (
-            <button onClick={onCreateBlock} title="Create block" aria-label="Create block">
+            <button onClick={onCreateBlock} title="Create Block" aria-label="Create Block">
               <Plus size={16} />
             </button>
           )}
@@ -163,7 +163,7 @@ export default function BlockSidebar({
               );
             })}
             <li>
-              <button onClick={onCreateBlock} title="Create block" aria-label="Create block">
+              <button onClick={onCreateBlock} title="Create Block" aria-label="Create Block">
                 <Plus size={32} />
               </button>
             </li>

--- a/app/frontend/Pages/Manage/Viewer/DebugPanel/DebugPanel.module.scss
+++ b/app/frontend/Pages/Manage/Viewer/DebugPanel/DebugPanel.module.scss
@@ -10,7 +10,7 @@
   gap: 0.5rem;
   font-size: 1.125rem;
   font-weight: 600;
-  color: var(--phosphor);
+  color: hsl(var(--foreground));
 }
 
 .content {
@@ -178,7 +178,7 @@
 
 .progressFill {
   height: 100%;
-  background: var(--green);
+  background: hsl(var(--primary));
   transition: width 0.2s;
 }
 
@@ -210,6 +210,6 @@
 
   &[data-status='open'] {
     background: var(--phosphor-glow);
-    color: var(--green);
+    color: var(--phosphor);
   }
 }

--- a/app/frontend/Pages/Manage/Viewer/ManageViewer.tsx
+++ b/app/frontend/Pages/Manage/Viewer/ManageViewer.tsx
@@ -25,16 +25,14 @@ import DebugPanel from './DebugPanel/DebugPanel';
 
 function ExperienceActionButton() {
   const { experience } = useExperience();
-  const { startExperience, isLoading: starting } = useExperienceStart();
-  const { pauseExperience, isLoading: pausing } = useExperiencePause();
-  const { resumeExperience, isLoading: resuming } = useExperienceResume();
+  const { startExperience } = useExperienceStart();
+  const { pauseExperience } = useExperiencePause();
+  const { resumeExperience } = useExperienceResume();
 
   if (!experience) return null;
 
   const config = ((): {
     onClick: () => void;
-    loading: boolean;
-    loadingText: string;
     icon: React.ReactNode;
     label: string;
     variant?: 'primary' | 'secondary' | 'ghost';
@@ -44,16 +42,12 @@ function ExperienceActionButton() {
       case 'lobby':
         return {
           onClick: startExperience,
-          loading: starting,
-          loadingText: 'Starting...',
           icon: <Play size={16} />,
           label: 'Start',
         };
       case 'live':
         return {
           onClick: pauseExperience,
-          loading: pausing,
-          loadingText: 'Pausing...',
           icon: <Pause size={16} />,
           label: 'Pause',
           variant: 'secondary',
@@ -61,8 +55,6 @@ function ExperienceActionButton() {
       case 'paused':
         return {
           onClick: resumeExperience,
-          loading: resuming,
-          loadingText: 'Resuming...',
           icon: <Play size={16} />,
           label: 'Resume',
         };
@@ -74,12 +66,7 @@ function ExperienceActionButton() {
   if (!config) return null;
 
   return (
-    <Button
-      variant={config.variant}
-      onClick={config.onClick}
-      loading={config.loading}
-      loadingText={config.loadingText}
-    >
+    <Button variant={config.variant} onClick={config.onClick}>
       {config.icon}
       <span>{config.label}</span>
     </Button>

--- a/app/frontend/Pages/Monitor/LobbyAvatars.test.tsx
+++ b/app/frontend/Pages/Monitor/LobbyAvatars.test.tsx
@@ -150,7 +150,7 @@ describe('LobbyAvatars', () => {
 
     // Charlie (p3) — not responded, grayed
     expect(groups[1].dataset.opacity).toBe('0.3');
-    expect(lines[1].dataset.stroke).toBe('#666');
+    expect(lines[1].dataset.stroke).toBe('hsl(60 4% 35%)');
 
     // Host (p1) — never grayed
     expect(groups[2].dataset.opacity).toBe('1');
@@ -194,7 +194,7 @@ describe('LobbyAvatars', () => {
 
     // Bob — not responded, grayed
     expect(groups[0].dataset.opacity).toBe('0.3');
-    expect(lines[0].dataset.stroke).toBe('#666');
+    expect(lines[0].dataset.stroke).toBe('hsl(60 4% 35%)');
 
     // Charlie — responded, full color
     expect(groups[1].dataset.opacity).toBe('1');

--- a/app/frontend/Pages/Monitor/LobbyAvatars.tsx
+++ b/app/frontend/Pages/Monitor/LobbyAvatars.tsx
@@ -131,7 +131,7 @@ export default function LobbyAvatars() {
         }
 
         const node = groupRefsRef.current.get(id);
-        if (node) {
+        if (node && typeof node.position === 'function') {
           const scale = BASE_SCALE * (1 + SCALE_AMPLITUDE * Math.sin(m.scalePhase));
           node.position({ x: m.x, y: m.y });
           node.scale({ x: scale, y: scale });
@@ -171,12 +171,12 @@ export default function LobbyAvatars() {
                     if (node) {
                       groupRefsRef.current.set(p.id, node);
                       const m = motionsRef.current.get(p.id);
-                      if (m) {
+                      if (m && typeof node.position === 'function') {
                         node.position({ x: m.x, y: m.y });
                         const s = BASE_SCALE * (1 + SCALE_AMPLITUDE * Math.sin(m.scalePhase));
                         node.scale({ x: s, y: s });
                       }
-                    } else {
+                    } else if (!node) {
                       groupRefsRef.current.delete(p.id);
                     }
                   }}

--- a/app/frontend/Pages/Monitor/LobbyAvatars.tsx
+++ b/app/frontend/Pages/Monitor/LobbyAvatars.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 
+import type Konva from 'konva';
 import { Group, Layer, Line, Stage } from 'react-konva';
 
 import { useExperience } from '@cctv/contexts/ExperienceContext';
@@ -77,9 +78,10 @@ export default function LobbyAvatars() {
   const hasActiveBlock = !!monitorView?.blocks[0] || !!monitorView?.participant_block_active;
 
   const motionsRef = useRef<Map<string, AvatarMotion>>(new Map());
+  const groupRefsRef = useRef<Map<string, Konva.Group>>(new Map());
+  const layerRef = useRef<Konva.Layer>(null);
   const rafRef = useRef<number | null>(null);
   const lastTimeRef = useRef<number | null>(null);
-  const [, forceUpdate] = useState(0);
 
   const prevSizeRef = useRef(size);
   useEffect(() => {
@@ -108,7 +110,7 @@ export default function LobbyAvatars() {
         lastTimeRef.current !== null ? Math.min((timestamp - lastTimeRef.current) / 1000, 0.1) : 0;
       lastTimeRef.current = timestamp;
 
-      for (const m of motionsRef.current.values()) {
+      for (const [id, m] of motionsRef.current.entries()) {
         m.x += m.vx * dt;
         m.y += m.vy * dt;
         m.scalePhase += m.scaleFreq * dt;
@@ -127,9 +129,16 @@ export default function LobbyAvatars() {
           m.y = maxY;
           m.vy = -Math.abs(m.vy);
         }
+
+        const node = groupRefsRef.current.get(id);
+        if (node) {
+          const scale = BASE_SCALE * (1 + SCALE_AMPLITUDE * Math.sin(m.scalePhase));
+          node.position({ x: m.x, y: m.y });
+          node.scale({ x: scale, y: scale });
+        }
       }
 
-      forceUpdate((n) => n + 1);
+      layerRef.current?.batchDraw();
       rafRef.current = requestAnimationFrame(animate);
     };
 
@@ -144,7 +153,7 @@ export default function LobbyAvatars() {
     <div className={styles.root}>
       <div className={styles.stageWrap} ref={containerRef}>
         <Stage width={size.w} height={size.h}>
-          <Layer>
+          <Layer ref={layerRef}>
             {participants.map((p) => {
               const strokes = drawState.strokes[p.id] ?? [];
               if (!strokes.length) return null;
@@ -152,23 +161,36 @@ export default function LobbyAvatars() {
               const motion = motionsRef.current.get(p.id);
               if (!motion) return null;
 
-              const scale = BASE_SCALE * (1 + SCALE_AMPLITUDE * Math.sin(motion.scalePhase));
+              const initialScale = BASE_SCALE * (1 + SCALE_AMPLITUDE * Math.sin(motion.scalePhase));
               const isGrayed = hasActiveBlock && p.role !== 'host' && !respondedIds.has(p.id);
 
               return (
                 <Group
                   key={p.id}
+                  ref={(node) => {
+                    if (node) {
+                      groupRefsRef.current.set(p.id, node);
+                      const m = motionsRef.current.get(p.id);
+                      if (m) {
+                        node.position({ x: m.x, y: m.y });
+                        const s = BASE_SCALE * (1 + SCALE_AMPLITUDE * Math.sin(m.scalePhase));
+                        node.scale({ x: s, y: s });
+                      }
+                    } else {
+                      groupRefsRef.current.delete(p.id);
+                    }
+                  }}
                   x={motion.x}
                   y={motion.y}
-                  scaleX={scale}
-                  scaleY={scale}
+                  scaleX={initialScale}
+                  scaleY={initialScale}
                   opacity={isGrayed ? 0.3 : 1}
                 >
                   {strokes.map((s, idx) => (
                     <Line
                       key={idx}
                       points={s.points}
-                      stroke={isGrayed ? '#666' : s.color}
+                      stroke={isGrayed ? 'hsl(60 4% 35%)' : s.color}
                       strokeWidth={s.width}
                       lineCap="round"
                     />

--- a/app/frontend/Pages/Monitor/Monitor.module.scss
+++ b/app/frontend/Pages/Monitor/Monitor.module.scss
@@ -45,8 +45,7 @@
   padding: var(--space-xs);
   border: 1px solid hsl(var(--border));
   border-radius: 8px;
-  background: hsl(var(--popover) / 0.7);
-  backdrop-filter: blur(6px);
+  background: hsl(var(--popover));
   max-width: 40vw;
   max-height: 40vh;
 }
@@ -61,7 +60,7 @@
 }
 
 .error {
-  color: var(--phosphor);
+  color: hsl(var(--destructive));
   text-shadow: none;
 }
 .participantNotification {
@@ -75,8 +74,7 @@
   color: var(--hot-white);
   text-align: center;
   padding: var(--space-md) var(--space-lg);
-  background: hsl(var(--popover) / 0.85);
-  backdrop-filter: blur(8px);
+  background: hsl(var(--popover));
   border: 1px solid hsl(var(--border));
   border-radius: 12px;
   letter-spacing: 0.02em;

--- a/app/frontend/Pages/Monitor/ParticipantsMenu.module.scss
+++ b/app/frontend/Pages/Monitor/ParticipantsMenu.module.scss
@@ -3,12 +3,11 @@
   top: var(--space-sm);
   left: var(--space-sm);
   z-index: 10;
-  width: 220px;
+  width: min(220px, calc(100vw - 2 * var(--space-sm)));
   padding: var(--space-xs) var(--space-xs);
   border-radius: 0.5rem;
   border: 1px solid hsl(var(--border));
-  background: hsl(var(--popover) / 0.7);
-  backdrop-filter: blur(6px);
+  background: hsl(var(--popover));
   overflow: hidden;
 }
 

--- a/app/frontend/Pages/Performers/Performers.module.scss
+++ b/app/frontend/Pages/Performers/Performers.module.scss
@@ -70,39 +70,48 @@
 }
 
 .grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 0;
+  display: flex;
+  flex-direction: column;
   border-top: 1px solid hsl(var(--border));
-  border-left: 1px solid hsl(var(--border));
 }
 
 .card {
   display: flex;
-  gap: var(--space-sm);
-  padding: var(--space-md);
-  border-right: 1px solid hsl(var(--border));
+  gap: var(--space-md);
+  align-items: center;
+  padding: var(--space-sm) var(--space-xs);
   border-bottom: 1px solid hsl(var(--border));
   text-decoration: none;
   color: inherit;
   transition: background 0.15s;
-  position: relative;
-
-  &::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border: 0 solid hsl(var(--primary));
-    pointer-events: none;
-    transition: border-width 0.15s;
-  }
 
   &:hover {
     background: hsl(var(--primary) / 0.04);
   }
 
-  &:hover::before {
-    border-left-width: 2px;
+  &:first-child {
+    padding-top: var(--space-md);
+    padding-bottom: var(--space-md);
+    gap: var(--space-md);
+  }
+
+  &:first-child .photo,
+  &:first-child .photoPlaceholder {
+    width: 96px;
+    height: 96px;
+  }
+
+  &:first-child .photoPlaceholder {
+    font-size: 2.75rem;
+  }
+
+  &:first-child .cardName {
+    font-size: clamp(1.75rem, 4vw, 2.25rem);
+  }
+
+  &:first-child .cardBio {
+    font-size: 0.9375rem;
+    -webkit-line-clamp: 3;
   }
 }
 
@@ -265,7 +274,7 @@
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-weight: 700;
-  color: var(--phosphor);
+  color: hsl(var(--muted-foreground));
   text-align: left;
   line-height: 1;
 }
@@ -412,26 +421,10 @@
   padding: var(--space-sm) var(--space-xs);
   text-decoration: none;
   color: inherit;
-  position: relative;
   transition: background 0.15s;
-
-  &::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    width: 0;
-    background: hsl(var(--primary));
-    transition: width 0.15s ease;
-  }
 
   &:hover {
     background: hsl(var(--primary) / 0.04);
-  }
-
-  &:hover::before {
-    width: 2px;
   }
 }
 

--- a/app/frontend/Pages/Performers/PerformersList.tsx
+++ b/app/frontend/Pages/Performers/PerformersList.tsx
@@ -54,6 +54,7 @@ function PerformerCard({ performer }: { performer: Performer }) {
           alt={performer.name}
           className={styles.photo}
           loading="lazy"
+          decoding="async"
           width={60}
           height={60}
         />

--- a/app/frontend/Pages/Playbill/Playbill.module.scss
+++ b/app/frontend/Pages/Playbill/Playbill.module.scss
@@ -5,6 +5,7 @@
   padding: var(--space-sm);
   position: relative;
   z-index: 10;
+  text-align: center;
 }
 
 .title {
@@ -33,10 +34,10 @@
   align-items: center;
   justify-content: center;
   background: var(--phosphor);
-  color: #000;
+  color: var(--black);
   border: none;
   cursor: pointer;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-md);
   text-decoration: none;
 }
 

--- a/app/frontend/Pages/Playbill/Playbill.tsx
+++ b/app/frontend/Pages/Playbill/Playbill.tsx
@@ -70,7 +70,9 @@ export default function Playbill() {
                   <img
                     className={styles.image}
                     src={section.image_url}
-                    alt={`Section ${index + 1} Image`}
+                    alt={section.title || `Playbill section ${index + 1}`}
+                    loading="lazy"
+                    decoding="async"
                   />
                 </div>
               )}

--- a/app/frontend/Pages/Register.tsx
+++ b/app/frontend/Pages/Register.tsx
@@ -74,18 +74,28 @@ export default function Register() {
       </div>
       <form className={styles.form} onSubmit={handleSubmit}>
         {!isAuthenticated && (
-          <input
-            className={styles.input}
-            type="email"
-            placeholder="Your Email"
-            value={email}
-            onChange={handleEmailChange}
-            onKeyPress={handleKeyPress}
-            disabled={isLoading}
-            maxLength={100}
-          />
+          <>
+            <label htmlFor="register-email" className="sr-only">
+              Your email
+            </label>
+            <input
+              id="register-email"
+              className={styles.input}
+              type="email"
+              placeholder="Your Email"
+              value={email}
+              onChange={handleEmailChange}
+              onKeyPress={handleKeyPress}
+              disabled={isLoading}
+              maxLength={100}
+            />
+          </>
         )}
+        <label htmlFor="register-name" className="sr-only">
+          Your name
+        </label>
         <input
+          id="register-name"
           className={styles.input}
           type="text"
           placeholder="Your Name"
@@ -95,7 +105,11 @@ export default function Register() {
           disabled={isLoading}
           maxLength={100}
         />
-        {error && <p className={`error-message ${styles.error}`}>{error}</p>}
+        {error && (
+          <p className={`error-message ${styles.error}`} role="alert" aria-live="polite">
+            {error}
+          </p>
+        )}
         <Button
           className="join-submit"
           type="submit"

--- a/app/frontend/Pages/TicketRip.tsx
+++ b/app/frontend/Pages/TicketRip.tsx
@@ -1,4 +1,4 @@
-import { PointerEvent, useCallback, useEffect, useRef, useState } from 'react';
+import { KeyboardEvent, PointerEvent, useCallback, useEffect, useRef, useState } from 'react';
 
 import * as THREE from 'three';
 import * as Tone from 'tone';
@@ -569,21 +569,35 @@ export default function TicketRip({ code, experienceName = '', onComplete }: Tic
     onCompleteRef.current();
   }, []);
 
+  const activate = useCallback(() => {
+    const phase = animRef.current.phase;
+    if (phase === 'hovering') {
+      animRef.current.phase = 'shaking';
+      animRef.current.time = 0;
+      setCaption('validating');
+      return;
+    }
+    if (phase === 'success') {
+      fireComplete();
+    }
+  }, [fireComplete]);
+
   const handlePointerDown = useCallback(
     (e: PointerEvent<HTMLDivElement>) => {
       e.preventDefault();
-      const phase = animRef.current.phase;
-      if (phase === 'hovering') {
-        animRef.current.phase = 'shaking';
-        animRef.current.time = 0;
-        setCaption('validating');
-        return;
-      }
-      if (phase === 'success') {
-        fireComplete();
+      activate();
+    },
+    [activate],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === ' ' || e.key === 'Enter') {
+        e.preventDefault();
+        activate();
       }
     },
-    [fireComplete],
+    [activate],
   );
 
   useEffect(() => {
@@ -1026,6 +1040,7 @@ export default function TicketRip({ code, experienceName = '', onComplete }: Tic
     <div
       className={styles.root}
       onPointerDown={handlePointerDown}
+      onKeyDown={handleKeyDown}
       role="button"
       tabIndex={0}
       aria-label={caption === 'tap-rip' ? 'Tap to tear ticket' : 'Tap to continue'}

--- a/app/frontend/Pages/Timeline/Timeline.module.scss
+++ b/app/frontend/Pages/Timeline/Timeline.module.scss
@@ -8,53 +8,110 @@
   color: hsl(var(--foreground));
   overflow: hidden;
   --row-h: 5.5rem;
+  --col-min-w: 13rem;
+  --rule-color: hsl(var(--border));
+  --rule-color-soft: hsl(var(--border) / 0.55);
+
+  @media (max-width: 768px) {
+    --col-min-w: 9rem;
+    --row-h: 4.5rem;
+  }
 }
+
+/* ─── Header ─── */
 
 .header {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   justify-content: space-between;
-  padding: 1rem;
-  height: 5rem;
-  border-bottom: 1px solid hsl(var(--border));
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md) 0.75rem;
+  border-bottom: 1px solid var(--rule-color);
   flex-shrink: 0;
 }
 
 .headerLeft {
   display: flex;
-  align-items: center;
-  gap: 0.75rem;
+  align-items: baseline;
+  gap: 0.625rem;
+  min-width: 0;
+}
+
+.titleStack {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.125rem;
+  min-width: 0;
+}
+
+.titleKicker {
+  font-family: var(--font-body);
+  font-size: 0.6875rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+  text-shadow: none;
+  line-height: 1;
 }
 
 .title {
-  font-size: 1.125rem;
-  font-weight: 600;
+  font-family: var(--font-display);
+  font-size: 1.875rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   color: hsl(var(--foreground));
+  line-height: 0.95;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 38ch;
 }
 
 .headerRight {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.375rem;
+  flex-shrink: 0;
 }
 
 .navToggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
-  padding: 0.375rem 0.75rem;
-  font-size: 0.875rem;
-  border: 1px solid hsl(var(--border));
-  border-radius: 0.375rem;
+  gap: 0.4375rem;
+  padding: 0.4375rem 0.75rem;
+  font-family: var(--font-ui);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
   color: hsl(var(--foreground));
   background: transparent;
+  border: 1px solid var(--rule-color);
+  border-radius: 0;
   cursor: pointer;
-  transition: background 0.15s;
+  text-decoration: none;
+  text-shadow: none;
+  transition:
+    border-color 0.12s ease,
+    color 0.12s ease,
+    background 0.12s ease;
 
   &:hover {
+    border-color: hsl(var(--foreground) / 0.45);
+    color: hsl(var(--foreground));
     background: hsl(var(--muted));
   }
+
+  &:focus-visible {
+    border-color: var(--phosphor);
+    color: hsl(var(--foreground));
+    background: hsl(var(--muted));
+    outline: none;
+  }
 }
+
+/* ─── Board ─── */
 
 .board {
   flex: 1;
@@ -63,68 +120,102 @@
   min-height: 0;
 }
 
+/* Column-header row matches headerStrip height across the three sub-columns
+   so cue numbers, "TRACKS" caption, and "PREVIEW" caption all align. */
+.headerStrip {
+  height: 2.25rem;
+  flex-shrink: 0;
+}
+
+/* ─── Track label column (left) ─── */
+
 .trackLabelCol {
-  width: 10rem;
+  width: 11rem;
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  border-right: 1px solid hsl(var(--border));
-  background: hsl(var(--card));
+  border-right: 1px solid var(--rule-color);
+  background: hsl(var(--background));
 }
 
 .trackLabelHeader {
-  height: 2.5rem;
-  border-bottom: 1px solid hsl(var(--border));
+  composes: headerStrip;
   display: flex;
   align-items: center;
   padding: 0 0.75rem;
-  font-size: 0.75rem;
+  border-bottom: 1px solid var(--rule-color);
+  font-family: var(--font-body);
+  font-size: 0.625rem;
+  letter-spacing: 0.28em;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
   color: hsl(var(--muted-foreground));
+  text-shadow: none;
 }
 
 .trackLabel {
   flex: 0 0 var(--row-h);
   height: var(--row-h);
-  padding: 0.75rem;
+  padding: 0 0.75rem;
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  border-bottom: 1px solid hsl(var(--border));
+  border-bottom: 1px solid var(--rule-color-soft);
+  font-family: var(--font-ui);
   font-size: 0.875rem;
-  font-weight: 500;
-  color: hsl(var(--card-foreground));
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: hsl(var(--foreground));
+  text-shadow: none;
 
   &:last-child {
     border-bottom: none;
   }
+
+  /* Lucide icons inherit color */
+  > svg {
+    color: hsl(var(--muted-foreground));
+    flex-shrink: 0;
+  }
+}
+
+/* Monitor is THE projection track — pull its weight up. */
+.trackLabel:first-child {
+  font-family: var(--font-display);
+  font-size: 1.125rem;
+  letter-spacing: 0.06em;
 }
 
 .trackLabelAudience {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  font-weight: 600;
+  font-family: var(--font-ui);
+  font-size: 0.8125rem;
+  letter-spacing: 0.14em;
   color: hsl(var(--muted-foreground));
 }
 
 .trackLabelSegment {
-  padding-left: 1.75rem;
-  font-size: 0.8125rem;
+  padding-left: 1.625rem;
+  font-family: var(--font-body);
+  font-size: 0.75rem;
   font-weight: 400;
+  letter-spacing: 0.06em;
+  text-transform: none;
   color: hsl(var(--muted-foreground));
 }
 
 .segmentSwatch {
-  width: 0.75rem;
-  height: 0.75rem;
-  border-radius: 0.25rem;
+  width: 0.625rem;
+  height: 0.625rem;
   flex-shrink: 0;
+  /* a flag, not a chip — sharper edges */
+  clip-path: polygon(0 0, 100% 0, 100% 70%, 50% 100%, 0 70%);
 }
+
+/* ─── Scroll area + columns ─── */
 
 .scroll {
   flex: 1;
+  min-width: 0;
   overflow-x: auto;
   overflow-y: hidden;
   display: flex;
@@ -132,43 +223,63 @@
 }
 
 .columnHeaderRow {
+  composes: headerStrip;
   display: flex;
-  height: 2.5rem;
-  border-bottom: 1px solid hsl(var(--border));
-  flex-shrink: 0;
+  border-bottom: 1px solid var(--rule-color);
+  background: hsl(var(--background));
 }
 
 .columnHeader {
-  min-width: 12rem;
+  width: var(--col-min-w);
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
   color: hsl(var(--muted-foreground));
-  border-right: 1px solid hsl(var(--border));
-  cursor: pointer;
+  border-right: 1px solid var(--rule-color-soft);
   background: transparent;
   border-top: none;
   border-bottom: none;
   border-left: none;
-  transition: background 0.15s;
+  cursor: pointer;
+  text-shadow: none;
+  position: relative;
+  padding: 0;
 
   &:hover {
-    background: hsl(var(--muted) / 0.4);
     color: hsl(var(--foreground));
+    background: hsl(var(--muted));
+  }
+
+  &:focus-visible {
+    outline: 1px solid var(--phosphor);
+    outline-offset: -3px;
   }
 }
 
 .columnHeaderSelected {
-  background: hsl(var(--muted));
   color: hsl(var(--foreground));
+  background: hsl(var(--muted));
+
+  /* Cue-mark: a precise 2px underline, like a tape mark */
+  &::after {
+    content: '';
+    position: absolute;
+    left: 50%;
+    bottom: 0;
+    width: 1.5rem;
+    height: 2px;
+    transform: translateX(-50%);
+    background: hsl(var(--accent));
+  }
 }
 
 .cellSelected {
-  background: hsl(var(--muted) / 0.25);
+  background: hsl(var(--muted));
 }
 
 .rows {
@@ -183,7 +294,7 @@
   display: flex;
   flex: 0 0 var(--row-h);
   height: var(--row-h);
-  border-bottom: 1px solid hsl(var(--border));
+  border-bottom: 1px solid var(--rule-color-soft);
 
   &:last-child {
     border-bottom: none;
@@ -191,50 +302,57 @@
 }
 
 .cell {
-  min-width: 12rem;
+  width: var(--col-min-w);
   flex-shrink: 0;
-  border-right: 1px solid hsl(var(--border));
+  border-right: 1px solid var(--rule-color-soft);
   padding: 0.5rem;
   display: flex;
   flex-direction: column;
   gap: 0.375rem;
-  transition: background 0.15s;
+  overflow: hidden;
+  transition: background 0.12s ease;
 }
 
 .cellDroppableOver {
-  background: hsl(var(--muted) / 0.5);
+  background: hsl(var(--accent) / 0.08);
+  outline: 1px dashed hsl(var(--accent));
+  outline-offset: -2px;
 }
 
 .placeholder {
   flex: 1;
-  border: 1px dashed hsl(var(--border));
-  border-radius: 0.375rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.75rem;
+  font-family: var(--font-body);
+  font-size: 0.875rem;
   color: hsl(var(--muted-foreground));
-  opacity: 0.5;
+  opacity: 0.45;
+  text-shadow: none;
+  user-select: none;
 }
 
+/* ─── Block cards ─── */
+
 .blockCard {
-  border: 1px solid hsl(var(--border));
-  background: hsl(var(--card));
-  color: hsl(var(--card-foreground));
-  border-radius: 0.375rem;
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--rule-color);
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
   padding: 0.5rem 0.625rem;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.3125rem;
   cursor: grab;
   user-select: none;
+  text-shadow: none;
   transition:
-    border-color 0.15s,
-    box-shadow 0.15s,
-    transform 0.15s;
+    border-color 0.12s ease,
+    background 0.12s ease;
 
   &:hover {
-    border-color: hsl(var(--primary));
+    border-color: hsl(var(--foreground) / 0.45);
   }
 
   &:active {
@@ -243,57 +361,104 @@
 }
 
 .blockCardDragging {
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
-  border-color: hsl(var(--primary));
+  border-color: hsl(var(--accent));
+  background: hsl(var(--accent) / 0.08);
 }
 
+/* "Ghost" copies in non-monitor tracks: outlined, no fill, dimmed. */
 .blockCardGhost {
-  opacity: 0.6;
+  background: transparent;
   border-style: dashed;
+  border-color: var(--rule-color-soft);
   cursor: default;
+  opacity: 0.7;
 
   &:hover {
-    border-color: hsl(var(--border));
+    border-color: var(--rule-color);
   }
 }
 
+/* The LIVE block. This is the only place phosphor wash lives. */
 .blockCardActive {
-  border-color: hsl(var(--primary));
-  box-shadow: 0 0 0 1px hsl(var(--primary));
+  border-color: var(--phosphor);
+  background: var(--phosphor-glow-faint);
 }
 
 .blockHeader {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
-  font-size: 0.75rem;
+  gap: 0.4375rem;
+  font-family: var(--font-body);
+  font-size: 0.6875rem;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
   color: hsl(var(--muted-foreground));
+  text-shadow: none;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .blockKind {
-  font-weight: 600;
+  font-weight: 700;
+  color: hsl(var(--foreground));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  /* bracket the kind like a cue type marker */
+  &::before {
+    content: '[';
+    color: hsl(var(--muted-foreground));
+    margin-right: 1px;
+  }
+  &::after {
+    content: ']';
+    color: hsl(var(--muted-foreground));
+    margin-left: 1px;
+  }
 }
 
 .blockStatusDot {
   width: 0.5rem;
   height: 0.5rem;
-  border-radius: 999px;
+  flex-shrink: 0;
   background: hsl(var(--muted-foreground));
+  /* hard square dot, like a status LED on a patch panel */
+  border-radius: 0;
+}
 
-  &.statusOpen {
-    background: hsl(var(--primary));
+.statusOpen {
+  background: var(--phosphor);
+  box-shadow: 0 0 6px var(--phosphor-glow-medium);
+  animation: statusPulse 1.6s ease-in-out infinite;
+}
+
+.statusClosed {
+  background: var(--amber);
+}
+
+@keyframes statusPulse {
+  0%,
+  100% {
+    opacity: 1;
   }
+  50% {
+    opacity: 0.55;
+  }
+}
 
-  &.statusClosed {
-    background: hsl(var(--destructive, 0 72% 51%));
+@media (prefers-reduced-motion: reduce) {
+  .statusOpen {
+    animation: none;
   }
 }
 
 .blockLabel {
+  font-family: var(--font-body);
   font-size: 0.875rem;
-  line-height: 1.2;
+  line-height: 1.25;
+  color: hsl(var(--foreground));
+  text-shadow: none;
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
@@ -303,19 +468,32 @@
 
 .blockChildren {
   display: flex;
+  align-items: center;
   gap: 0.25rem;
-  margin-top: 0.25rem;
+  margin-top: 0.125rem;
   flex-wrap: wrap;
+  font-family: var(--font-body);
+  font-size: 0.625rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+  text-shadow: none;
 }
 
 .childChip {
-  font-size: 0.6875rem;
-  padding: 0.125rem 0.375rem;
-  border-radius: 0.25rem;
-  background: hsl(var(--muted));
-  color: hsl(var(--muted-foreground));
-  border: 1px solid hsl(var(--border));
+  /* No card-on-card. Just a typed token with a leading mark. */
+  display: inline-flex;
+  align-items: center;
+
+  &::before {
+    content: '→';
+    margin-right: 0.25rem;
+    color: hsl(var(--muted-foreground));
+    opacity: 0.6;
+  }
 }
+
+/* ─── Empty state ─── */
 
 .emptyState {
   flex: 1;
@@ -323,93 +501,262 @@
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  gap: 0.5rem;
-  color: hsl(var(--muted-foreground));
+  gap: 0.625rem;
+  padding: var(--space-md);
+  font-family: var(--font-body);
   font-size: 0.875rem;
+  color: hsl(var(--muted-foreground));
+  text-shadow: none;
+  text-align: center;
 }
 
+/* ─── Preview panel (right) ─── */
+
 .previewCol {
-  width: 16rem;
+  width: 19rem;
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  border-left: 1px solid hsl(var(--border));
-  background: hsl(var(--card));
+  border-left: 1px solid var(--rule-color);
+  background: hsl(var(--background));
 }
 
 .previewHeader {
-  height: 2.5rem;
-  padding: 0 0.75rem;
+  composes: headerStrip;
+  padding: 0 0.875rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  border-bottom: 1px solid hsl(var(--border));
-  font-size: 0.75rem;
+  border-bottom: 1px solid var(--rule-color);
+  font-family: var(--font-body);
+  font-size: 0.625rem;
+  letter-spacing: 0.28em;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
   color: hsl(var(--muted-foreground));
+  text-shadow: none;
 }
 
 .previewColumnLabel {
+  font-family: var(--font-body);
+  font-weight: 700;
+  letter-spacing: 0.16em;
   color: hsl(var(--foreground));
-  font-weight: 600;
 }
 
-.previewRows {
+.previewIdle {
   flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow-y: auto;
-}
-
-.previewRow {
-  flex: 0 0 var(--row-h);
-  height: var(--row-h);
-  padding: 0.5rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-bottom: 1px solid hsl(var(--border));
+  padding: var(--space-md);
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  letter-spacing: 0.04em;
+  color: hsl(var(--muted-foreground));
+  text-shadow: none;
+  opacity: 0.7;
+}
+
+.previewBody {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+  padding: 0.875rem;
+  overflow-y: auto;
+}
+
+.previewSectionLabel {
+  display: flex;
+  align-items: center;
+  gap: 0.4375rem;
+  font-family: var(--font-body);
+  font-size: 0.625rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+  text-shadow: none;
+
+  > svg {
+    color: hsl(var(--muted-foreground));
+    flex-shrink: 0;
+  }
+}
+
+.previewMonitor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4375rem;
+}
+
+/* Big landscape Monitor preview — fills the column width, 16:9 aspect.
+   Inset shadow + corner brackets read as a CRT/viewfinder. */
+.previewFrame {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border: 1px solid var(--rule-color);
+  background: hsl(var(--background));
+  box-shadow:
+    inset 0 0 0 1px hsl(var(--background)),
+    inset 0 0 18px hsl(0 0% 0% / 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.625rem 0.75rem;
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  text-align: center;
+  line-height: 1.35;
+  color: hsl(var(--foreground));
+  text-shadow: none;
+  overflow: hidden;
+
+  /* viewfinder corner marks, sized to actually be visible at this scale */
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    width: 0.625rem;
+    height: 0.625rem;
+    border: 1px solid hsl(var(--muted-foreground));
+    opacity: 0.55;
+    pointer-events: none;
+  }
+  &::before {
+    top: 4px;
+    left: 4px;
+    border-right: none;
+    border-bottom: none;
+  }
+  &::after {
+    bottom: 4px;
+    right: 4px;
+    border-left: none;
+    border-top: none;
+  }
+}
+
+.previewFrameInner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.3125rem;
+  max-width: 100%;
+}
+
+.previewFrameLabel {
+  font-family: var(--font-body);
+  font-size: 0.875rem;
+  line-height: 1.25;
+  color: hsl(var(--foreground));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+}
+
+.previewKind {
+  font-family: var(--font-body);
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+}
+
+.previewEmpty {
+  opacity: 0.4;
+  font-size: 1.5rem;
+  letter-spacing: 0.04em;
+
+  /* hide corner brackets when empty — they're decorative for a real preview */
+  &::before,
+  &::after {
+    display: none;
+  }
+}
+
+/* ─── Participant tracks: typed Q-list rows (no aspect frames) ─── */
+
+.previewList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.previewItem {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.1875rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--rule-color-soft);
 
   &:last-child {
     border-bottom: none;
   }
 }
 
-.previewFrame {
-  border: 1px solid hsl(var(--border));
-  background: hsl(var(--background));
-  border-radius: 0.25rem;
-  overflow: hidden;
+.previewItemTrack {
   display: flex;
   align-items: center;
-  justify-content: center;
-  padding: 0.25rem 0.375rem;
+  gap: 0.4375rem;
+  font-family: var(--font-ui);
   font-size: 0.6875rem;
-  text-align: center;
-  line-height: 1.2;
-  color: hsl(var(--card-foreground));
-}
-
-.previewFrameLandscape {
-  width: 85%;
-  aspect-ratio: 16 / 9;
-}
-
-.previewFramePortrait {
-  height: 90%;
-  aspect-ratio: 9 / 16;
-}
-
-.previewEmpty {
-  opacity: 0.4;
-  font-style: italic;
-}
-
-.previewKind {
-  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
   color: hsl(var(--muted-foreground));
-  margin-bottom: 0.125rem;
+  text-shadow: none;
+}
+
+.previewItemContent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  padding-left: 0.0625rem;
+}
+
+.previewItemKind {
+  font-family: var(--font-body);
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+
+  &::before {
+    content: '[';
+    color: hsl(var(--muted-foreground));
+    margin-right: 1px;
+  }
+  &::after {
+    content: ']';
+    color: hsl(var(--muted-foreground));
+    margin-left: 1px;
+  }
+}
+
+.previewItemBody {
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  line-height: 1.3;
+  color: hsl(var(--foreground));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.previewItemEmpty {
+  font-family: var(--font-body);
+  font-size: 0.875rem;
+  color: hsl(var(--muted-foreground));
+  opacity: 0.45;
+  padding-left: 0.0625rem;
 }

--- a/app/frontend/Pages/Timeline/Timeline.tsx
+++ b/app/frontend/Pages/Timeline/Timeline.tsx
@@ -189,7 +189,10 @@ export default function Timeline() {
     <section className={styles.page}>
       <div className={styles.header}>
         <div className={styles.headerLeft}>
-          <div className={styles.title}>{experience?.name || 'Experience'} — Timeline</div>
+          <div className={styles.titleStack}>
+            <span className={styles.titleKicker}>Timeline</span>
+            <span className={styles.title}>{experience?.name || 'Experience'}</span>
+          </div>
         </div>
         <div className={styles.headerRight}>
           <button
@@ -263,7 +266,7 @@ export default function Timeline() {
                     [styles.columnHeaderSelected]: selectedColumn === col,
                   })}
                 >
-                  {col + 1}
+                  {String(col + 1).padStart(2, '0')}
                 </button>
               ))}
             </div>
@@ -352,42 +355,88 @@ export default function Timeline() {
             <div className={styles.previewHeader}>
               <span>Preview</span>
               {selectedColumn !== null && (
-                <span className={styles.previewColumnLabel}>Col {selectedColumn + 1}</span>
+                <span className={styles.previewColumnLabel}>
+                  Cue {String(selectedColumn + 1).padStart(2, '0')}
+                </span>
               )}
             </div>
-            <div className={styles.previewRows}>
-              {tracks.map((track) => {
-                const blocksAtCol =
-                  selectedColumn === null ? [] : blocksByColumn.get(selectedColumn) || [];
-                const visibleBlocks = blocksAtCol.filter((b) => blockIsVisibleOnTrack(b, track));
-                const previewBlock = visibleBlocks[0];
-                const isLandscape = track.kind === 'monitor';
-                return (
-                  <div key={track.id} className={styles.previewRow}>
-                    <div
-                      className={classNames(styles.previewFrame, {
-                        [styles.previewFrameLandscape]: isLandscape,
-                        [styles.previewFramePortrait]: !isLandscape,
-                        [styles.previewEmpty]: !previewBlock,
-                      })}
-                    >
-                      {selectedColumn === null ? (
-                        <span>Select a column</span>
-                      ) : previewBlock ? (
-                        <div>
-                          <div className={styles.previewKind}>
-                            {previewBlock.kind.replace(/_/g, ' ')}
+            {selectedColumn === null ? (
+              <div className={styles.previewIdle}>
+                <span>Select a cue</span>
+              </div>
+            ) : (
+              <div className={styles.previewBody}>
+                {(() => {
+                  const blocksAtCol = blocksByColumn.get(selectedColumn) || [];
+                  const monitorTrack = tracks.find((t) => t.kind === 'monitor');
+                  const monitorBlock = monitorTrack
+                    ? blocksAtCol.filter((b) => blockIsVisibleOnTrack(b, monitorTrack))[0]
+                    : undefined;
+                  return (
+                    <div className={styles.previewMonitor}>
+                      <div className={styles.previewSectionLabel}>
+                        <MonitorIcon size={11} />
+                        <span>Monitor</span>
+                      </div>
+                      <div
+                        className={classNames(styles.previewFrame, {
+                          [styles.previewEmpty]: !monitorBlock,
+                        })}
+                      >
+                        {monitorBlock ? (
+                          <div className={styles.previewFrameInner}>
+                            <div className={styles.previewKind}>
+                              {monitorBlock.kind.replace(/_/g, ' ')}
+                            </div>
+                            <div className={styles.previewFrameLabel}>
+                              {blockLabel(monitorBlock)}
+                            </div>
                           </div>
-                          <div>{blockLabel(previewBlock)}</div>
-                        </div>
-                      ) : (
-                        <span>—</span>
-                      )}
+                        ) : (
+                          <span>—</span>
+                        )}
+                      </div>
                     </div>
-                  </div>
-                );
-              })}
-            </div>
+                  );
+                })()}
+
+                <div className={styles.previewSectionLabel}>
+                  <Users size={11} />
+                  <span>Participants</span>
+                </div>
+                <ul className={styles.previewList}>
+                  {tracks
+                    .filter((t) => t.kind !== 'monitor')
+                    .map((track) => {
+                      const blocksAtCol = blocksByColumn.get(selectedColumn) || [];
+                      const block = blocksAtCol.filter((b) => blockIsVisibleOnTrack(b, track))[0];
+                      return (
+                        <li key={track.id} className={styles.previewItem}>
+                          <div className={styles.previewItemTrack}>
+                            {track.kind === 'segment' && (
+                              <span
+                                className={styles.segmentSwatch}
+                                style={{ background: track.segment.color }}
+                              />
+                            )}
+                            <span>{track.label}</span>
+                          </div>
+                          {block ? (
+                            <div className={styles.previewItemContent}>
+                              <span className={styles.previewItemKind}>
+                                {block.kind.replace(/_/g, ' ')}
+                              </span>
+                              <span className={styles.previewItemBody}>{blockLabel(block)}</span>
+                            </div>
+                          ) : (
+                            <span className={styles.previewItemEmpty}>—</span>
+                          )}
+                        </li>
+                      );
+                    })}
+                </ul>
+              </div>
+            )}
           </div>
         </div>
       </DragDropContext>

--- a/app/frontend/Pages/join.tsx
+++ b/app/frontend/Pages/join.tsx
@@ -11,7 +11,7 @@ import {
 
 import { useSearchParams } from 'react-router-dom';
 
-import { Html5Qrcode } from 'html5-qrcode';
+import type { Html5Qrcode } from 'html5-qrcode';
 import { Camera } from 'lucide-react';
 
 import { Button } from '@cctv/core/Button/Button';
@@ -108,6 +108,9 @@ export default function Join() {
   const startScanner = useCallback(async () => {
     if (!readerRef.current || scannerRef.current) return;
 
+    const { Html5Qrcode } = await import('html5-qrcode');
+    if (!readerRef.current || scannerRef.current) return;
+
     const scanner = new Html5Qrcode(readerRef.current.id);
     scannerRef.current = scanner;
 
@@ -171,10 +174,11 @@ export default function Join() {
     <section className="page flex-centered">
       <div className={styles.header}>
         {registrationInfo?.experience?.name && <p>{registrationInfo.experience.name}</p>}
-        <p>Enter the secret code:</p>
+        <label htmlFor="join-code">Enter the secret code:</label>
       </div>
       <form className={styles.form} onSubmit={handleSubmit}>
         <input
+          id="join-code"
           type="text"
           placeholder="Secret Code"
           value={actualCode}
@@ -184,7 +188,11 @@ export default function Join() {
           autoCapitalize="characters"
           style={{ textTransform: 'uppercase' }}
         />
-        {error && <p className={`error-message ${styles.error}`}>{error}</p>}
+        {error && (
+          <p className={`error-message ${styles.error}`} role="alert" aria-live="polite">
+            {error}
+          </p>
+        )}
         <Button
           className="join-submit"
           type="submit"

--- a/app/frontend/static.css
+++ b/app/frontend/static.css
@@ -391,3 +391,49 @@
     transform: translateX(0) skewX(0deg);
   }
 }
+
+/* Touch devices: keep the static noise + scanlines as a still texture, drop the
+   moving tear bands and the staticAnim/flicker loops to save phone battery. */
+@media (hover: none) {
+  :root[data-bg='animated'] .tv-static {
+    animation: none;
+  }
+
+  :root[data-bg='animated'] .tv-static::after {
+    animation: none;
+  }
+
+  :root[data-bg='animated'] .tear-single,
+  :root[data-bg='animated'] .tear-double,
+  :root[data-bg='animated'] .tear-band {
+    display: none;
+  }
+}
+
+/* Reduced motion: drop CRT noise, scanlines, tears, and the boot flash.
+   The vignette gradient stays — it's static, not motion. */
+@media (prefers-reduced-motion: reduce) {
+  :root[data-bg='animated'] .tv-static {
+    background: hsl(var(--background));
+    filter: none;
+    animation: none;
+  }
+
+  :root[data-bg='animated'] .tv-static::after,
+  :root[data-bg='animated'] .tear-single,
+  :root[data-bg='animated'] .tear-double,
+  :root[data-bg='animated'] .tear-band {
+    display: none;
+    animation: none;
+  }
+
+  .tv-on-effect,
+  .tv-on-effect::after {
+    display: none;
+    animation: none;
+  }
+
+  .app--booting .wink-container {
+    animation: none;
+  }
+}

--- a/app/frontend/styles.css
+++ b/app/frontend/styles.css
@@ -1,12 +1,13 @@
 :root {
   --phosphor: #c8f060;
+  /* HSL form of --phosphor for shadcn-style consumers (--primary derives from this in dark mode). */
+  --phosphor-hsl: 78 86% 60%;
   --amber: #f5a623;
   --hot-white: #f0ede4;
   --black: #080808;
   --deep: #0d0d0f;
   --dim: #3a3a3a;
   --red: #ff4911;
-  --green: #c8f060;
   --phosphor-glow-faint: rgba(200, 240, 96, 0.05);
   --phosphor-glow: rgba(200, 240, 96, 0.15);
   --phosphor-glow-light: rgba(200, 240, 96, 0.2);
@@ -48,7 +49,10 @@
   --input: 42 10% 90%;
   --ring: 78 86% 40%;
   --radius: 0.75rem;
-  --shadow-1: 0 8px 16px hsl(var(--foreground) / 0.08);
+  --shadow-sm: 0 1px 3px hsl(var(--foreground) / 0.08);
+  --shadow-md: 0 2px 8px hsl(var(--foreground) / 0.1);
+  --shadow-lg: 0 8px 16px hsl(var(--foreground) / 0.12);
+  --shadow-1: var(--shadow-lg);
 }
 
 :root[data-theme='dark'] {
@@ -58,7 +62,7 @@
   --card-foreground: 42 15% 91%;
   --popover: 60 4% 5.5%;
   --popover-foreground: 42 15% 91%;
-  --primary: 78 86% 60%;
+  --primary: var(--phosphor-hsl);
   --primary-foreground: 0 0% 3%;
   --secondary: 0 0% 10%;
   --secondary-foreground: 42 15% 91%;
@@ -70,9 +74,12 @@
   --destructive-foreground: 0 0% 100%;
   --border: 50 8% 16%;
   --input: 0 0% 10%;
-  --ring: 78 86% 60%;
+  --ring: var(--phosphor-hsl);
   --radius: 0.75rem;
-  --shadow-1: 0 8px 16px rgba(0, 0, 0, 0.4);
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.3);
+  --shadow-lg: 0 8px 16px rgba(0, 0, 0, 0.4);
+  --shadow-1: var(--shadow-lg);
 }
 
 .app {
@@ -156,6 +163,7 @@ body {
   align-items: center;
   min-height: calc(100dvh - var(--nav-h));
   width: 100%;
+  text-align: center;
 }
 
 h1,
@@ -169,7 +177,6 @@ h6 {
   position: relative;
   z-index: 10;
   font-weight: 800;
-  text-align: center;
   line-height: 1;
   font-family: var(--font-display);
   color: hsl(var(--foreground));
@@ -200,7 +207,6 @@ label,
 body {
   font-family: var(--font-primary);
   margin: 0;
-  text-align: center;
   font-size: clamp(1rem, 4vw, 24px);
   color: hsl(var(--foreground));
   text-shadow: none;
@@ -212,12 +218,6 @@ body {
 :root[data-theme='dark'] h4,
 :root[data-theme='dark'] h5,
 :root[data-theme='dark'] h6 {
-  text-shadow: var(--tv-glow);
-}
-
-:root[data-theme='dark'] p,
-:root[data-theme='dark'] label,
-:root[data-theme='dark'] body {
   text-shadow: var(--tv-glow);
 }
 
@@ -324,6 +324,11 @@ input:focus {
   outline: none;
   border-color: hsl(var(--ring));
   box-shadow: 0 0 0 0.125rem hsl(var(--ring) / 0.3);
+}
+
+input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 button {
@@ -563,4 +568,28 @@ button:active {
 .error-message {
   color: hsl(var(--destructive));
   text-shadow: none;
+}
+
+:where(button, a, [role='button'], [tabindex='0']):focus-visible {
+  outline: 2px solid var(--phosphor);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glitch,
+  .glitch::before,
+  .glitch::after {
+    animation: none;
+    transform: none;
+  }
+
+  .glitch::before,
+  .glitch::after {
+    display: none;
+  }
+
+  .wink-container.is-wink-out,
+  .wink-container.is-wink-in {
+    animation: none;
+  }
 }


### PR DESCRIPTION
## Summary

Full `/audit` + remediation sweep across every page. Initial score 13/20 (Acceptable) → significantly higher after fixes.

**P0 (blocking)**
- Stripped loading spinners off operator cue buttons (Start/Pause/Resume, Reset Buzzers, Queue/Play). The websocket-first spec requires these to feel optimistic, not block on round-trip.
- Replaced 4 undefined CSS vars in `Block.module.scss` (e.g. `--spacing-xl` → `var(--space-lg)`, `--color-text-primary` → `hsl(var(--foreground))`).
- Themed the `EventDetail` QR holder background (was hard `#fff`, invisible in light mode).

**P1 — `/quieter`**
- Phosphor (#c8f060) cut from 43 → ~20 occurrences. Reserved for live indicators, primary CTAs, focus rings, brand wayfinding.
- Errors → `--destructive`, help text → `--muted-foreground`, disconnected → `--amber`.
- Removed duplicate `--green` token (was identical to `--phosphor`).

**P1 — `/layout`**
- Removed banned `border-left: 2px` colored stripe on Calendar event cards.
- Performers grid → list with hero variant (first card 96px, rest 60px) — breaks Eventbrite-template anti-pattern.
- Flattened nested-card pattern on `EventDetail` join section.

**P1 — `/clarify`**
- Real `<label>` elements on join + Register inputs (was placeholder-only).
- Errors wrapped in `role=\"alert\" aria-live=\"polite\"` for screen reader announcement.
- `aria-label` + `aria-expanded` on icon-only buttons (BlockSidebar, PlaybillTab).
- Descriptive `alt` on Playbill section images.

**P2 — `/optimize`**
- Most claims were already-optimized (html5-qrcode lazy-imported, TicketRip lazy-loaded, Konva already imperative, Monitor block already gated). Added `decoding=\"async\"` to large lazy images.

**P2 — `/adapt`**
- 44px+ touch targets on `assignBtn`, `kickBtn`, `iconBtn`, `imageRemoveBtn`, BlockSidebar `iconButton`.
- Fluid `min(220px, calc(100vw - …))` on ParticipantsMenu.
- ~~Phone-mode `--col-min-w: 9rem` on Timeline.~~ Reverted during merge from main (see Deferred).

**P3 — `/polish`**
- Replaced last `color: white` and `#666`/`#4b5563` hardcodes with theme tokens.
- Added `input:disabled` state.
- Made Calendar `monthLabel` fluid via `clamp()`.

**CI fixes (incremental)**
- BlockSidebar create button: restored \"Create Block\" casing on title/aria-label so Capybara's case-sensitive substring match for `click_button \"Block\"` (used by every system spec's `queue_block` helper) hits.
- LobbyAvatars: added `typeof node.position === 'function'` guard before invoking the imperative Konva ref API. Real Konva refs expose `.position()/.scale()`; the test mock renders `Group` as a `<div>`, which doesn't.
- LobbyAvatars test: updated grayed-stroke assertion from `'#666'` → `'hsl(60 4% 35%)'` to match the polish color change.
- Dialog: added `transform: translate(-50%, -50%)` as a base style on `.content`. An earlier branch session had added `prefers-reduced-motion: reduce { animation: none }`, but the centering transform only lived in the keyframe's `to` state. CI runs Cuprite with `--force-prefers-reduced-motion`, which killed the animation and pushed the dialog footer off-screen — causing `MouseEventFailed` on every `click_button \"Queue block\"` / `\"Save\"`.

## Deferred — pick up next session

Each item is worth its own PR. None are regressions from this work; they're explicitly scoped out.

- **ManageViewer modal-as-drawer refactor** — design context says \"no modals during live mode\"; the four full-screen `Dialog`s in `ManageViewer.tsx` (Create Block, Edit Block, Debug Panel, Edit Playbill) violate this. Real fix is converting them to non-modal side drawers, but the codebase has no Drawer/Sheet component yet. Build that component first, then migrate. Currently `Dialog` is dismissable via Esc / backdrop, so live operation is degraded but not blocked.
- **Bottom-nav tabs sized 56×42px** — `Navigation.module.scss` `.bottomTab` (Home / Shows / Settings) is below the 44px touch-target minimum on mobile. Pre-existing global component, flagged in the original `.context/todos.md`. Single-file fix; held out of this PR because it touches a shared chrome component used by every page.
- **Timeline mobile column width regression** — main refactored Timeline from flex to CSS grid with fixed `repeat(N, 12rem)` columns. My audit-pass added a `--col-min-w: 9rem` phone-mode override that no longer applies under the grid layout. To restore narrower mobile columns, `Timeline.tsx` needs to pass a viewport-aware `--col-template` (e.g. `repeat(${columns.length}, 9rem)` under 768px) — currently it hardcodes `12rem`.
- **Playbill image CLS** — `Playbill.tsx` `<img>` tags need `aspect-ratio` to prevent layout shift on lazy load. Image dimensions are unknown at render (user-uploaded), so requires backend support to surface intrinsic width/height with the playbill section payload.
- **LobbyAvatars test infra** — current `typeof node.position` guard is defensive but masks the real gap: the test mocks `react-konva` `Group` as a `<div>`. If Konva ref API is used more extensively in future, the test mock should stub `position()` / `scale()` / `batchDraw()` properly. Cheap, single-file follow-up.
- **Light-mode link color identity** — `styles.css` light-mode `.link` falls back to `hsl(var(--foreground))` (loses phosphor identity). Want a tinted-green token for light mode that still reads as \"link\" while being legible on cream background. Needs a color decision.
- **Hover-underline on phosphor surfaces** — when `.link` color is `--phosphor` and underline color inherits, the underline is invisible against phosphor backgrounds. Need `text-decoration-color` override.
- **Form-submit spinners** — `Create.tsx`, `EditBlock.tsx`, `CreateEvent/EditEvent.tsx`, `CreatePerformer/EditPerformer.tsx`, `Register.tsx`, `join.tsx`, `PlaybillTab.tsx Save` still use `loading` / `loadingText`. Per spec these are non-cue actions (form saves) so they're allowed, but worth a separate pass to decide form-save UX policy consistently.
- **Long blockLabel truncation tooltip** — `Timeline.module.scss .blockLabel` uses `-webkit-line-clamp: 2` with no `title` attribute. Operator loses full context on truncated cues.

## Test plan

- [x] `yarn tsc --noEmit` passes
- [x] `yarn format:check` clean
- [x] `yarn test` — 43/43 vitest passing
- [x] Playwright smoke spec on public pages — 17/17 passing (config + spec in gitignored `.context/`)
- [ ] CI green
- [ ] Visual: operator manage page — phosphor only on live indicators, primary CTAs, focused inputs
- [ ] Light-mode: open `/events/:slug` — QR holder visible (not white-on-white)
- [ ] Mobile (≤768px): Performers list stacks with hero variant; touch targets ≥44px on operator surfaces
- [ ] Live show drive: start/pause/resume should feel snappy (no spinners)