### PR TITLE
Add Minigame block category with Arithmetic and Balloon Pump variants

### DIFF
--- a/app/controllers/api/experience_blocks_controller.rb
+++ b/app/controllers/api/experience_blocks_controller.rb
@@ -5,11 +5,14 @@ class Api::ExperienceBlocksController < Api::BaseController
     start_playing reveal_bucket show_x next_question restart_playing
     restart_categorizing restart_everything
     next_guess_who_slide previous_guess_who_slide reveal_guess_who
+    start_minigame_arithmetic end_minigame_arithmetic
+    start_minigame_balloon_pump end_minigame_balloon_pump
   ].freeze
 
   SUBMISSION_ACTIONS = %i[
     submit_poll_response submit_question_response
     submit_mad_lib_response submit_photo_upload_response submit_buzzer_response
+    submit_minigame_arithmetic_response submit_minigame_balloon_pump_update
   ].freeze
 
   before_action :authenticate_and_set_user_and_experience
@@ -556,6 +559,98 @@ class Api::ExperienceBlocksController < Api::BaseController
       Experiences::Broadcaster.new(@experience).broadcast_experience_update
 
       render json: { success: true }, status: 200
+    end
+  end
+
+  # POST /api/experiences/:experience_id/blocks/:id/minigame/start
+  def start_minigame_arithmetic
+    with_experience_orchestration do
+      block = Experiences::Orchestrator.new(
+        experience: @experience, actor: @user
+      ).start_minigame_arithmetic!(block_id: params[:id])
+
+      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      render json: { success: true, data: block }, status: 200
+    end
+  end
+
+  # POST /api/experiences/:experience_id/blocks/:id/minigame/end
+  def end_minigame_arithmetic
+    with_experience_orchestration do
+      block = Experiences::Orchestrator.new(
+        experience: @experience, actor: @user
+      ).end_minigame_arithmetic!(block_id: params[:id])
+
+      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      render json: { success: true, data: block }, status: 200
+    end
+  end
+
+  # POST /api/experiences/:experience_id/blocks/:id/minigame/responses
+  def submit_minigame_arithmetic_response
+    with_experience_orchestration do
+      submission = Experiences::Orchestrator.new(
+        experience: @experience, actor: @user
+      ).submit_minigame_arithmetic_response!(
+        block_id:       params[:id],
+        question_index: params[:question_index],
+        answer:         params[:answer]
+      )
+
+      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      render json: {
+        success: true,
+        submission: { id: submission.id, question_index: submission.question_index }
+      }, status: 200
+    end
+  end
+
+  # POST /api/experiences/:experience_id/blocks/:id/minigame/balloon_pump/start
+  def start_minigame_balloon_pump
+    with_experience_orchestration do
+      block = Experiences::Orchestrator.new(
+        experience: @experience, actor: @user
+      ).start_minigame_balloon_pump!(block_id: params[:id])
+
+      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      render json: { success: true, data: block }, status: 200
+    end
+  end
+
+  # POST /api/experiences/:experience_id/blocks/:id/minigame/balloon_pump/end
+  def end_minigame_balloon_pump
+    with_experience_orchestration do
+      block = Experiences::Orchestrator.new(
+        experience: @experience, actor: @user
+      ).end_minigame_balloon_pump!(block_id: params[:id])
+
+      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      render json: { success: true, data: block }, status: 200
+    end
+  end
+
+  # POST /api/experiences/:experience_id/blocks/:id/minigame/balloon_pump/pump
+  def submit_minigame_balloon_pump_update
+    with_experience_orchestration do
+      outcome = Experiences::Orchestrator.new(
+        experience: @experience, actor: @user
+      ).submit_balloon_pump_update!(
+        block_id:    params[:id],
+        fill_amount: params[:fill_amount]
+      )
+
+      if outcome[:winners]&.any?
+        Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      elsif outcome[:leader_changed]
+        Experiences::Broadcaster.new(@experience).broadcast_balloon_pump_leader_update(block: @block.reload)
+      end
+
+      render json: { success: true, result: outcome[:result] }, status: 200
     end
   end
 

--- a/app/frontend/Contexts/DispatchRegistryContext.tsx
+++ b/app/frontend/Contexts/DispatchRegistryContext.tsx
@@ -2,6 +2,12 @@ import { ReactNode, createContext, useCallback, useContext, useMemo, useRef } fr
 
 import { FamilyFeudAction } from '@cctv/pages/Block/FamilyFeudManager/familyFeudReducer';
 
+export interface BalloonPumpLeaderUpdate {
+  leader_fill: number;
+  target_units: number;
+  leader_participant_id: string | null;
+}
+
 export interface DispatchRegistryContextType {
   registerFamilyFeudDispatch: (
     blockId: string,
@@ -9,12 +15,23 @@ export interface DispatchRegistryContextType {
   ) => void;
   unregisterFamilyFeudDispatch: (blockId: string) => void;
   getFamilyFeudDispatch: (blockId: string) => ((action: FamilyFeudAction) => void) | undefined;
+  registerBalloonPumpListener: (
+    blockId: string,
+    listener: (update: BalloonPumpLeaderUpdate) => void,
+  ) => void;
+  unregisterBalloonPumpListener: (blockId: string) => void;
+  getBalloonPumpListener: (
+    blockId: string,
+  ) => ((update: BalloonPumpLeaderUpdate) => void) | undefined;
 }
 
 const DispatchRegistryContext = createContext<DispatchRegistryContextType | undefined>(undefined);
 
 export function DispatchRegistryProvider({ children }: { children: ReactNode }) {
   const familyFeudDispatchRegistry = useRef<Map<string, (action: FamilyFeudAction) => void>>(
+    new Map(),
+  );
+  const balloonPumpRegistry = useRef<Map<string, (update: BalloonPumpLeaderUpdate) => void>>(
     new Map(),
   );
 
@@ -33,13 +50,38 @@ export function DispatchRegistryProvider({ children }: { children: ReactNode }) 
     return familyFeudDispatchRegistry.current.get(blockId);
   }, []);
 
+  const registerBalloonPumpListener = useCallback(
+    (blockId: string, listener: (update: BalloonPumpLeaderUpdate) => void) => {
+      balloonPumpRegistry.current.set(blockId, listener);
+    },
+    [],
+  );
+
+  const unregisterBalloonPumpListener = useCallback((blockId: string) => {
+    balloonPumpRegistry.current.delete(blockId);
+  }, []);
+
+  const getBalloonPumpListener = useCallback((blockId: string) => {
+    return balloonPumpRegistry.current.get(blockId);
+  }, []);
+
   const value = useMemo<DispatchRegistryContextType>(
     () => ({
       registerFamilyFeudDispatch,
       unregisterFamilyFeudDispatch,
       getFamilyFeudDispatch,
+      registerBalloonPumpListener,
+      unregisterBalloonPumpListener,
+      getBalloonPumpListener,
     }),
-    [registerFamilyFeudDispatch, unregisterFamilyFeudDispatch, getFamilyFeudDispatch],
+    [
+      registerFamilyFeudDispatch,
+      unregisterFamilyFeudDispatch,
+      getFamilyFeudDispatch,
+      registerBalloonPumpListener,
+      unregisterBalloonPumpListener,
+      getBalloonPumpListener,
+    ],
   );
 
   return (

--- a/app/frontend/Contexts/WebSocketContext.tsx
+++ b/app/frontend/Contexts/WebSocketContext.tsx
@@ -15,6 +15,7 @@ import {
   FamilyFeudActionType,
 } from '@cctv/pages/Block/FamilyFeudManager/familyFeudReducer';
 import {
+  BalloonPumpLeaderUpdatedMessage,
   ExperienceChannelMessage,
   FamilyFeudUpdatedMessage,
   SubmissionStateMessage,
@@ -161,7 +162,7 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
     setSubmissionState,
     impersonatedParticipantId,
   } = useExperienceState();
-  const { getFamilyFeudDispatch } = useDispatchRegistry();
+  const { getFamilyFeudDispatch, getBalloonPumpListener } = useDispatchRegistry();
   const lobbyDrawingDispatch = useLobbyDrawingDispatch();
 
   const [wsConnected, setWsConnected] = useState(false);
@@ -299,6 +300,16 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
             dispatch({ type: actionType, payload: data } as FamilyFeudAction);
           }
         }
+      } else if (wsMessage.type === WebSocketMessageTypes.BALLOON_PUMP_LEADER_UPDATED) {
+        const bpMsg = wsMessage as BalloonPumpLeaderUpdatedMessage;
+        const listener = getBalloonPumpListener(bpMsg.block_id);
+        if (listener) {
+          listener({
+            leader_fill: bpMsg.leader_fill,
+            target_units: bpMsg.target_units,
+            leader_participant_id: bpMsg.leader_participant_id,
+          });
+        }
       } else if (target === 'main' && wsMessage.type === WebSocketMessageTypes.SUBMISSION_STATE) {
         const ssMsg = wsMessage as SubmissionStateMessage;
         setSubmissionState(ssMsg.submissions);
@@ -314,6 +325,7 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
       setWsReady,
       setSubmissionState,
       getFamilyFeudDispatch,
+      getBalloonPumpListener,
       lobbyDrawingDispatch,
       reconnectParticipantWs,
     ],

--- a/app/frontend/Experiences/ExperienceBlockContainer/ExperienceBlockContainer.tsx
+++ b/app/frontend/Experiences/ExperienceBlockContainer/ExperienceBlockContainer.tsx
@@ -5,6 +5,8 @@ import Buzzer from '../Buzzer/Buzzer';
 import FamilyFeud from '../FamilyFeud/FamilyFeud';
 import GuessWho from '../GuessWho/GuessWho';
 import MadLib from '../MadLib/MadLib';
+import MinigameArithmetic from '../MinigameArithmetic/MinigameArithmetic';
+import MinigameBalloonPump from '../MinigameBalloonPump/MinigameBalloonPump';
 import PhotoUpload from '../PhotoUpload/PhotoUpload';
 import Poll from '../Poll/Poll';
 import Question from '../Question/Question';
@@ -74,6 +76,10 @@ export default function ExperienceBlockContainer({
       return <Buzzer block={block} viewContext={viewContext} />;
     case BlockKind.GUESS_WHO:
       return <GuessWho payload={block.payload} />;
+    case BlockKind.MINIGAME_ARITHMETIC:
+      return <MinigameArithmetic block={block} viewContext={viewContext} />;
+    case BlockKind.MINIGAME_BALLOON_PUMP:
+      return <MinigameBalloonPump block={block} viewContext={viewContext} />;
     default:
       const exhaustiveCheck: never = block;
       return (

--- a/app/frontend/Experiences/MinigameArithmetic/MinigameArithmetic.module.scss
+++ b/app/frontend/Experiences/MinigameArithmetic/MinigameArithmetic.module.scss
@@ -1,0 +1,164 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 2rem;
+  min-height: 60vh;
+}
+
+.timer {
+  font-family: var(--font-display);
+  font-size: 3rem;
+  letter-spacing: 0.05em;
+  color: var(--phosphor);
+  text-shadow: var(--tv-glow);
+}
+
+.score {
+  font-family: var(--font-body);
+  font-size: 1.25rem;
+  color: var(--foreground);
+  opacity: 0.8;
+}
+
+.prompt {
+  font-family: var(--font-display);
+  font-size: 4rem;
+  letter-spacing: 0.05em;
+  text-align: center;
+  color: var(--foreground);
+}
+
+.input {
+  font-family: var(--font-body);
+  font-size: 2.5rem;
+  text-align: center;
+  width: 12rem;
+  padding: 0.5rem 1rem;
+  border: 2px solid var(--phosphor);
+  border-radius: 0.5rem;
+  background: transparent;
+  color: var(--foreground);
+
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 4px var(--phosphor-glow);
+  }
+}
+
+.waiting {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  color: var(--foreground);
+  opacity: 0.7;
+  text-align: center;
+}
+
+.monitorRoot {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2.5rem;
+  padding: 3rem;
+  min-height: 60vh;
+}
+
+.monitorIndicator {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  letter-spacing: 0.1em;
+  color: var(--foreground);
+  text-align: center;
+  opacity: 0.85;
+}
+
+.monitorTimer {
+  font-family: var(--font-display);
+  font-size: 9rem;
+  line-height: 1;
+  letter-spacing: 0.05em;
+  color: var(--phosphor);
+  text-shadow: var(--tv-glow);
+}
+
+.leaderboard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: min(36rem, 100%);
+}
+
+.leaderboardTitle {
+  font-family: var(--font-display);
+  font-size: 2.5rem;
+  text-align: center;
+  margin-bottom: 1rem;
+  color: var(--phosphor);
+  text-shadow: var(--tv-glow);
+}
+
+.leaderboardRow {
+  display: grid;
+  grid-template-columns: 3rem 1fr auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--phosphor-glow-medium);
+  border-radius: 0.5rem;
+  font-family: var(--font-body);
+  font-size: 1.25rem;
+}
+
+.leaderboardRank {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  color: var(--amber);
+}
+
+.leaderboardName {
+  font-weight: 500;
+}
+
+.leaderboardScore {
+  font-family: var(--font-display);
+  letter-spacing: 0.05em;
+  color: var(--phosphor);
+}
+
+.manageRoot {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.manageActions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.manageStat {
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  opacity: 0.85;
+}
+
+.questionPreview {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
+  gap: 0.5rem;
+  max-height: 12rem;
+  overflow-y: auto;
+  padding: 0.5rem;
+  border: 1px dashed var(--phosphor-glow-medium);
+  border-radius: 0.5rem;
+}
+
+.questionPreviewItem {
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  padding: 0.25rem 0.5rem;
+}

--- a/app/frontend/Experiences/MinigameArithmetic/MinigameArithmetic.tsx
+++ b/app/frontend/Experiences/MinigameArithmetic/MinigameArithmetic.tsx
@@ -1,0 +1,210 @@
+import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
+
+import { Button } from '@cctv/core/Button/Button';
+import { useMinigameArithmetic } from '@cctv/hooks/useMinigameArithmetic';
+import { MinigameArithmeticBlock } from '@cctv/types';
+
+import styles from './MinigameArithmetic.module.scss';
+
+interface MinigameArithmeticProps {
+  block: MinigameArithmeticBlock;
+  viewContext?: 'participant' | 'monitor' | 'manage';
+}
+
+function useCountdown(startedAt: string | null, durationSeconds: number, endedAt: string | null) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!startedAt || endedAt) return;
+    const id = window.setInterval(() => setNow(Date.now()), 250);
+    return () => window.clearInterval(id);
+  }, [startedAt, endedAt]);
+
+  return useMemo(() => {
+    if (!startedAt) return durationSeconds;
+    const start = new Date(startedAt).getTime();
+    const elapsed = Math.floor((now - start) / 1000);
+    return Math.max(0, durationSeconds - elapsed);
+  }, [now, startedAt, durationSeconds]);
+}
+
+function formatSeconds(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+export default function MinigameArithmetic({
+  block,
+  viewContext = 'participant',
+}: MinigameArithmeticProps) {
+  switch (viewContext) {
+    case 'monitor':
+      return <MonitorView block={block} />;
+    case 'manage':
+      return <ManageView block={block} />;
+    default:
+      return <ParticipantView block={block} />;
+  }
+}
+
+function ParticipantView({ block }: { block: MinigameArithmeticBlock }) {
+  const { submitAnswer, isSubmitting } = useMinigameArithmetic();
+  const { duration_seconds, started_at, ended_at, current_question, score, leaderboard } =
+    block.payload;
+  const remaining = useCountdown(started_at, duration_seconds, ended_at);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [value, setValue] = useState('');
+
+  useEffect(() => {
+    setValue('');
+    inputRef.current?.focus();
+  }, [current_question?.index]);
+
+  if (ended_at && leaderboard) {
+    return <Leaderboard block={block} />;
+  }
+
+  if (!started_at) {
+    return (
+      <div className={styles.root}>
+        <p className={styles.waiting}>Get ready…</p>
+      </div>
+    );
+  }
+
+  if (!current_question) {
+    return (
+      <div className={styles.root}>
+        <p className={styles.timer}>{formatSeconds(remaining)}</p>
+        <p className={styles.score}>
+          {score?.correct ?? 0} / {score?.completed ?? 0}
+        </p>
+        <p className={styles.waiting}>All questions answered. Hold tight!</p>
+      </div>
+    );
+  }
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (isSubmitting) return;
+    await submitAnswer(block.id, current_question.index, value);
+  };
+
+  return (
+    <div className={styles.root}>
+      <p className={styles.timer}>{formatSeconds(remaining)}</p>
+      <p className={styles.score}>
+        {score?.correct ?? 0} / {score?.completed ?? 0}
+      </p>
+      <p className={styles.prompt}>{current_question.prompt} = ?</p>
+      <form onSubmit={handleSubmit}>
+        <input
+          ref={inputRef}
+          className={styles.input}
+          type="text"
+          inputMode="numeric"
+          autoComplete="off"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          disabled={isSubmitting}
+          aria-label="Your answer"
+        />
+      </form>
+    </div>
+  );
+}
+
+function MonitorView({ block }: { block: MinigameArithmeticBlock }) {
+  const { duration_seconds, started_at, ended_at, leaderboard } = block.payload;
+  const remaining = useCountdown(started_at, duration_seconds, ended_at);
+
+  if (ended_at && leaderboard) {
+    return <Leaderboard block={block} />;
+  }
+
+  if (!started_at) {
+    return (
+      <div className={styles.monitorRoot}>
+        <p className={styles.monitorIndicator}>Arithmetic minigame — get ready</p>
+        <p className={styles.monitorTimer}>{formatSeconds(duration_seconds)}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.monitorRoot}>
+      <p className={styles.monitorIndicator}>Arithmetic on phones</p>
+      <p className={styles.monitorTimer}>{formatSeconds(remaining)}</p>
+    </div>
+  );
+}
+
+function ManageView({ block }: { block: MinigameArithmeticBlock }) {
+  const { start, end } = useMinigameArithmetic();
+  const { started_at, ended_at, duration_seconds, question_count, questions, leaderboard } =
+    block.payload;
+  const remaining = useCountdown(started_at, duration_seconds, ended_at);
+  const submissionTotal = block.responses?.total ?? 0;
+  const correctTotal = block.responses?.correct_count ?? 0;
+  const participantCounts = block.responses?.participant_counts ?? {};
+  const playerCount = Object.keys(participantCounts).length;
+
+  const status = !started_at ? 'queued' : ended_at ? 'ended' : 'running';
+
+  return (
+    <div className={styles.manageRoot}>
+      <p className={styles.manageStat}>
+        Status: <strong>{status}</strong>
+        {status === 'running' && <> — {formatSeconds(remaining)} remaining</>}
+      </p>
+      <p className={styles.manageStat}>
+        Questions: {question_count} • Players answering: {playerCount} • Total submissions:{' '}
+        {submissionTotal} ({correctTotal} correct)
+      </p>
+
+      <div className={styles.manageActions}>
+        {status === 'queued' && <Button onClick={() => start(block.id)}>Start minigame</Button>}
+        {status === 'running' && (
+          <Button variant="secondary" onClick={() => end(block.id)}>
+            End early
+          </Button>
+        )}
+      </div>
+
+      {questions && (
+        <div className={styles.questionPreview}>
+          {questions.map((q) => (
+            <div key={q.index} className={styles.questionPreviewItem}>
+              {q.prompt} = {q.answer}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {ended_at && leaderboard && <Leaderboard block={block} />}
+    </div>
+  );
+}
+
+function Leaderboard({ block }: { block: MinigameArithmeticBlock }) {
+  const entries = block.payload.leaderboard ?? [];
+
+  return (
+    <div className={styles.monitorRoot}>
+      <p className={styles.leaderboardTitle}>Leaderboard</p>
+      <div className={styles.leaderboard}>
+        {entries.length === 0 && <p className={styles.waiting}>No submissions — nobody played.</p>}
+        {entries.map((entry) => (
+          <div key={entry.participant_id} className={styles.leaderboardRow}>
+            <span className={styles.leaderboardRank}>#{entry.rank}</span>
+            <span className={styles.leaderboardName}>{entry.name}</span>
+            <span className={styles.leaderboardScore}>
+              {entry.correct} / {entry.completed}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/Experiences/MinigameBalloonPump/Balloon.tsx
+++ b/app/frontend/Experiences/MinigameBalloonPump/Balloon.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useRef } from 'react';
+
+interface BalloonProps {
+  fillRatio: number;
+  popped?: boolean;
+  size?: number;
+  color?: string;
+}
+
+const MIN_SCALE = 0.35;
+const MAX_SCALE = 1.05;
+
+export default function Balloon({
+  fillRatio,
+  popped = false,
+  size = 240,
+  color = '#ff4911',
+}: BalloonProps) {
+  const lastFillRef = useRef(0);
+  const wobbleRef = useRef(0);
+
+  useEffect(() => {
+    const delta = fillRatio - lastFillRef.current;
+    if (delta > 0.005) {
+      wobbleRef.current = Date.now();
+    }
+    lastFillRef.current = fillRatio;
+  }, [fillRatio]);
+
+  const eased = MIN_SCALE + (MAX_SCALE - MIN_SCALE) * Math.min(1, fillRatio);
+  const wobbleAge = Date.now() - wobbleRef.current;
+  const wobble = wobbleAge < 400 ? Math.sin(wobbleAge / 28) * (1 - wobbleAge / 400) * 0.04 : 0;
+  const scaleX = eased * (1 + wobble);
+  const scaleY = eased * (1 - wobble * 0.6);
+
+  if (popped) {
+    return <PoppedBalloon size={size} color={color} />;
+  }
+
+  return (
+    <svg width={size} height={size} viewBox="-100 -100 200 200" style={{ overflow: 'visible' }}>
+      <defs>
+        <radialGradient id="balloonGrad" cx="-0.2" cy="-0.3" r="1">
+          <stop offset="0%" stopColor={lighten(color, 0.45)} />
+          <stop offset="60%" stopColor={color} />
+          <stop offset="100%" stopColor={darken(color, 0.25)} />
+        </radialGradient>
+      </defs>
+      <g transform={`scale(${scaleX} ${scaleY})`}>
+        <path d="M 0 70 L -3 76 L 3 76 Z" fill={darken(color, 0.4)} />
+        <ellipse cx="0" cy="0" rx="60" ry="72" fill="url(#balloonGrad)" />
+        <ellipse cx="-22" cy="-28" rx="14" ry="22" fill="rgba(255,255,255,0.35)" />
+        <ellipse cx="0" cy="74" rx="6" ry="4" fill={darken(color, 0.4)} />
+      </g>
+      <line
+        x1="0"
+        y1={76 * scaleY}
+        x2="-2"
+        y2={(76 + 60) * scaleY}
+        stroke="#3a3a3a"
+        strokeWidth="1.2"
+      />
+    </svg>
+  );
+}
+
+function PoppedBalloon({ size, color }: { size: number; color: string }) {
+  return (
+    <svg width={size} height={size} viewBox="-100 -100 200 200">
+      <g>
+        {[...Array(14)].map((_, i) => {
+          const angle = (i / 14) * Math.PI * 2 + Math.random() * 0.3;
+          const dist = 60 + Math.random() * 40;
+          const x = Math.cos(angle) * dist;
+          const y = Math.sin(angle) * dist;
+          return (
+            <path
+              key={i}
+              d={`M ${x.toFixed(1)} ${y.toFixed(1)} l ${(Math.random() * 12 - 6).toFixed(1)} ${(Math.random() * 12 - 6).toFixed(1)}`}
+              stroke={color}
+              strokeWidth="3"
+              strokeLinecap="round"
+            />
+          );
+        })}
+      </g>
+    </svg>
+  );
+}
+
+function lighten(hex: string, amount: number): string {
+  return mixHex(hex, '#ffffff', amount);
+}
+
+function darken(hex: string, amount: number): string {
+  return mixHex(hex, '#000000', amount);
+}
+
+function mixHex(hex: string, target: string, amount: number): string {
+  const a = hexToRgb(hex);
+  const b = hexToRgb(target);
+  const r = Math.round(a.r + (b.r - a.r) * amount);
+  const g = Math.round(a.g + (b.g - a.g) * amount);
+  const bl = Math.round(a.b + (b.b - a.b) * amount);
+  return `rgb(${r}, ${g}, ${bl})`;
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const stripped = hex.replace('#', '');
+  const expanded =
+    stripped.length === 3
+      ? stripped
+          .split('')
+          .map((c) => c + c)
+          .join('')
+      : stripped;
+  return {
+    r: parseInt(expanded.slice(0, 2), 16),
+    g: parseInt(expanded.slice(2, 4), 16),
+    b: parseInt(expanded.slice(4, 6), 16),
+  };
+}

--- a/app/frontend/Experiences/MinigameBalloonPump/MinigameBalloonPump.module.scss
+++ b/app/frontend/Experiences/MinigameBalloonPump/MinigameBalloonPump.module.scss
@@ -1,0 +1,249 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 1rem;
+  padding: 1rem;
+  min-height: 70vh;
+  user-select: none;
+  touch-action: none;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  font-family: var(--font-display);
+  letter-spacing: 0.05em;
+  text-align: center;
+}
+
+.fillLabel {
+  font-size: 1.5rem;
+  color: var(--phosphor);
+  text-shadow: var(--tv-glow);
+}
+
+.targetLabel {
+  font-size: 1rem;
+  opacity: 0.65;
+}
+
+.balloonStage {
+  position: relative;
+  width: min(80vw, 320px);
+  height: 280px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.balloonSvg {
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+.balloonString {
+  stroke: var(--dim);
+  stroke-width: 1.5;
+  fill: none;
+}
+
+.pumpStage {
+  position: relative;
+  width: min(85vw, 320px);
+  height: 360px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.pumpCanvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  border-radius: 0.5rem;
+}
+
+.pumpHint {
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  opacity: 0.7;
+  margin-top: 0.5rem;
+  text-align: center;
+}
+
+.waiting {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  color: var(--foreground);
+  opacity: 0.7;
+  text-align: center;
+}
+
+.endedBanner {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  color: var(--phosphor);
+  text-align: center;
+  letter-spacing: 0.05em;
+}
+
+// Monitor
+
+.monitorRoot {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem;
+  min-height: 70vh;
+}
+
+.monitorTitle {
+  font-family: var(--font-display);
+  font-size: 2.25rem;
+  letter-spacing: 0.1em;
+  color: var(--foreground);
+  opacity: 0.85;
+  text-align: center;
+}
+
+.monitorBalloonStage {
+  position: relative;
+  width: min(60vw, 600px);
+  height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.monitorPercent {
+  font-family: var(--font-display);
+  font-size: 4rem;
+  letter-spacing: 0.05em;
+  color: var(--phosphor);
+  text-shadow: var(--tv-glow);
+}
+
+// Podium
+
+.podium {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.podiumColumn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  width: 14rem;
+}
+
+.podiumPlace {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  letter-spacing: 0.1em;
+}
+
+.podiumPlace[data-place='1'] {
+  color: #ffd700;
+  text-shadow: 0 0 12px rgba(255, 215, 0, 0.6);
+}
+
+.podiumPlace[data-place='2'] {
+  color: #c0c0c0;
+  text-shadow: 0 0 8px rgba(192, 192, 192, 0.5);
+}
+
+.podiumPlace[data-place='3'] {
+  color: #cd7f32;
+  text-shadow: 0 0 8px rgba(205, 127, 50, 0.5);
+}
+
+.podiumName {
+  font-family: var(--font-body);
+  font-size: 1.5rem;
+  text-align: center;
+}
+
+.podiumAvatar {
+  width: 7rem;
+  height: 7rem;
+  border-radius: 50%;
+  background: var(--card);
+  border: 3px solid var(--phosphor-glow-medium);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.podiumPlatform {
+  width: 100%;
+  background: linear-gradient(180deg, var(--phosphor-glow-strong) 0%, var(--phosphor-glow) 100%);
+  border-radius: 0.5rem 0.5rem 0 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  color: var(--black);
+}
+
+.podiumPlatform[data-place='1'] {
+  height: 7rem;
+}
+
+.podiumPlatform[data-place='2'] {
+  height: 5rem;
+}
+
+.podiumPlatform[data-place='3'] {
+  height: 3.5rem;
+}
+
+// Manage
+
+.manageRoot {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.manageStat {
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  opacity: 0.85;
+}
+
+.manageActions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.liveResults {
+  max-height: 16rem;
+  overflow-y: auto;
+  border: 1px dashed var(--phosphor-glow-medium);
+  border-radius: 0.5rem;
+  padding: 0.5rem;
+}
+
+.liveResultRow {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 1rem;
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+  padding: 0.25rem 0.5rem;
+}

--- a/app/frontend/Experiences/MinigameBalloonPump/MinigameBalloonPump.tsx
+++ b/app/frontend/Experiences/MinigameBalloonPump/MinigameBalloonPump.tsx
@@ -1,0 +1,266 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { Layer, Line, Stage } from 'react-konva';
+
+import { useExperience } from '@cctv/contexts/ExperienceContext';
+import { Button } from '@cctv/core/Button/Button';
+import { useBalloonPumpLeader, useMinigameBalloonPump } from '@cctv/hooks/useMinigameBalloonPump';
+import { MinigameBalloonPumpBlock, MinigameBalloonPumpPodiumEntry } from '@cctv/types';
+
+import Balloon from './Balloon';
+import Pump from './Pump';
+
+import styles from './MinigameBalloonPump.module.scss';
+
+interface Props {
+  block: MinigameBalloonPumpBlock;
+  viewContext?: 'participant' | 'monitor' | 'manage';
+}
+
+export default function MinigameBalloonPump({ block, viewContext = 'participant' }: Props) {
+  switch (viewContext) {
+    case 'monitor':
+      return <MonitorView block={block} />;
+    case 'manage':
+      return <ManageView block={block} />;
+    default:
+      return <ParticipantView block={block} />;
+  }
+}
+
+function ParticipantView({ block }: { block: MinigameBalloonPumpBlock }) {
+  const { submitPump } = useMinigameBalloonPump();
+  const { participant } = useExperience();
+  const { target_units, started_at, ended_at, own_fill, winner_participant_ids } = block.payload;
+  const [localFill, setLocalFill] = useState(own_fill ?? 0);
+  const localFillRef = useRef(localFill);
+
+  useEffect(() => {
+    localFillRef.current = localFill;
+  }, [localFill]);
+
+  // Reset on game (re)start.
+  useEffect(() => {
+    if (!started_at) {
+      setLocalFill(0);
+      localFillRef.current = 0;
+    }
+  }, [started_at]);
+
+  // Reconcile with server when own_fill arrives larger than local (e.g. on reconnect).
+  useEffect(() => {
+    if ((own_fill ?? 0) > localFillRef.current) {
+      setLocalFill(own_fill ?? 0);
+      localFillRef.current = own_fill ?? 0;
+    }
+  }, [own_fill]);
+
+  const handlePumpUnits = (units: number) => {
+    if (!started_at || ended_at) return;
+    if (localFillRef.current >= target_units) return;
+    const next = Math.min(target_units, localFillRef.current + units);
+    setLocalFill(next);
+    localFillRef.current = next;
+    submitPump(block.id, Math.round(next));
+  };
+
+  const fillRatio = target_units > 0 ? Math.min(1, localFill / target_units) : 0;
+  const popped = (ended_at && fillRatio >= 0.999) || false;
+
+  const youWon = useMemo(() => {
+    if (!ended_at || !participant) return false;
+    return winner_participant_ids.includes(participant.id);
+  }, [ended_at, participant, winner_participant_ids]);
+
+  if (!started_at) {
+    return (
+      <div className={styles.root}>
+        <p className={styles.waiting}>Get ready to pump…</p>
+      </div>
+    );
+  }
+
+  if (ended_at) {
+    return (
+      <div className={styles.root}>
+        <div className={styles.balloonStage}>
+          <Balloon fillRatio={fillRatio} popped={popped} size={220} />
+        </div>
+        <p className={styles.endedBanner}>
+          {youWon ? 'BURST! You did it.' : 'Game over — see the monitor.'}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.header}>
+        <span className={styles.fillLabel}>
+          {Math.round(localFill)} / {target_units}
+        </span>
+        <span className={styles.targetLabel}>{Math.round(fillRatio * 100)}% inflated</span>
+      </div>
+      <div className={styles.balloonStage}>
+        <Balloon fillRatio={fillRatio} size={220} />
+      </div>
+      <div className={styles.pumpStage}>
+        <Pump pumpUnits={localFill} onStrokeUnits={handlePumpUnits} disabled={fillRatio >= 1} />
+        <p className={styles.pumpHint}>Drag the handle down. Release to spring back.</p>
+      </div>
+    </div>
+  );
+}
+
+function MonitorView({ block }: { block: MinigameBalloonPumpBlock }) {
+  const { target_units, leader_fill, leader_participant_id, started_at, ended_at, podium } =
+    block.payload;
+
+  const leader = useBalloonPumpLeader(block.id, {
+    leader_fill,
+    target_units,
+    leader_participant_id,
+  });
+
+  const [popping, setPopping] = useState(false);
+
+  useEffect(() => {
+    if (ended_at && !popping) {
+      setPopping(true);
+      const t = window.setTimeout(() => setPopping(false), 1600);
+      return () => window.clearTimeout(t);
+    }
+  }, [ended_at, popping]);
+
+  const fillRatio = target_units > 0 ? Math.min(1, leader.leader_fill / target_units) : 0;
+
+  if (!started_at) {
+    return (
+      <div className={styles.monitorRoot}>
+        <p className={styles.monitorTitle}>Balloon Pump — get ready</p>
+      </div>
+    );
+  }
+
+  if (ended_at && podium && podium.length > 0) {
+    return (
+      <div className={styles.monitorRoot}>
+        <p className={styles.monitorTitle}>BURST!</p>
+        <Podium podium={podium} />
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.monitorRoot}>
+      <p className={styles.monitorTitle}>Closest to popping</p>
+      <div className={styles.monitorBalloonStage}>
+        <Balloon fillRatio={fillRatio} popped={popping} size={420} />
+      </div>
+      <p className={styles.monitorPercent}>{Math.round(fillRatio * 100)}%</p>
+    </div>
+  );
+}
+
+function ManageView({ block }: { block: MinigameBalloonPumpBlock }) {
+  const { start, end } = useMinigameBalloonPump();
+  const { target_units, started_at, ended_at, leader_fill, live_results } = block.payload;
+  const status = !started_at ? 'queued' : ended_at ? 'ended' : 'running';
+
+  return (
+    <div className={styles.manageRoot}>
+      <p className={styles.manageStat}>
+        Status: <strong>{status}</strong> • Target: {target_units} units (={' '}
+        {(target_units / 10).toFixed(1)} strokes)
+      </p>
+      <p className={styles.manageStat}>
+        Leader fill: {leader_fill ?? 0} (
+        {target_units > 0 ? Math.round(((leader_fill ?? 0) / target_units) * 100) : 0}%)
+      </p>
+
+      <div className={styles.manageActions}>
+        {status === 'queued' && <Button onClick={() => start(block.id)}>Start minigame</Button>}
+        {status === 'running' && (
+          <Button variant="secondary" onClick={() => end(block.id)}>
+            End early
+          </Button>
+        )}
+      </div>
+
+      {live_results && live_results.length > 0 && (
+        <div className={styles.liveResults}>
+          {live_results.map((r) => (
+            <div key={r.participant_id} className={styles.liveResultRow}>
+              <span>{r.name}</span>
+              <span>{r.fill_amount}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Podium({ podium }: { podium: MinigameBalloonPumpPodiumEntry[] }) {
+  const order: Array<1 | 2 | 3> = [2, 1, 3];
+  const byPlace = new Map<1 | 2 | 3, MinigameBalloonPumpPodiumEntry[]>();
+  podium.forEach((entry) => {
+    const place = entry.place;
+    const list = byPlace.get(place) ?? [];
+    list.push(entry);
+    byPlace.set(place, list);
+  });
+
+  return (
+    <div className={styles.podium}>
+      {order.map((place) => {
+        const entries = byPlace.get(place);
+        if (!entries || entries.length === 0) return null;
+        return (
+          <div key={place} className={styles.podiumColumn}>
+            <span className={styles.podiumPlace} data-place={place}>
+              {place === 1 ? 'GOLD' : place === 2 ? 'SILVER' : 'BRONZE'}
+            </span>
+            {entries.map((entry) => (
+              <div key={entry.participant_id} className={styles.podiumColumn}>
+                <PodiumAvatar entry={entry} />
+                <span className={styles.podiumName}>{entry.name}</span>
+              </div>
+            ))}
+            <div className={styles.podiumPlatform} data-place={place}>
+              #{place}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+const AVATAR_DRAW_SIZE = 320;
+const AVATAR_DISPLAY_SIZE = 112;
+const AVATAR_SCALE = AVATAR_DISPLAY_SIZE / AVATAR_DRAW_SIZE;
+
+function PodiumAvatar({ entry }: { entry: MinigameBalloonPumpPodiumEntry }) {
+  const strokes = entry.avatar?.strokes ?? [];
+  if (strokes.length === 0) {
+    return <div className={styles.podiumAvatar} />;
+  }
+  return (
+    <div className={styles.podiumAvatar}>
+      <Stage width={AVATAR_DISPLAY_SIZE} height={AVATAR_DISPLAY_SIZE}>
+        <Layer scaleX={AVATAR_SCALE} scaleY={AVATAR_SCALE}>
+          {strokes.map((s, i) => (
+            <Line
+              key={i}
+              points={s.points}
+              stroke={s.color}
+              strokeWidth={s.width}
+              lineCap="round"
+            />
+          ))}
+        </Layer>
+      </Stage>
+    </div>
+  );
+}

--- a/app/frontend/Experiences/MinigameBalloonPump/Pump.tsx
+++ b/app/frontend/Experiences/MinigameBalloonPump/Pump.tsx
@@ -1,0 +1,260 @@
+import { PointerEvent, useCallback, useEffect, useRef, useState } from 'react';
+
+const PUMP_WIDTH = 280;
+const PUMP_HEIGHT = 360;
+const HANDLE_RADIUS = 28;
+const HANDLE_X = PUMP_WIDTH / 2;
+const HANDLE_TOP_Y = 36;
+const HANDLE_BOTTOM_Y = 280;
+const HANDLE_TRAVEL = HANDLE_BOTTOM_Y - HANDLE_TOP_Y;
+
+const BARREL_X = HANDLE_X - 22;
+const BARREL_W = 44;
+const BARREL_TOP = HANDLE_BOTTOM_Y;
+const BARREL_BOTTOM = 320;
+
+const BASE_X = HANDLE_X - 60;
+const BASE_W = 120;
+const BASE_TOP = BARREL_BOTTOM;
+const BASE_BOTTOM = 348;
+
+const SHAFT_W = 12;
+const SPRING_RETURN_PX_PER_FRAME = 14;
+
+interface PumpProps {
+  onStrokeUnits: (units: number) => void;
+  pumpUnits: number;
+  disabled?: boolean;
+}
+
+function lerp(a: number, b: number, t: number) {
+  return a + (b - a) * t;
+}
+
+export default function Pump({ onStrokeUnits, pumpUnits, disabled = false }: PumpProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [handleY, setHandleY] = useState(HANDLE_TOP_Y);
+  const handleYRef = useRef(HANDLE_TOP_Y);
+  const draggingRef = useRef(false);
+  const lastPointerYRef = useRef(0);
+  const dragStartHandleYRef = useRef(HANDLE_TOP_Y);
+  const dragStartPointerYRef = useRef(0);
+  const animFrameRef = useRef<number | null>(null);
+  const audioCtxRef = useRef<AudioContext | null>(null);
+
+  useEffect(() => {
+    handleYRef.current = handleY;
+  }, [handleY]);
+
+  const playWoosh = useCallback((intensity: number) => {
+    try {
+      if (!audioCtxRef.current) {
+        audioCtxRef.current = new AudioContext();
+      }
+      const ctx = audioCtxRef.current;
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      const noise = ctx.createBufferSource();
+      const buffer = ctx.createBuffer(1, ctx.sampleRate * 0.2, ctx.sampleRate);
+      const data = buffer.getChannelData(0);
+      for (let i = 0; i < data.length; i++) {
+        const decay = 1 - i / data.length;
+        data[i] = (Math.random() * 2 - 1) * decay * 0.3;
+      }
+      noise.buffer = buffer;
+      const noiseGain = ctx.createGain();
+      noiseGain.gain.setValueAtTime(0.18 * intensity, ctx.currentTime);
+      noiseGain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.18);
+      noise.connect(noiseGain);
+      noiseGain.connect(ctx.destination);
+
+      osc.type = 'sawtooth';
+      osc.frequency.setValueAtTime(80 + intensity * 60, ctx.currentTime);
+      osc.frequency.exponentialRampToValueAtTime(40, ctx.currentTime + 0.18);
+      gain.gain.setValueAtTime(0.06 * intensity, ctx.currentTime);
+      gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.18);
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+
+      osc.start();
+      noise.start();
+      osc.stop(ctx.currentTime + 0.18);
+      noise.stop(ctx.currentTime + 0.2);
+    } catch {
+      // best-effort
+    }
+  }, []);
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    if (canvas.width !== PUMP_WIDTH * dpr) {
+      canvas.width = PUMP_WIDTH * dpr;
+      canvas.height = PUMP_HEIGHT * dpr;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+
+    ctx.clearRect(0, 0, PUMP_WIDTH, PUMP_HEIGHT);
+
+    const styles = getComputedStyle(document.documentElement);
+    const phosphor = styles.getPropertyValue('--phosphor').trim() || '#c8f060';
+    const dim = styles.getPropertyValue('--dim').trim() || '#3a3a3a';
+    const ink = styles.getPropertyValue('--black').trim() || '#080808';
+
+    // Base / foot
+    ctx.fillStyle = dim;
+    ctx.beginPath();
+    ctx.moveTo(BASE_X, BASE_TOP);
+    ctx.lineTo(BASE_X + BASE_W, BASE_TOP);
+    ctx.lineTo(BASE_X + BASE_W - 18, BASE_BOTTOM);
+    ctx.lineTo(BASE_X + 18, BASE_BOTTOM);
+    ctx.closePath();
+    ctx.fill();
+
+    // Barrel
+    const barrelGrad = ctx.createLinearGradient(BARREL_X, 0, BARREL_X + BARREL_W, 0);
+    barrelGrad.addColorStop(0, dim);
+    barrelGrad.addColorStop(0.5, '#5a5a5a');
+    barrelGrad.addColorStop(1, dim);
+    ctx.fillStyle = barrelGrad;
+    ctx.fillRect(BARREL_X, BARREL_TOP, BARREL_W, BARREL_BOTTOM - BARREL_TOP);
+
+    // Shaft (drops down with handle)
+    const shaftTop = handleYRef.current;
+    const shaftBottom = BARREL_TOP + 16;
+    ctx.fillStyle = '#888';
+    ctx.fillRect(HANDLE_X - SHAFT_W / 2, shaftTop, SHAFT_W, shaftBottom - shaftTop);
+
+    // Pressure indicator: green band climbing
+    const indicatorTop = lerp(HANDLE_BOTTOM_Y - 14, BARREL_TOP + 18, pumpUnits / 100);
+    ctx.fillStyle = phosphor;
+    ctx.globalAlpha = 0.18;
+    ctx.fillRect(BARREL_X + 4, indicatorTop, BARREL_W - 8, BARREL_BOTTOM - indicatorTop - 4);
+    ctx.globalAlpha = 1;
+
+    // Hose to balloon
+    ctx.strokeStyle = ink;
+    ctx.lineWidth = 5;
+    ctx.lineCap = 'round';
+    ctx.beginPath();
+    ctx.moveTo(BARREL_X + BARREL_W, BARREL_TOP + (BARREL_BOTTOM - BARREL_TOP) * 0.5);
+    ctx.bezierCurveTo(
+      BARREL_X + BARREL_W + 30,
+      BARREL_TOP + 8,
+      PUMP_WIDTH - 8,
+      BARREL_TOP + 30,
+      PUMP_WIDTH - 4,
+      BARREL_TOP + 50,
+    );
+    ctx.stroke();
+
+    // Handle (T-bar)
+    ctx.fillStyle = '#222';
+    ctx.fillRect(HANDLE_X - 70, handleYRef.current - 14, 140, 18);
+
+    ctx.beginPath();
+    ctx.fillStyle = '#444';
+    ctx.arc(HANDLE_X, handleYRef.current - 5, HANDLE_RADIUS, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.lineWidth = 2;
+    ctx.strokeStyle = ink;
+    ctx.stroke();
+  }, [pumpUnits]);
+
+  useEffect(() => {
+    let raf = 0;
+    const tick = () => {
+      draw();
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [draw]);
+
+  const animateSpringBack = useCallback(() => {
+    if (animFrameRef.current !== null) cancelAnimationFrame(animFrameRef.current);
+    const step = () => {
+      const current = handleYRef.current;
+      if (current <= HANDLE_TOP_Y + 0.5) {
+        handleYRef.current = HANDLE_TOP_Y;
+        setHandleY(HANDLE_TOP_Y);
+        animFrameRef.current = null;
+        return;
+      }
+      const next = Math.max(HANDLE_TOP_Y, current - SPRING_RETURN_PX_PER_FRAME);
+      handleYRef.current = next;
+      setHandleY(next);
+      animFrameRef.current = requestAnimationFrame(step);
+    };
+    animFrameRef.current = requestAnimationFrame(step);
+  }, []);
+
+  const handlePointerDown = (e: PointerEvent<HTMLCanvasElement>) => {
+    if (disabled) return;
+    if (animFrameRef.current !== null) {
+      cancelAnimationFrame(animFrameRef.current);
+      animFrameRef.current = null;
+    }
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    canvas.setPointerCapture(e.pointerId);
+    draggingRef.current = true;
+    dragStartPointerYRef.current = e.clientY;
+    dragStartHandleYRef.current = handleYRef.current;
+    lastPointerYRef.current = e.clientY;
+  };
+
+  const handlePointerMove = (e: PointerEvent<HTMLCanvasElement>) => {
+    if (!draggingRef.current || disabled) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const scale = rect.height / PUMP_HEIGHT;
+    const deltaPx = (e.clientY - dragStartPointerYRef.current) / scale;
+    const desiredY = dragStartHandleYRef.current + deltaPx;
+    const clamped = Math.max(HANDLE_TOP_Y, Math.min(HANDLE_BOTTOM_Y, desiredY));
+
+    const previousY = handleYRef.current;
+    if (clamped > previousY) {
+      const downwardPx = clamped - previousY;
+      const units = (downwardPx / HANDLE_TRAVEL) * 10;
+      if (units > 0) {
+        onStrokeUnits(units);
+        playWoosh(Math.min(1, units / 4));
+      }
+    }
+
+    handleYRef.current = clamped;
+    setHandleY(clamped);
+    lastPointerYRef.current = e.clientY;
+  };
+
+  const handlePointerUp = (e: PointerEvent<HTMLCanvasElement>) => {
+    if (!draggingRef.current) return;
+    draggingRef.current = false;
+    const canvas = canvasRef.current;
+    if (canvas) canvas.releasePointerCapture(e.pointerId);
+    animateSpringBack();
+  };
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{
+        width: '100%',
+        maxWidth: PUMP_WIDTH,
+        height: 'auto',
+        aspectRatio: `${PUMP_WIDTH} / ${PUMP_HEIGHT}`,
+        cursor: disabled ? 'default' : 'grab',
+      }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
+    />
+  );
+}

--- a/app/frontend/Experiences/index.ts
+++ b/app/frontend/Experiences/index.ts
@@ -4,3 +4,5 @@ export { default as Question } from './Question/Question';
 export { default as Announcement } from './Announcement/Announcement';
 export { default as Buzzer } from './Buzzer/Buzzer';
 export { default as GuessWho } from './GuessWho/GuessWho';
+export { default as MinigameArithmetic } from './MinigameArithmetic/MinigameArithmetic';
+export { default as MinigameBalloonPump } from './MinigameBalloonPump/MinigameBalloonPump';

--- a/app/frontend/Hooks/index.ts
+++ b/app/frontend/Hooks/index.ts
@@ -37,3 +37,5 @@ export { useEvent } from './useEvent';
 export { usePerformers } from './usePerformers';
 export { usePerformer } from './usePerformer';
 export { useFollowPerformer } from './useFollowPerformer';
+export { useMinigameArithmetic } from './useMinigameArithmetic';
+export { useMinigameBalloonPump, useBalloonPumpLeader } from './useMinigameBalloonPump';

--- a/app/frontend/Hooks/useMinigameArithmetic.ts
+++ b/app/frontend/Hooks/useMinigameArithmetic.ts
@@ -1,0 +1,93 @@
+import { useCallback, useState } from 'react';
+
+import { useAdminAuth } from '@cctv/contexts/AdminAuthContext';
+import { useExperience } from '@cctv/contexts/ExperienceContext';
+
+interface ActionResult {
+  success: boolean;
+  error?: string;
+}
+
+export function useMinigameArithmetic() {
+  const { code, experienceFetch } = useExperience();
+  const { adminFetch } = useAdminAuth();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const buildAdminUrl = useCallback(
+    (blockId: string, action: 'start' | 'end') =>
+      `/api/experiences/${encodeURIComponent(code ?? '')}/blocks/${encodeURIComponent(blockId)}/minigame/arithmetic/${action}`,
+    [code],
+  );
+
+  const buildResponseUrl = useCallback(
+    (blockId: string) =>
+      `/api/experiences/${encodeURIComponent(code ?? '')}/blocks/${encodeURIComponent(blockId)}/minigame/arithmetic/responses`,
+    [code],
+  );
+
+  const start = useCallback(
+    async (blockId: string): Promise<ActionResult> => {
+      if (!code) return { success: false, error: 'Missing experience code' };
+      setError(null);
+      const res = await adminFetch(buildAdminUrl(blockId, 'start'), { method: 'POST' });
+      const data = await res.json();
+      if (!res.ok || !data?.success) {
+        const msg = data?.error || 'Failed to start minigame';
+        setError(msg);
+        return { success: false, error: msg };
+      }
+      return { success: true };
+    },
+    [code, adminFetch, buildAdminUrl],
+  );
+
+  const end = useCallback(
+    async (blockId: string): Promise<ActionResult> => {
+      if (!code) return { success: false, error: 'Missing experience code' };
+      setError(null);
+      const res = await adminFetch(buildAdminUrl(blockId, 'end'), { method: 'POST' });
+      const data = await res.json();
+      if (!res.ok || !data?.success) {
+        const msg = data?.error || 'Failed to end minigame';
+        setError(msg);
+        return { success: false, error: msg };
+      }
+      return { success: true };
+    },
+    [code, adminFetch, buildAdminUrl],
+  );
+
+  const submitAnswer = useCallback(
+    async (blockId: string, questionIndex: number, answer: string): Promise<ActionResult> => {
+      if (!code) return { success: false, error: 'Missing experience code' };
+      setIsSubmitting(true);
+      setError(null);
+      try {
+        const res = await experienceFetch(buildResponseUrl(blockId), {
+          method: 'POST',
+          body: JSON.stringify({ question_index: questionIndex, answer }),
+        });
+        const data = await res.json();
+        if (!res.ok || !data?.success) {
+          const msg = data?.error || 'Failed to submit answer';
+          setError(msg);
+          return { success: false, error: msg };
+        }
+        return { success: true };
+      } catch (e: unknown) {
+        const msg =
+          e instanceof Error && e.message === 'Authentication expired'
+            ? 'Authentication expired'
+            : 'Connection error. Please try again.';
+        setError(msg);
+        return { success: false, error: msg };
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [code, experienceFetch, buildResponseUrl],
+  );
+
+  return { start, end, submitAnswer, isSubmitting, error };
+}

--- a/app/frontend/Hooks/useMinigameBalloonPump.ts
+++ b/app/frontend/Hooks/useMinigameBalloonPump.ts
@@ -1,0 +1,166 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useAdminAuth } from '@cctv/contexts/AdminAuthContext';
+import {
+  BalloonPumpLeaderUpdate,
+  useDispatchRegistry,
+} from '@cctv/contexts/DispatchRegistryContext';
+import { useExperience } from '@cctv/contexts/ExperienceContext';
+
+interface ActionResult {
+  success: boolean;
+  error?: string;
+}
+
+const MIN_PUMP_INTERVAL_MS = 100;
+
+export function useMinigameBalloonPump() {
+  const { code, experienceFetch } = useExperience();
+  const { adminFetch } = useAdminAuth();
+  const [error, setError] = useState<string | null>(null);
+  const lastPumpAtRef = useRef(0);
+  const pendingFillRef = useRef<number | null>(null);
+  const flushTimerRef = useRef<number | null>(null);
+  const inflightRef = useRef(false);
+
+  const buildAdminUrl = useCallback(
+    (blockId: string, action: 'start' | 'end') =>
+      `/api/experiences/${encodeURIComponent(code ?? '')}/blocks/${encodeURIComponent(blockId)}/minigame/balloon_pump/${action}`,
+    [code],
+  );
+
+  const buildPumpUrl = useCallback(
+    (blockId: string) =>
+      `/api/experiences/${encodeURIComponent(code ?? '')}/blocks/${encodeURIComponent(blockId)}/minigame/balloon_pump/pump`,
+    [code],
+  );
+
+  const start = useCallback(
+    async (blockId: string): Promise<ActionResult> => {
+      if (!code) return { success: false, error: 'Missing experience code' };
+      setError(null);
+      const res = await adminFetch(buildAdminUrl(blockId, 'start'), { method: 'POST' });
+      const data = await res.json();
+      if (!res.ok || !data?.success) {
+        const msg = data?.error || 'Failed to start minigame';
+        setError(msg);
+        return { success: false, error: msg };
+      }
+      return { success: true };
+    },
+    [code, adminFetch, buildAdminUrl],
+  );
+
+  const end = useCallback(
+    async (blockId: string): Promise<ActionResult> => {
+      if (!code) return { success: false, error: 'Missing experience code' };
+      setError(null);
+      const res = await adminFetch(buildAdminUrl(blockId, 'end'), { method: 'POST' });
+      const data = await res.json();
+      if (!res.ok || !data?.success) {
+        const msg = data?.error || 'Failed to end minigame';
+        setError(msg);
+        return { success: false, error: msg };
+      }
+      return { success: true };
+    },
+    [code, adminFetch, buildAdminUrl],
+  );
+
+  const sendPump = useCallback(
+    async (blockId: string, fillAmount: number) => {
+      if (inflightRef.current) {
+        pendingFillRef.current = fillAmount;
+        return;
+      }
+
+      inflightRef.current = true;
+      try {
+        await experienceFetch(buildPumpUrl(blockId), {
+          method: 'POST',
+          body: JSON.stringify({ fill_amount: fillAmount }),
+        });
+      } catch {
+        // Network errors are non-fatal: next pump tick will retry with the latest fill
+      } finally {
+        inflightRef.current = false;
+        const queued = pendingFillRef.current;
+        if (queued !== null) {
+          pendingFillRef.current = null;
+          sendPump(blockId, queued);
+        }
+      }
+    },
+    [experienceFetch, buildPumpUrl],
+  );
+
+  const submitPump = useCallback(
+    (blockId: string, fillAmount: number) => {
+      if (!code) return;
+      const now = Date.now();
+      const elapsed = now - lastPumpAtRef.current;
+
+      if (elapsed >= MIN_PUMP_INTERVAL_MS) {
+        lastPumpAtRef.current = now;
+        sendPump(blockId, fillAmount);
+        if (flushTimerRef.current !== null) {
+          window.clearTimeout(flushTimerRef.current);
+          flushTimerRef.current = null;
+        }
+      } else {
+        pendingFillRef.current = fillAmount;
+        if (flushTimerRef.current === null) {
+          flushTimerRef.current = window.setTimeout(() => {
+            flushTimerRef.current = null;
+            const fill = pendingFillRef.current;
+            if (fill !== null) {
+              pendingFillRef.current = null;
+              lastPumpAtRef.current = Date.now();
+              sendPump(blockId, fill);
+            }
+          }, MIN_PUMP_INTERVAL_MS - elapsed);
+        }
+      }
+    },
+    [code, sendPump],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (flushTimerRef.current !== null) {
+        window.clearTimeout(flushTimerRef.current);
+      }
+    };
+  }, []);
+
+  return { start, end, submitPump, error };
+}
+
+export function useBalloonPumpLeader(
+  blockId: string,
+  initial: BalloonPumpLeaderUpdate,
+): BalloonPumpLeaderUpdate {
+  const { registerBalloonPumpListener, unregisterBalloonPumpListener } = useDispatchRegistry();
+  const [state, setState] = useState<BalloonPumpLeaderUpdate>(initial);
+  const initialRef = useRef(initial);
+
+  useEffect(() => {
+    if (
+      initial.leader_fill !== initialRef.current.leader_fill ||
+      initial.target_units !== initialRef.current.target_units ||
+      initial.leader_participant_id !== initialRef.current.leader_participant_id
+    ) {
+      initialRef.current = initial;
+      setState(initial);
+    }
+  }, [initial]);
+
+  useEffect(() => {
+    registerBalloonPumpListener(blockId, (update) => {
+      setState(update);
+    });
+    return () => unregisterBalloonPumpListener(blockId);
+  }, [blockId, registerBalloonPumpListener, unregisterBalloonPumpListener]);
+
+  return state;
+}

--- a/app/frontend/Pages/Manage/CreateBlock/CreateBlock.tsx
+++ b/app/frontend/Pages/Manage/CreateBlock/CreateBlock.tsx
@@ -11,6 +11,8 @@ import CreateBuzzer from './CreateBuzzer/CreateBuzzer';
 import CreateFamilyFeud from './CreateFamilyFeud/CreateFamilyFeud';
 import CreateGuessWho from './CreateGuessWho/CreateGuessWho';
 import CreateMadLib from './CreateMadLib/CreateMadLib';
+import CreateMinigameArithmetic from './CreateMinigameArithmetic/CreateMinigameArithmetic';
+import CreateMinigameBalloonPump from './CreateMinigameBalloonPump/CreateMinigameBalloonPump';
 import CreatePhotoUpload from './CreatePhotoUpload/CreatePhotoUpload';
 import CreatePoll from './CreatePoll/CreatePoll';
 import CreateQuestion from './CreateQuestion/CreateQuestion';
@@ -65,6 +67,8 @@ function CreateBlockForm({ onClose }: CreateBlockFormProps) {
           { label: 'Photo Upload', value: BlockKind.PHOTO_UPLOAD },
           { label: 'Buzzer', value: BlockKind.BUZZER },
           { label: 'Guess Who', value: BlockKind.GUESS_WHO },
+          { label: 'Minigame: Arithmetic', value: BlockKind.MINIGAME_ARITHMETIC },
+          { label: 'Minigame: Balloon Pump', value: BlockKind.MINIGAME_BALLOON_PUMP },
         ]}
         value={blockData.kind}
         onChange={setKind}
@@ -127,6 +131,10 @@ function BlockEditor() {
       return <CreateBuzzer data={blockData.data} onChange={onChange} />;
     case BlockKind.GUESS_WHO:
       return <CreateGuessWho data={blockData.data} onChange={onChange} />;
+    case BlockKind.MINIGAME_ARITHMETIC:
+      return <CreateMinigameArithmetic data={blockData.data} onChange={onChange} />;
+    case BlockKind.MINIGAME_BALLOON_PUMP:
+      return <CreateMinigameBalloonPump data={blockData.data} onChange={onChange} />;
     default:
       const exhaustiveCheck: never = blockData;
       return <div className={styles.details}>Unknown block type: {exhaustiveCheck}</div>;

--- a/app/frontend/Pages/Manage/CreateBlock/CreateBlockContext.tsx
+++ b/app/frontend/Pages/Manage/CreateBlock/CreateBlockContext.tsx
@@ -43,6 +43,20 @@ import {
 } from './CreateGuessWho/CreateGuessWho';
 import { getDefaultMadLibState, validateMadLib } from './CreateMadLib/CreateMadLib';
 import {
+  buildMinigameArithmeticPayload,
+  canMinigameArithmeticOpenImmediately,
+  getDefaultMinigameArithmeticState,
+  processMinigameArithmeticBeforeSubmit,
+  validateMinigameArithmetic,
+} from './CreateMinigameArithmetic/CreateMinigameArithmetic';
+import {
+  buildMinigameBalloonPumpPayload,
+  canMinigameBalloonPumpOpenImmediately,
+  getDefaultMinigameBalloonPumpState,
+  processMinigameBalloonPumpBeforeSubmit,
+  validateMinigameBalloonPump,
+} from './CreateMinigameBalloonPump/CreateMinigameBalloonPump';
+import {
   buildPhotoUploadPayload,
   canPhotoUploadOpenImmediately,
   getDefaultPhotoUploadState,
@@ -108,6 +122,13 @@ export function CreateBlockProvider({
         return { kind: BlockKind.BUZZER, data: getDefaultBuzzerState() };
       case BlockKind.GUESS_WHO:
         return { kind: BlockKind.GUESS_WHO, data: getDefaultGuessWhoState() };
+      case BlockKind.MINIGAME_ARITHMETIC:
+        return { kind: BlockKind.MINIGAME_ARITHMETIC, data: getDefaultMinigameArithmeticState() };
+      case BlockKind.MINIGAME_BALLOON_PUMP:
+        return {
+          kind: BlockKind.MINIGAME_BALLOON_PUMP,
+          data: getDefaultMinigameBalloonPumpState(),
+        };
       default: {
         const _exhaust: never = blockKind;
         throw new Error(`Unknown block kind: ${_exhaust}`);
@@ -169,6 +190,18 @@ export function CreateBlockProvider({
         case BlockKind.GUESS_WHO:
           validationError = validateGuessWho(blockData.data);
           break;
+        case BlockKind.MINIGAME_ARITHMETIC:
+          validationError = validateMinigameArithmetic(blockData.data);
+          if (!validationError && visibleSegments.length === 0) {
+            validationError = 'A segment is required for arithmetic minigames';
+          }
+          break;
+        case BlockKind.MINIGAME_BALLOON_PUMP:
+          validationError = validateMinigameBalloonPump(blockData.data);
+          if (!validationError && visibleSegments.length === 0) {
+            validationError = 'A segment is required for balloon pump minigames';
+          }
+          break;
         default: {
           const _exhaust: never = blockData;
           validationError = `Unknown block kind: ${(_exhaust as FormBlockData).kind}`;
@@ -205,6 +238,12 @@ export function CreateBlockProvider({
           break;
         case BlockKind.GUESS_WHO:
           canOpenImmediately = canGuessWhoOpenImmediately(blockData.data, participants);
+          break;
+        case BlockKind.MINIGAME_ARITHMETIC:
+          canOpenImmediately = canMinigameArithmeticOpenImmediately(blockData.data, participants);
+          break;
+        case BlockKind.MINIGAME_BALLOON_PUMP:
+          canOpenImmediately = canMinigameBalloonPumpOpenImmediately(blockData.data, participants);
           break;
         default: {
           const _exhaust: never = blockData;
@@ -272,6 +311,18 @@ export function CreateBlockProvider({
             data: processGuessWhoBeforeSubmit(blockData.data, status, participants),
           };
           break;
+        case BlockKind.MINIGAME_ARITHMETIC:
+          processedFormData = {
+            kind: BlockKind.MINIGAME_ARITHMETIC,
+            data: processMinigameArithmeticBeforeSubmit(blockData.data, status, participants),
+          };
+          break;
+        case BlockKind.MINIGAME_BALLOON_PUMP:
+          processedFormData = {
+            kind: BlockKind.MINIGAME_BALLOON_PUMP,
+            data: processMinigameBalloonPumpBeforeSubmit(blockData.data, status, participants),
+          };
+          break;
         default: {
           const _exhaust: never = blockData;
           processedFormData = _exhaust as FormBlockData;
@@ -307,6 +358,12 @@ export function CreateBlockProvider({
           break;
         case BlockKind.GUESS_WHO:
           payload = buildGuessWhoPayload(processedFormData.data);
+          break;
+        case BlockKind.MINIGAME_ARITHMETIC:
+          payload = buildMinigameArithmeticPayload(processedFormData.data);
+          break;
+        case BlockKind.MINIGAME_BALLOON_PUMP:
+          payload = buildMinigameBalloonPumpPayload(processedFormData.data);
           break;
         default: {
           const _exhaust: never = processedFormData;

--- a/app/frontend/Pages/Manage/CreateBlock/CreateMinigameArithmetic/CreateMinigameArithmetic.tsx
+++ b/app/frontend/Pages/Manage/CreateBlock/CreateMinigameArithmetic/CreateMinigameArithmetic.tsx
@@ -1,0 +1,101 @@
+import { TextInput } from '@cctv/core/TextInput/TextInput';
+import {
+  BlockComponentProps,
+  BlockKind,
+  BlockStatus,
+  MinigameArithmeticApiPayload,
+  MinigameArithmeticData,
+  MinigameArithmeticPayload,
+  ParticipantSummary,
+} from '@cctv/types';
+
+import sharedStyles from '../CreateBlock.module.scss';
+
+export const getDefaultMinigameArithmeticState = (): MinigameArithmeticData => ({
+  duration_seconds: 60,
+  question_count: 30,
+  leaderboard_size: 5,
+});
+
+export const validateMinigameArithmetic = (data: MinigameArithmeticData): string | null => {
+  if (!Number.isInteger(data.duration_seconds) || data.duration_seconds <= 0) {
+    return 'Duration must be a positive whole number of seconds';
+  }
+  if (!Number.isInteger(data.question_count) || data.question_count <= 0) {
+    return 'Question count must be a positive whole number';
+  }
+  if (!Number.isInteger(data.leaderboard_size) || data.leaderboard_size <= 0) {
+    return 'Leaderboard size must be a positive whole number';
+  }
+  return null;
+};
+
+export const buildMinigameArithmeticPayload = (
+  data: MinigameArithmeticData,
+): MinigameArithmeticApiPayload => ({
+  type: BlockKind.MINIGAME_ARITHMETIC,
+  variant: 'arithmetic',
+  duration_seconds: data.duration_seconds,
+  question_count: data.question_count,
+  leaderboard_size: data.leaderboard_size,
+});
+
+export const canMinigameArithmeticOpenImmediately = (
+  _data: MinigameArithmeticData,
+  _participants: ParticipantSummary[],
+): boolean => false;
+
+export const processMinigameArithmeticBeforeSubmit = (
+  data: MinigameArithmeticData,
+  _status: BlockStatus,
+  _participants: ParticipantSummary[],
+): MinigameArithmeticData => data;
+
+export const minigameArithmeticPayloadToFormData = (
+  payload: MinigameArithmeticPayload,
+): MinigameArithmeticData => ({
+  duration_seconds: payload.duration_seconds,
+  question_count: payload.question_count,
+  leaderboard_size: payload.leaderboard_size,
+});
+
+export default function CreateMinigameArithmetic({
+  data,
+  onChange,
+}: BlockComponentProps<MinigameArithmeticData>) {
+  const handleNumberChange =
+    (key: keyof MinigameArithmeticData) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = parseInt(e.target.value, 10);
+      onChange?.({ [key]: Number.isNaN(value) ? 0 : value } as Partial<MinigameArithmeticData>);
+    };
+
+  return (
+    <div className={sharedStyles.container}>
+      <TextInput
+        label="Duration (seconds)"
+        type="number"
+        min={5}
+        value={data.duration_seconds || ''}
+        onChange={handleNumberChange('duration_seconds')}
+      />
+      <TextInput
+        label="Number of questions"
+        type="number"
+        min={1}
+        value={data.question_count || ''}
+        onChange={handleNumberChange('question_count')}
+      />
+      <TextInput
+        label="Leaderboard size"
+        type="number"
+        min={1}
+        value={data.leaderboard_size || ''}
+        onChange={handleNumberChange('leaderboard_size')}
+      />
+      <p style={{ fontSize: '0.85rem', opacity: 0.8 }}>
+        A segment is required — set it under "Additional Details". Only participants in that segment
+        will see and play the minigame.
+      </p>
+    </div>
+  );
+}

--- a/app/frontend/Pages/Manage/CreateBlock/CreateMinigameBalloonPump/CreateMinigameBalloonPump.tsx
+++ b/app/frontend/Pages/Manage/CreateBlock/CreateMinigameBalloonPump/CreateMinigameBalloonPump.tsx
@@ -1,0 +1,87 @@
+import { TextInput } from '@cctv/core/TextInput/TextInput';
+import {
+  BlockComponentProps,
+  BlockKind,
+  BlockStatus,
+  MinigameBalloonPumpApiPayload,
+  MinigameBalloonPumpData,
+  MinigameBalloonPumpPayload,
+  ParticipantSummary,
+} from '@cctv/types';
+
+import sharedStyles from '../CreateBlock.module.scss';
+
+const STROKE_UNITS = 10;
+
+export const getDefaultMinigameBalloonPumpState = (): MinigameBalloonPumpData => ({
+  target_units: 100,
+});
+
+export const validateMinigameBalloonPump = (data: MinigameBalloonPumpData): string | null => {
+  if (!Number.isInteger(data.target_units) || data.target_units <= 0) {
+    return 'Target units must be a positive whole number';
+  }
+  return null;
+};
+
+export const buildMinigameBalloonPumpPayload = (
+  data: MinigameBalloonPumpData,
+): MinigameBalloonPumpApiPayload => ({
+  type: BlockKind.MINIGAME_BALLOON_PUMP,
+  variant: 'balloon_pump',
+  target_units: data.target_units,
+});
+
+export const canMinigameBalloonPumpOpenImmediately = (
+  _data: MinigameBalloonPumpData,
+  _participants: ParticipantSummary[],
+): boolean => false;
+
+export const processMinigameBalloonPumpBeforeSubmit = (
+  data: MinigameBalloonPumpData,
+  _status: BlockStatus,
+  _participants: ParticipantSummary[],
+): MinigameBalloonPumpData => data;
+
+export const minigameBalloonPumpPayloadToFormData = (
+  payload: MinigameBalloonPumpPayload,
+): MinigameBalloonPumpData => ({
+  target_units: payload.target_units,
+});
+
+export default function CreateMinigameBalloonPump({
+  data,
+  onChange,
+}: BlockComponentProps<MinigameBalloonPumpData>) {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(e.target.value, 10);
+    onChange?.({ target_units: Number.isNaN(value) ? 0 : value });
+  };
+
+  const strokeEstimate =
+    data.target_units > 0 ? (data.target_units / STROKE_UNITS).toFixed(1) : '0';
+
+  return (
+    <div className={sharedStyles.container}>
+      <TextInput
+        label="Target units to fill the balloon"
+        type="number"
+        min={1}
+        value={data.target_units || ''}
+        onChange={handleChange}
+      />
+      <p style={{ fontSize: '0.85rem', opacity: 0.8, marginTop: '0.25rem' }}>
+        A full pump stroke = {STROKE_UNITS} units.{' '}
+        {data.target_units > 0 && (
+          <>
+            That's about <strong>{strokeEstimate} strokes</strong> to burst.
+          </>
+        )}
+      </p>
+      <p style={{ fontSize: '0.85rem', opacity: 0.8 }}>
+        A segment is required — set it under "Additional Details". Only participants in that segment
+        will play.
+      </p>
+    </div>
+  );
+}

--- a/app/frontend/Pages/Manage/EditBlock/EditBlock.tsx
+++ b/app/frontend/Pages/Manage/EditBlock/EditBlock.tsx
@@ -9,6 +9,8 @@ import CreateBuzzer from '../CreateBlock/CreateBuzzer/CreateBuzzer';
 import CreateFamilyFeud from '../CreateBlock/CreateFamilyFeud/CreateFamilyFeud';
 import CreateGuessWho from '../CreateBlock/CreateGuessWho/CreateGuessWho';
 import CreateMadLib from '../CreateBlock/CreateMadLib/CreateMadLib';
+import CreateMinigameArithmetic from '../CreateBlock/CreateMinigameArithmetic/CreateMinigameArithmetic';
+import CreateMinigameBalloonPump from '../CreateBlock/CreateMinigameBalloonPump/CreateMinigameBalloonPump';
 import CreatePhotoUpload from '../CreateBlock/CreatePhotoUpload/CreatePhotoUpload';
 import CreatePoll from '../CreateBlock/CreatePoll/CreatePoll';
 import CreateQuestion from '../CreateBlock/CreateQuestion/CreateQuestion';
@@ -48,6 +50,8 @@ const KIND_LABELS: Record<BlockKind, string> = {
   [BlockKind.PHOTO_UPLOAD]: 'Photo Upload',
   [BlockKind.BUZZER]: 'Buzzer',
   [BlockKind.GUESS_WHO]: 'Guess Who',
+  [BlockKind.MINIGAME_ARITHMETIC]: 'Minigame: Arithmetic',
+  [BlockKind.MINIGAME_BALLOON_PUMP]: 'Minigame: Balloon Pump',
 };
 
 function EditBlockForm({ onClose, block }: EditBlockFormProps) {
@@ -135,6 +139,10 @@ function BlockEditor() {
       return <CreateBuzzer data={blockData.data} onChange={onChange} />;
     case BlockKind.GUESS_WHO:
       return <CreateGuessWho data={blockData.data} onChange={onChange} />;
+    case BlockKind.MINIGAME_ARITHMETIC:
+      return <CreateMinigameArithmetic data={blockData.data} onChange={onChange} />;
+    case BlockKind.MINIGAME_BALLOON_PUMP:
+      return <CreateMinigameBalloonPump data={blockData.data} onChange={onChange} />;
     default: {
       const _exhaust: never = blockData;
       return <div>Unknown block type: {(_exhaust as { kind: string }).kind}</div>;

--- a/app/frontend/Pages/Manage/EditBlock/EditBlockContext.tsx
+++ b/app/frontend/Pages/Manage/EditBlock/EditBlockContext.tsx
@@ -36,6 +36,16 @@ import {
 } from '../CreateBlock/CreateGuessWho/CreateGuessWho';
 import { madLibPayloadToFormData, validateMadLib } from '../CreateBlock/CreateMadLib/CreateMadLib';
 import {
+  buildMinigameArithmeticPayload,
+  minigameArithmeticPayloadToFormData,
+  validateMinigameArithmetic,
+} from '../CreateBlock/CreateMinigameArithmetic/CreateMinigameArithmetic';
+import {
+  buildMinigameBalloonPumpPayload,
+  minigameBalloonPumpPayloadToFormData,
+  validateMinigameBalloonPump,
+} from '../CreateBlock/CreateMinigameBalloonPump/CreateMinigameBalloonPump';
+import {
   buildPhotoUploadPayload,
   photoUploadPayloadToFormData,
   validatePhotoUpload,
@@ -99,6 +109,16 @@ function blockToFormData(block: Block, participants: ParticipantSummary[]): Form
       return { kind: BlockKind.BUZZER, data: buzzerPayloadToFormData(block.payload) };
     case BlockKind.GUESS_WHO:
       return { kind: BlockKind.GUESS_WHO, data: guessWhoPayloadToFormData(block.payload) };
+    case BlockKind.MINIGAME_ARITHMETIC:
+      return {
+        kind: BlockKind.MINIGAME_ARITHMETIC,
+        data: minigameArithmeticPayloadToFormData(block.payload),
+      };
+    case BlockKind.MINIGAME_BALLOON_PUMP:
+      return {
+        kind: BlockKind.MINIGAME_BALLOON_PUMP,
+        data: minigameBalloonPumpPayloadToFormData(block.payload),
+      };
     default: {
       const _exhaust: never = block;
       throw new Error(`Unknown block kind: ${(_exhaust as Block).kind}`);
@@ -141,6 +161,10 @@ function buildUpdatePayload(blockData: FormBlockData): {
       return { payload: buildBuzzerPayload(blockData.data) };
     case BlockKind.GUESS_WHO:
       return { payload: buildGuessWhoPayload(blockData.data) };
+    case BlockKind.MINIGAME_ARITHMETIC:
+      return { payload: buildMinigameArithmeticPayload(blockData.data) };
+    case BlockKind.MINIGAME_BALLOON_PUMP:
+      return { payload: buildMinigameBalloonPumpPayload(blockData.data) };
     default: {
       const _exhaust: never = blockData;
       throw new Error(`Unknown block kind: ${(_exhaust as FormBlockData).kind}`);
@@ -180,8 +204,13 @@ export function EditBlockProvider({
     async (visible_to_segment_ids: string[]) => {
       const { payload, variables, questions } = buildUpdatePayload(blockData);
 
+      const payloadWithShowOnMonitor: Record<string, unknown> = {
+        ...(payload as unknown as Record<string, unknown>),
+        show_on_monitor: showOnMonitor,
+      };
+
       const result = await updateExperienceBlock(block.id, {
-        payload: { ...payload, show_on_monitor: showOnMonitor },
+        payload: payloadWithShowOnMonitor,
         visible_to_segment_ids,
         ...(variables && { variables }),
         ...(questions && { questions }),
@@ -233,6 +262,12 @@ export function EditBlockProvider({
         break;
       case BlockKind.GUESS_WHO:
         validationError = validateGuessWho(blockData.data);
+        break;
+      case BlockKind.MINIGAME_ARITHMETIC:
+        validationError = validateMinigameArithmetic(blockData.data);
+        break;
+      case BlockKind.MINIGAME_BALLOON_PUMP:
+        validationError = validateMinigameBalloonPump(blockData.data);
         break;
       default: {
         const _exhaust: never = blockData;

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -20,6 +20,8 @@ export enum BlockKind {
   PHOTO_UPLOAD = 'photo_upload',
   BUZZER = 'buzzer',
   GUESS_WHO = 'guess_who',
+  MINIGAME_ARITHMETIC = 'minigame_arithmetic',
+  MINIGAME_BALLOON_PUMP = 'minigame_balloon_pump',
 }
 
 export interface ExperienceSegment {
@@ -120,6 +122,71 @@ export interface GuessWhoPayload {
   error?: string;
 }
 
+export interface MinigameArithmeticQuestion {
+  index: number;
+  lhs: number;
+  op: '+' | '-' | '*' | '/';
+  rhs: number;
+  answer: number;
+  prompt: string;
+}
+
+export interface MinigameArithmeticCurrentQuestion {
+  index: number;
+  prompt: string;
+}
+
+export interface MinigameArithmeticLeaderboardEntry {
+  participant_id: string;
+  user_id: string;
+  name: string;
+  avatar?: { strokes?: AvatarStroke[] } | null;
+  correct: number;
+  completed: number;
+  rank: number;
+}
+
+export interface MinigameArithmeticPayload {
+  variant: 'arithmetic';
+  duration_seconds: number;
+  question_count: number;
+  leaderboard_size: number;
+  started_at: string | null;
+  ended_at: string | null;
+  questions?: MinigameArithmeticQuestion[];
+  current_question?: MinigameArithmeticCurrentQuestion | null;
+  score?: { correct: number; completed: number };
+  leaderboard?: MinigameArithmeticLeaderboardEntry[];
+  submission_count?: number;
+}
+
+export interface MinigameBalloonPumpPodiumEntry {
+  place: 1 | 2 | 3;
+  participant_id: string;
+  name: string;
+  avatar?: { strokes?: AvatarStroke[] } | null;
+  fill_amount: number;
+}
+
+export interface MinigameBalloonPumpLiveResult {
+  participant_id: string;
+  name: string;
+  fill_amount: number;
+}
+
+export interface MinigameBalloonPumpPayload {
+  variant: 'balloon_pump';
+  target_units: number;
+  started_at: string | null;
+  ended_at: string | null;
+  leader_fill: number;
+  leader_participant_id: string | null;
+  winner_participant_ids: string[];
+  own_fill?: number;
+  podium?: MinigameBalloonPumpPodiumEntry[];
+  live_results?: MinigameBalloonPumpLiveResult[];
+}
+
 export interface BlockLink {
   id: string;
   parent_block_id: string;
@@ -214,6 +281,20 @@ export interface GuessWhoApiPayload {
   segment_id: string;
 }
 
+export interface MinigameArithmeticApiPayload {
+  type: 'minigame_arithmetic';
+  variant: 'arithmetic';
+  duration_seconds: number;
+  question_count: number;
+  leaderboard_size: number;
+}
+
+export interface MinigameBalloonPumpApiPayload {
+  type: 'minigame_balloon_pump';
+  variant: 'balloon_pump';
+  target_units: number;
+}
+
 // Discriminated union for API payloads (what gets sent to backend)
 export type ApiPayload =
   | PollApiPayload
@@ -223,7 +304,9 @@ export type ApiPayload =
   | FamilyFeudApiPayload
   | PhotoUploadApiPayload
   | BuzzerApiPayload
-  | GuessWhoApiPayload;
+  | GuessWhoApiPayload
+  | MinigameArithmeticApiPayload
+  | MinigameBalloonPumpApiPayload;
 
 // ===== PLAYBILL TYPES =====
 
@@ -384,6 +467,24 @@ export interface GuessWhoBlock extends BaseBlock {
   payload: GuessWhoPayload;
 }
 
+export interface MinigameArithmeticBlock extends BaseBlock {
+  kind: BlockKind.MINIGAME_ARITHMETIC;
+  payload: MinigameArithmeticPayload;
+  responses?: {
+    total: number;
+    correct_count?: number;
+    participant_counts?: Record<string, number>;
+  };
+}
+
+export interface MinigameBalloonPumpBlock extends BaseBlock {
+  kind: BlockKind.MINIGAME_BALLOON_PUMP;
+  payload: MinigameBalloonPumpPayload;
+  responses?: {
+    total: number;
+  };
+}
+
 export type Block =
   | PollBlock
   | QuestionBlock
@@ -392,7 +493,9 @@ export type Block =
   | FamilyFeudBlock
   | PhotoUploadBlock
   | BuzzerBlock
-  | GuessWhoBlock;
+  | GuessWhoBlock
+  | MinigameArithmeticBlock
+  | MinigameBalloonPumpBlock;
 
 export interface Experience {
   id: string;
@@ -453,7 +556,9 @@ export interface CreateBlockPayload {
     | FamilyFeudPayload
     | PhotoUploadPayload
     | BuzzerPayload
-    | GuessWhoPayload;
+    | GuessWhoPayload
+    | MinigameArithmeticPayload
+    | MinigameBalloonPumpPayload;
   visible_to_segment_ids?: string[];
   status?: BlockStatus;
   open_immediately?: boolean;
@@ -610,6 +715,7 @@ export const WebSocketMessageTypes = {
   CONFIRM_SUBSCRIPTION: 'confirm_subscription',
   PING: 'ping',
   FAMILY_FEUD_UPDATED: 'family_feud_updated',
+  BALLOON_PUMP_LEADER_UPDATED: 'balloon_pump_leader_updated',
   SUBMISSION_STATE: 'submission_state',
 } as const;
 
@@ -693,6 +799,15 @@ export interface FamilyFeudUpdatedMessage
   data: FamilyFeudDispatchPayload;
 }
 
+export interface BalloonPumpLeaderUpdatedMessage {
+  type: 'balloon_pump_leader_updated';
+  block_id: string;
+  leader_fill: number;
+  target_units: number;
+  leader_participant_id: string | null;
+  timestamp: number;
+}
+
 export type SubmissionState = Record<
   string,
   { id: string; answer: Record<string, unknown>; photo_url?: string }
@@ -716,6 +831,7 @@ export type WebSocketMessage =
   | ConfirmSubscriptionMessage
   | PingMessage
   | FamilyFeudUpdatedMessage
+  | BalloonPumpLeaderUpdatedMessage
   | SubmissionStateMessage;
 
 export interface DrawingUpdateMessage {
@@ -853,6 +969,16 @@ export interface GuessWhoData {
   segment_id: string;
 }
 
+export interface MinigameArithmeticData {
+  duration_seconds: number;
+  question_count: number;
+  leaderboard_size: number;
+}
+
+export interface MinigameBalloonPumpData {
+  target_units: number;
+}
+
 // Union type for all block component data
 export type BlockComponentData =
   | PollData
@@ -862,7 +988,9 @@ export type BlockComponentData =
   | FamilyFeudData
   | PhotoUploadData
   | BuzzerData
-  | GuessWhoData;
+  | GuessWhoData
+  | MinigameArithmeticData
+  | MinigameBalloonPumpData;
 
 // Discriminated union for form block data
 export type FormBlockData =
@@ -873,7 +1001,9 @@ export type FormBlockData =
   | { kind: BlockKind.FAMILY_FEUD; data: FamilyFeudData }
   | { kind: BlockKind.PHOTO_UPLOAD; data: PhotoUploadData }
   | { kind: BlockKind.BUZZER; data: BuzzerData }
-  | { kind: BlockKind.GUESS_WHO; data: GuessWhoData };
+  | { kind: BlockKind.GUESS_WHO; data: GuessWhoData }
+  | { kind: BlockKind.MINIGAME_ARITHMETIC; data: MinigameArithmeticData }
+  | { kind: BlockKind.MINIGAME_BALLOON_PUMP; data: MinigameBalloonPumpData };
 
 export interface UpdateBlockPayload {
   payload: ApiPayload | Record<string, unknown>;

--- a/app/jobs/minigames/end_arithmetic_job.rb
+++ b/app/jobs/minigames/end_arithmetic_job.rb
@@ -1,0 +1,22 @@
+module Minigames
+  class EndArithmeticJob < ApplicationJob
+    queue_as :default
+
+    discard_on ActiveRecord::RecordNotFound
+
+    def perform(block_id, expected_started_at_iso)
+      block = ExperienceBlock.find(block_id)
+      return unless block.kind == ExperienceBlock::MINIGAME_ARITHMETIC
+
+      payload = block.payload || {}
+      return if payload["ended_at"].present?
+      return if payload["started_at"].blank?
+      return if payload["started_at"] != expected_started_at_iso
+
+      payload["ended_at"] = Time.current.iso8601
+      block.update!(payload: payload, status: :closed)
+
+      Experiences::Broadcaster.new(block.experience).broadcast_experience_update
+    end
+  end
+end

--- a/app/models/experience_block.rb
+++ b/app/models/experience_block.rb
@@ -9,7 +9,9 @@ class ExperienceBlock < ApplicationRecord
     FAMILY_FEUD = "family_feud",
     PHOTO_UPLOAD = "photo_upload",
     BUZZER = "buzzer",
-    GUESS_WHO = "guess_who"
+    GUESS_WHO = "guess_who",
+    MINIGAME_ARITHMETIC = "minigame_arithmetic",
+    MINIGAME_BALLOON_PUMP = "minigame_balloon_pump"
   ]
 
   belongs_to :experience
@@ -28,6 +30,8 @@ class ExperienceBlock < ApplicationRecord
   has_many :experience_mad_lib_submissions, dependent: :destroy
   has_many :experience_photo_upload_submissions, dependent: :destroy
   has_many :experience_buzzer_submissions, dependent: :destroy
+  has_many :experience_minigame_submissions, dependent: :destroy
+  has_many :experience_minigame_balloon_results, dependent: :destroy
 
   has_many :parent_links,
     class_name: "ExperienceBlockLink",

--- a/app/models/experience_minigame_balloon_result.rb
+++ b/app/models/experience_minigame_balloon_result.rb
@@ -1,0 +1,7 @@
+class ExperienceMinigameBalloonResult < ApplicationRecord
+  belongs_to :experience_block
+  belongs_to :user
+
+  validates :fill_amount, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :user_id, uniqueness: { scope: :experience_block_id }
+end

--- a/app/models/experience_minigame_submission.rb
+++ b/app/models/experience_minigame_submission.rb
@@ -1,0 +1,8 @@
+class ExperienceMinigameSubmission < ApplicationRecord
+  belongs_to :experience_block
+  belongs_to :user
+
+  validates :question_index, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :submitted_at, presence: true
+  validates :user_id, uniqueness: { scope: [:experience_block_id, :question_index] }
+end

--- a/app/policies/experience_block_policy.rb
+++ b/app/policies/experience_block_policy.rb
@@ -19,6 +19,14 @@ class ExperienceBlockPolicy < ApplicationPolicy
     user_allowed_to_interact_with_block?
   end
 
+  def submit_minigame_arithmetic_response?
+    user_allowed_to_interact_with_block?
+  end
+
+  def submit_minigame_balloon_pump_update?
+    user_allowed_to_interact_with_block?
+  end
+
   private
 
   def user_allowed_to_interact_with_block?

--- a/app/services/experiences/broadcaster.rb
+++ b/app/services/experiences/broadcaster.rb
@@ -22,6 +22,39 @@ class Experiences::Broadcaster
     broadcast_admin_view
   end
 
+  # Lightweight monitor-only broadcast for balloon pump leader updates.
+  # Server-side throttle: only broadcasts if MIN_BROADCAST_INTERVAL_MS has
+  # elapsed since the last broadcast for this block.
+  MIN_BALLOON_BROADCAST_INTERVAL_MS = 150
+
+  def broadcast_balloon_pump_leader_update(block:)
+    payload      = block.payload || {}
+    last_at_iso  = payload["leader_last_broadcast_at"]
+    now          = Time.current
+
+    if last_at_iso.present?
+      last_at = Time.iso8601(last_at_iso) rescue nil
+      if last_at && ((now - last_at) * 1000.0) < MIN_BALLOON_BROADCAST_INTERVAL_MS
+        return
+      end
+    end
+
+    block.update_columns(
+      payload: payload.merge("leader_last_broadcast_at" => now.iso8601),
+      updated_at: now
+    )
+
+    message = WebsocketMessageService.balloon_pump_leader_updated(
+      block_id: block.id,
+      leader_fill: payload["leader_fill"].to_i,
+      target_units: payload["target_units"].to_i,
+      leader_participant_id: payload["leader_participant_id"]
+    )
+
+    send_broadcast(self.class.monitor_stream_key(experience), message)
+    send_broadcast(self.class.admin_stream_key(experience), message)
+  end
+
   def broadcast_family_feud_update(block_id:, operation:, data:)
     Rails.logger.info(
       "[Broadcaster] Broadcasting family_feud_updated to experience #{experience.code}"

--- a/app/services/experiences/orchestrator.rb
+++ b/app/services/experiences/orchestrator.rb
@@ -25,10 +25,12 @@ module Experiences
       transaction do
         max_position = experience.experience_blocks.parent_blocks.maximum(:position) || -1
 
+        prepared_payload = prepare_block_payload(kind: kind, payload: payload)
+
         block = experience.experience_blocks.create!(
           kind: kind,
           status: status,
-          payload: payload,
+          payload: prepared_payload,
           visible_to_roles: visible_to_roles,
           target_user_ids: target_user_ids,
           position: max_position + 1
@@ -37,6 +39,40 @@ module Experiences
 
         block
       end
+    end
+
+    def prepare_block_payload(kind:, payload:)
+      payload = payload.deep_dup || {}
+
+      case kind
+      when ExperienceBlock::MINIGAME_ARITHMETIC
+        question_count   = payload["question_count"].to_i
+        duration_seconds = payload["duration_seconds"].to_i
+        leaderboard_size = payload["leaderboard_size"].to_i
+
+        raise ArgumentError, "question_count must be positive"   unless question_count.positive?
+        raise ArgumentError, "duration_seconds must be positive" unless duration_seconds.positive?
+        raise ArgumentError, "leaderboard_size must be positive" unless leaderboard_size.positive?
+
+        payload["variant"]    = "arithmetic"
+        payload["questions"]  = Minigames::ArithmeticQuestionGenerator.generate(count: question_count)
+        payload["started_at"] = nil
+        payload["ended_at"]   = nil
+      when ExperienceBlock::MINIGAME_BALLOON_PUMP
+        target_units = payload["target_units"].to_i
+        raise ArgumentError, "target_units must be positive" unless target_units.positive?
+
+        payload["variant"]                  = "balloon_pump"
+        payload["target_units"]              = target_units
+        payload["started_at"]                = nil
+        payload["ended_at"]                  = nil
+        payload["winner_participant_ids"]    = []
+        payload["leader_fill"]               = 0
+        payload["leader_participant_id"]     = nil
+        payload["leader_last_broadcast_at"]  = nil
+      end
+
+      payload
     end
 
     def close_block!(block_id)
@@ -566,6 +602,160 @@ module Experiences
       block
     end
 
+    # Minigame: arithmetic ----------------------------------------------------
+
+    def start_minigame_arithmetic!(block_id:)
+      block = experience.experience_blocks.find(block_id)
+      raise ArgumentError, "Block is not an arithmetic minigame" unless block.kind == ExperienceBlock::MINIGAME_ARITHMETIC
+
+      transaction do
+        payload = block.payload || {}
+
+        unless payload["questions"].is_a?(Array) && payload["questions"].any?
+          raise ArgumentError, "Minigame has no questions configured"
+        end
+
+        started_at = Time.current
+        duration   = payload["duration_seconds"].to_i
+
+        payload["started_at"] = started_at.iso8601
+        payload["ended_at"]   = nil
+
+        block.update!(payload: payload, status: :open)
+
+        Minigames::EndArithmeticJob.set(wait: duration.seconds)
+          .perform_later(block.id, payload["started_at"])
+
+        block
+      end
+    end
+
+    def end_minigame_arithmetic!(block_id:)
+      block = experience.experience_blocks.find(block_id)
+      raise ArgumentError, "Block is not an arithmetic minigame" unless block.kind == ExperienceBlock::MINIGAME_ARITHMETIC
+
+      transaction do
+        payload = block.payload || {}
+        return block if payload["ended_at"].present?
+
+        payload["ended_at"] = Time.current.iso8601
+        block.update!(payload: payload, status: :closed)
+      end
+
+      block
+    end
+
+    def submit_minigame_arithmetic_response!(block_id:, question_index:, answer:)
+      block = experience.experience_blocks.find(block_id)
+      raise ArgumentError, "Block is not an arithmetic minigame" unless block.kind == ExperienceBlock::MINIGAME_ARITHMETIC
+
+      payload = block.payload || {}
+      raise Experiences::InvalidTransitionError, "Minigame has not started" if payload["started_at"].blank?
+      raise Experiences::InvalidTransitionError, "Minigame has ended"       if payload["ended_at"].present?
+
+      questions = Array(payload["questions"])
+      index     = question_index.to_i
+      question  = questions[index]
+      raise ActiveRecord::RecordNotFound, "Question not found" unless question
+
+      submitted_text = answer.to_s.strip
+      parsed         = Integer(submitted_text, exception: false)
+      correct        = parsed.present? && parsed == question["answer"].to_i
+
+      submission = ExperienceMinigameSubmission.find_or_initialize_by(
+        experience_block_id: block.id,
+        user_id:             actor.id,
+        question_index:      index
+      )
+
+      return submission if submission.persisted?
+
+      submission.submitted_answer = submitted_text
+      submission.correct          = correct
+      submission.submitted_at     = Time.current
+      submission.save!
+      submission
+    end
+
+    # Minigame: balloon pump --------------------------------------------------
+
+    def start_minigame_balloon_pump!(block_id:)
+      block = experience.experience_blocks.find(block_id)
+      raise ArgumentError, "Block is not a balloon pump minigame" unless block.kind == ExperienceBlock::MINIGAME_BALLOON_PUMP
+
+      transaction do
+        payload                              = block.payload || {}
+        payload["started_at"]                = Time.current.iso8601
+        payload["ended_at"]                  = nil
+        payload["winner_participant_ids"]    = []
+        payload["leader_fill"]               = 0
+        payload["leader_participant_id"]     = nil
+        payload["leader_last_broadcast_at"]  = nil
+
+        block.experience_minigame_balloon_results.delete_all
+        block.update!(payload: payload, status: :open)
+      end
+
+      block
+    end
+
+    def end_minigame_balloon_pump!(block_id:)
+      block = experience.experience_blocks.find(block_id)
+      raise ArgumentError, "Block is not a balloon pump minigame" unless block.kind == ExperienceBlock::MINIGAME_BALLOON_PUMP
+
+      transaction do
+        payload = block.payload || {}
+        return block if payload["ended_at"].present?
+
+        payload["ended_at"] = Time.current.iso8601
+        block.update!(payload: payload, status: :closed)
+      end
+
+      block
+    end
+
+    # Hot path. Returns a hash describing the resulting state so the controller
+    # can decide what (if anything) to broadcast.
+    #
+    # @return [Hash] :result — :accepted, :ignored
+    #                :winners — array of ExperienceParticipant when game just ended
+    #                :leader_changed — true if the leader for monitor display moved
+    def submit_balloon_pump_update!(block_id:, fill_amount:)
+      block = experience.experience_blocks.find(block_id)
+      raise ArgumentError, "Block is not a balloon pump minigame" unless block.kind == ExperienceBlock::MINIGAME_BALLOON_PUMP
+
+      payload      = block.payload || {}
+      target_units = payload["target_units"].to_i
+      requested    = fill_amount.to_i.clamp(0, target_units)
+
+      return { result: :ignored } if payload["started_at"].blank?
+      return { result: :ignored } if payload["ended_at"].present?
+
+      participant = experience.experience_participants.find_by(user_id: actor.id)
+      raise ActiveRecord::RecordNotFound, "Participant not found" unless participant
+
+      result = ExperienceMinigameBalloonResult
+        .where(experience_block_id: block.id, user_id: actor.id)
+        .first_or_initialize
+
+      return { result: :ignored } if result.persisted? && result.fill_amount >= requested
+
+      result.fill_amount = [result.fill_amount, requested].max
+      result.save!
+
+      crossed_target = result.fill_amount >= target_units
+      leader_changed = false
+      winners        = []
+
+      if crossed_target
+        winners = close_balloon_pump_with_winners!(block, target_units)
+      else
+        leader_changed = update_balloon_pump_leader!(block, participant, result.fill_amount)
+      end
+
+      { result: :accepted, winners: winners, leader_changed: leader_changed }
+    end
+
     def update_block!(block_id:, payload:, visible_to_segment_ids:, variables: nil, questions: nil)
       transaction do
         block = experience.experience_blocks.find(block_id)
@@ -669,6 +859,54 @@ module Experiences
     end
 
     private
+
+    def close_balloon_pump_with_winners!(block, target_units)
+      transaction do
+        block.lock!
+        payload = block.payload || {}
+        return [] if payload["ended_at"].present?
+
+        winning_results = ExperienceMinigameBalloonResult
+          .where(experience_block_id: block.id)
+          .where("fill_amount >= ?", target_units)
+          .to_a
+
+        winning_user_ids = winning_results.map(&:user_id)
+        winners = experience.experience_participants
+          .includes(:user)
+          .where(user_id: winning_user_ids)
+          .to_a
+
+        payload["ended_at"]               = Time.current.iso8601
+        payload["winner_participant_ids"] = winners.map(&:id)
+        payload["leader_fill"]            = target_units
+        payload["leader_participant_id"]  = winners.first&.id
+
+        block.update!(payload: payload, status: :closed)
+        winners
+      end
+    end
+
+    def update_balloon_pump_leader!(block, participant, fill_amount)
+      payload      = block.payload || {}
+      target_units = payload["target_units"].to_i
+      return false if target_units.zero?
+
+      current_leader_fill = payload["leader_fill"].to_i
+
+      return false if fill_amount < current_leader_fill
+      return false if fill_amount == current_leader_fill && payload["leader_participant_id"] == participant.id
+
+      block.update_columns(
+        payload: payload.merge(
+          "leader_fill"            => fill_amount,
+          "leader_participant_id"  => participant.id
+        ),
+        updated_at: Time.current
+      )
+
+      true
+    end
 
     def adjust_guess_who_slide!(block_id, delta)
       block = experience.experience_blocks.find(block_id)

--- a/app/services/experiences/visibility.rb
+++ b/app/services/experiences/visibility.rb
@@ -81,15 +81,21 @@ module Experiences
       children_by_parent = all.reject { |b| b.parent_block_id.nil? }.group_by(&:parent_block_id)
 
       candidates = if @experience.status == "lobby"
-        parents.select { |b| b.show_in_lobby? && !b.has_visibility_rules? }
+        parents.select { |b| b.show_in_lobby? && monitor_visibility_ok?(b) }
       else
-        parents.select { |b| b.open? && !b.has_visibility_rules? }
+        parents.select { |b| b.open? && monitor_visibility_ok?(b) }
       end
 
       candidates
         .reject { |b| b.payload["show_on_monitor"] == false }
         .sort_by(&:position)
         .flat_map { |parent| resolve_monitor_entry(parent, children_by_parent[parent.id] || []) }
+    end
+
+    def monitor_visibility_ok?(block)
+      return true if block.kind == ExperienceBlock::MINIGAME_ARITHMETIC
+      return true if block.kind == ExperienceBlock::MINIGAME_BALLOON_PUMP
+      !block.has_visibility_rules?
     end
 
     def participant_visible_blocks(participant)
@@ -169,8 +175,114 @@ module Experiences
     end
 
     def shape_payload(block, participant_role, user, view_context)
-      return block.payload unless block.kind == ExperienceBlock::GUESS_WHO
+      case block.kind
+      when ExperienceBlock::GUESS_WHO
+        shape_guess_who_payload(block, participant_role, user, view_context)
+      when ExperienceBlock::MINIGAME_ARITHMETIC
+        shape_minigame_arithmetic_payload(block, participant_role, user, view_context)
+      when ExperienceBlock::MINIGAME_BALLOON_PUMP
+        shape_minigame_balloon_pump_payload(block, participant_role, user, view_context)
+      else
+        block.payload
+      end
+    end
 
+    def shape_minigame_balloon_pump_payload(block, participant_role, user, view_context)
+      payload = block.payload.deep_dup || {}
+
+      privileged =
+        view_context == :admin ||
+        (view_context == :participant && (mod_or_host?(participant_role) || admin_user?(user)))
+
+      target_units = payload["target_units"].to_i
+      ended        = payload["ended_at"].present?
+
+      shaped = {
+        "variant"                => payload["variant"],
+        "target_units"           => target_units,
+        "started_at"             => payload["started_at"],
+        "ended_at"               => payload["ended_at"],
+        "leader_fill"            => payload["leader_fill"].to_i,
+        "leader_participant_id"  => payload["leader_participant_id"],
+        "winner_participant_ids" => Array(payload["winner_participant_ids"])
+      }
+
+      if view_context == :participant && !privileged && user
+        own = ExperienceMinigameBalloonResult.find_by(experience_block_id: block.id, user_id: user.id)
+        shaped["own_fill"] = own&.fill_amount.to_i
+      end
+
+      if ended
+        shaped["podium"] = balloon_pump_podium(block, shaped["winner_participant_ids"])
+      end
+
+      if privileged
+        shaped["live_results"] = balloon_pump_live_results(block)
+      end
+
+      shaped
+    end
+
+    def balloon_pump_live_results(block)
+      participants_by_user_id = @experience.experience_participants
+        .includes(:user)
+        .index_by(&:user_id)
+
+      ExperienceMinigameBalloonResult
+        .where(experience_block_id: block.id)
+        .order(fill_amount: :desc)
+        .map do |r|
+          participant = participants_by_user_id[r.user_id]
+          next nil unless participant
+
+          {
+            "participant_id" => participant.id,
+            "name"           => participant.name,
+            "fill_amount"    => r.fill_amount
+          }
+        end.compact
+    end
+
+    def balloon_pump_podium(block, winner_ids)
+      participants_by_user_id = @experience.experience_participants
+        .includes(:user)
+        .index_by(&:user_id)
+      participants_by_id = @experience.experience_participants.index_by(&:id)
+
+      winners = winner_ids.filter_map { |id| participants_by_id[id] }
+
+      results = ExperienceMinigameBalloonResult
+        .where(experience_block_id: block.id)
+        .where.not(user_id: winners.map(&:user_id))
+        .order(fill_amount: :desc)
+        .limit(2)
+        .to_a
+
+      runners_up = results.filter_map do |r|
+        participants_by_user_id[r.user_id]
+      end
+
+      podium_for = ->(participant, place, fill) do
+        next nil unless participant
+        {
+          "place"          => place,
+          "participant_id" => participant.id,
+          "name"           => participant.name,
+          "avatar"         => participant.avatar.presence,
+          "fill_amount"    => fill
+        }
+      end
+
+      target_units = block.payload["target_units"].to_i
+
+      gold = winners.map { |p| podium_for.call(p, 1, target_units) }
+      silver = runners_up[0] && [podium_for.call(runners_up[0], 2, results[0]&.fill_amount.to_i)]
+      bronze = runners_up[1] && [podium_for.call(runners_up[1], 3, results[1]&.fill_amount.to_i)]
+
+      [gold, silver, bronze].compact.flatten.compact
+    end
+
+    def shape_guess_who_payload(block, participant_role, user, view_context)
       payload = block.payload.deep_dup || {}
 
       payload["user_a"] = guess_who_user_summary(payload["user_a_id"])
@@ -195,6 +307,83 @@ module Experiences
       end
 
       payload
+    end
+
+    def shape_minigame_arithmetic_payload(block, participant_role, user, view_context)
+      payload = block.payload.deep_dup || {}
+
+      privileged =
+        view_context == :admin ||
+        (view_context == :participant && (mod_or_host?(participant_role) || admin_user?(user)))
+
+      ended  = payload["ended_at"].present?
+      started = payload["started_at"].present?
+
+      shaped = {
+        "variant"          => payload["variant"],
+        "duration_seconds" => payload["duration_seconds"],
+        "question_count"   => payload["question_count"],
+        "leaderboard_size" => payload["leaderboard_size"],
+        "started_at"       => payload["started_at"],
+        "ended_at"         => payload["ended_at"]
+      }
+
+      if privileged
+        shaped["questions"] = payload["questions"]
+      end
+
+      if ended
+        size = payload["leaderboard_size"].to_i
+        full = Minigames::ArithmeticLeaderboard.compute(block: block)
+        shaped["leaderboard"] = leaderboard_top_n(full, size)
+      end
+
+      if view_context == :participant && !privileged
+        shaped.merge!(participant_minigame_view(block, user, started, ended, payload))
+      end
+
+      if view_context == :monitor
+        shaped["submission_count"] = ExperienceMinigameSubmission.where(experience_block_id: block.id).count
+      end
+
+      shaped
+    end
+
+    def participant_minigame_view(block, user, started, ended, payload)
+      return { "current_question" => nil, "score" => { "correct" => 0, "completed" => 0 } } unless user
+
+      submissions = ExperienceMinigameSubmission
+        .where(experience_block_id: block.id, user_id: user.id)
+        .order(question_index: :asc)
+        .to_a
+
+      answered_indexes = submissions.map(&:question_index).to_set
+      questions = Array(payload["questions"])
+
+      next_question = nil
+      if started && !ended
+        next_q = questions.find { |q| !answered_indexes.include?(q["index"]) }
+        if next_q
+          next_question = { "index" => next_q["index"], "prompt" => next_q["prompt"] }
+        end
+      end
+
+      {
+        "current_question" => next_question,
+        "score" => {
+          "correct"   => submissions.count(&:correct),
+          "completed" => submissions.size
+        }
+      }
+    end
+
+    def leaderboard_top_n(entries, size)
+      return entries if size <= 0 || entries.empty?
+
+      cutoff = entries[size - 1]
+      return entries if cutoff.nil?
+
+      entries.select { |e| e["correct"] >= cutoff["correct"] }
     end
 
     def guess_who_user_summary(user_id)
@@ -276,6 +465,21 @@ module Experiences
         end
 
         response
+
+      when ExperienceBlock::MINIGAME_ARITHMETIC
+        submissions = block.experience_minigame_submissions.to_a
+        response    = { total: submissions.count }
+
+        if mod_or_host?(participant_role) || admin_user?(user)
+          response[:correct_count]   = submissions.count(&:correct)
+          response[:participant_counts] = submissions.group_by(&:user_id).transform_values(&:size)
+        end
+
+        response
+
+      when ExperienceBlock::MINIGAME_BALLOON_PUMP
+        results = block.experience_minigame_balloon_results.to_a
+        { total: results.count }
 
       when ExperienceBlock::BUZZER
         submissions = block.experience_buzzer_submissions.order(Arel.sql("answer->>'buzzed_at' ASC")).to_a

--- a/app/services/minigames/arithmetic_leaderboard.rb
+++ b/app/services/minigames/arithmetic_leaderboard.rb
@@ -1,0 +1,64 @@
+module Minigames
+  class ArithmeticLeaderboard
+    def self.compute(block:)
+      new(block: block).compute
+    end
+
+    def initialize(block:)
+      @block = block
+    end
+
+    def compute
+      submissions = ExperienceMinigameSubmission
+        .where(experience_block_id: @block.id)
+        .order(submitted_at: :asc)
+
+      grouped = submissions.group_by(&:user_id)
+
+      participants_by_user_id = @block.experience.experience_participants
+        .includes(:user)
+        .index_by(&:user_id)
+
+      entries = grouped.map do |user_id, user_submissions|
+        participant = participants_by_user_id[user_id]
+        next nil unless participant
+
+        correct = user_submissions.count(&:correct)
+        last_submitted_at = user_submissions.last.submitted_at
+
+        {
+          "participant_id" => participant.id,
+          "user_id"        => user_id,
+          "name"           => participant.name,
+          "avatar"         => participant.avatar.presence,
+          "correct"        => correct,
+          "completed"      => user_submissions.size,
+          "last_submitted_at" => last_submitted_at
+        }
+      end.compact
+
+      ranked = entries.sort_by.with_index { |e, i| [-e["correct"], i] }
+
+      assign_ranks(ranked)
+    end
+
+    private
+
+    def assign_ranks(entries)
+      previous_correct = nil
+      previous_rank    = 0
+
+      entries.each_with_index do |entry, index|
+        if entry["correct"] == previous_correct
+          entry["rank"] = previous_rank
+        else
+          entry["rank"]    = index + 1
+          previous_rank    = entry["rank"]
+          previous_correct = entry["correct"]
+        end
+      end
+
+      entries
+    end
+  end
+end

--- a/app/services/minigames/arithmetic_question_generator.rb
+++ b/app/services/minigames/arithmetic_question_generator.rb
@@ -1,0 +1,102 @@
+module Minigames
+  class ArithmeticQuestionGenerator
+    EASY_OPS    = %w[+ -]
+    MEDIUM_OPS  = %w[+ - * /]
+    HARD_OPS    = %w[+ - * /]
+
+    EASY_THRESHOLD   = 10
+    MEDIUM_THRESHOLD = 20
+
+    def self.generate(count:, seed: nil)
+      new(count: count, seed: seed).generate
+    end
+
+    def initialize(count:, seed: nil)
+      @count   = count.to_i
+      @random  = seed ? Random.new(seed) : Random.new
+    end
+
+    def generate
+      raise ArgumentError, "count must be positive" if @count <= 0
+
+      Array.new(@count) do |index|
+        build_question(index)
+      end
+    end
+
+    private
+
+    def build_question(index)
+      operator   = pick_operator(index)
+      lhs, rhs   = pick_operands(operator, index)
+      answer     = compute(lhs, operator, rhs)
+
+      {
+        "index"  => index,
+        "lhs"    => lhs,
+        "op"     => operator,
+        "rhs"    => rhs,
+        "answer" => answer,
+        "prompt" => "#{lhs} #{display_operator(operator)} #{rhs}"
+      }
+    end
+
+    def pick_operator(index)
+      pool =
+        if index < EASY_THRESHOLD
+          EASY_OPS
+        elsif index < MEDIUM_THRESHOLD
+          MEDIUM_OPS
+        else
+          HARD_OPS
+        end
+
+      pool.sample(random: @random)
+    end
+
+    def pick_operands(operator, index)
+      max =
+        if index < EASY_THRESHOLD
+          12
+        elsif index < MEDIUM_THRESHOLD
+          20
+        else
+          50
+        end
+
+      case operator
+      when "+"
+        [@random.rand(1..max), @random.rand(1..max)]
+      when "-"
+        a = @random.rand(1..max)
+        b = @random.rand(1..a)
+        [a, b]
+      when "*"
+        cap = index < MEDIUM_THRESHOLD ? 12 : 15
+        [@random.rand(2..cap), @random.rand(2..cap)]
+      when "/"
+        divisor  = @random.rand(2..12)
+        quotient = @random.rand(2..(index < MEDIUM_THRESHOLD ? 12 : 15))
+        dividend = divisor * quotient
+        [dividend, divisor]
+      end
+    end
+
+    def compute(lhs, operator, rhs)
+      case operator
+      when "+" then lhs + rhs
+      when "-" then lhs - rhs
+      when "*" then lhs * rhs
+      when "/" then lhs / rhs
+      end
+    end
+
+    def display_operator(operator)
+      case operator
+      when "*" then "×"
+      when "/" then "÷"
+      else operator
+      end
+    end
+  end
+end

--- a/app/services/websocket_message_service.rb
+++ b/app/services/websocket_message_service.rb
@@ -10,6 +10,7 @@ class WebsocketMessageService
 
     # Block-specific updates
     FAMILY_FEUD_UPDATED: 'family_feud_updated',
+    BALLOON_PUMP_LEADER_UPDATED: 'balloon_pump_leader_updated',
 
     # Subscription management
     RESUBSCRIBE_REQUIRED: 'resubscribe_required',
@@ -89,6 +90,18 @@ class WebsocketMessageService
     {
       type: MESSAGE_TYPES[:SUBMISSION_STATE],
       submissions: submissions
+    }
+  end
+
+  # Build balloon pump leader update message (lightweight, monitor-only)
+  def self.balloon_pump_leader_updated(block_id:, leader_fill:, target_units:, leader_participant_id:)
+    {
+      type: MESSAGE_TYPES[:BALLOON_PUMP_LEADER_UPDATED],
+      block_id: block_id,
+      leader_fill: leader_fill,
+      target_units: target_units,
+      leader_participant_id: leader_participant_id,
+      timestamp: Time.current.to_f
     }
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,14 @@ Rails.application.routes.draw do
           post 'guess_who/next', action: :next_guess_who_slide
           post 'guess_who/previous', action: :previous_guess_who_slide
           post 'guess_who/reveal', action: :reveal_guess_who
+
+          post 'minigame/arithmetic/start', action: :start_minigame_arithmetic
+          post 'minigame/arithmetic/end', action: :end_minigame_arithmetic
+          post 'minigame/arithmetic/responses', action: :submit_minigame_arithmetic_response
+
+          post 'minigame/balloon_pump/start', action: :start_minigame_balloon_pump
+          post 'minigame/balloon_pump/end', action: :end_minigame_balloon_pump
+          post 'minigame/balloon_pump/pump', action: :submit_minigame_balloon_pump_update
         end
 
         # collection do

--- a/db/migrate/20260505000001_create_experience_minigame_submissions.rb
+++ b/db/migrate/20260505000001_create_experience_minigame_submissions.rb
@@ -1,0 +1,24 @@
+class CreateExperienceMinigameSubmissions < ActiveRecord::Migration[7.2]
+  def change
+    create_table :experience_minigame_submissions, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      t.uuid :experience_block_id, null: false
+      t.uuid :user_id, null: false
+      t.integer :question_index, null: false
+      t.string :submitted_answer
+      t.boolean :correct, null: false, default: false
+      t.datetime :submitted_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :experience_minigame_submissions, :experience_block_id
+    add_index :experience_minigame_submissions, :user_id
+    add_index :experience_minigame_submissions,
+      [:experience_block_id, :user_id, :question_index],
+      unique: true,
+      name: "index_minigame_submissions_unique"
+
+    add_foreign_key :experience_minigame_submissions, :experience_blocks, on_delete: :cascade
+    add_foreign_key :experience_minigame_submissions, :users, on_delete: :cascade
+  end
+end

--- a/db/migrate/20260505000002_create_experience_minigame_balloon_results.rb
+++ b/db/migrate/20260505000002_create_experience_minigame_balloon_results.rb
@@ -1,0 +1,25 @@
+class CreateExperienceMinigameBalloonResults < ActiveRecord::Migration[7.2]
+  def change
+    create_table :experience_minigame_balloon_results, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      t.uuid :experience_block_id, null: false
+      t.uuid :user_id, null: false
+      t.integer :fill_amount, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :experience_minigame_balloon_results, :experience_block_id
+    add_index :experience_minigame_balloon_results, :user_id
+    add_index :experience_minigame_balloon_results,
+      [:experience_block_id, :user_id],
+      unique: true,
+      name: "index_balloon_results_unique"
+    add_index :experience_minigame_balloon_results,
+      [:experience_block_id, :fill_amount],
+      order: { fill_amount: :desc },
+      name: "index_balloon_results_by_fill"
+
+    add_foreign_key :experience_minigame_balloon_results, :experience_blocks, on_delete: :cascade
+    add_foreign_key :experience_minigame_balloon_results, :users, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_17_000001) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_05_000002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -173,6 +173,32 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_17_000001) do
     t.index ["user_id"], name: "index_experience_mad_lib_submissions_on_user_id"
   end
 
+  create_table "experience_minigame_balloon_results", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "experience_block_id", null: false
+    t.uuid "user_id", null: false
+    t.integer "fill_amount", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["experience_block_id", "fill_amount"], name: "index_balloon_results_by_fill", order: { fill_amount: :desc }
+    t.index ["experience_block_id", "user_id"], name: "index_balloon_results_unique", unique: true
+    t.index ["experience_block_id"], name: "idx_on_experience_block_id_7a1bd4ca9d"
+    t.index ["user_id"], name: "index_experience_minigame_balloon_results_on_user_id"
+  end
+
+  create_table "experience_minigame_submissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "experience_block_id", null: false
+    t.uuid "user_id", null: false
+    t.integer "question_index", null: false
+    t.string "submitted_answer"
+    t.boolean "correct", default: false, null: false
+    t.datetime "submitted_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["experience_block_id", "user_id", "question_index"], name: "index_minigame_submissions_unique", unique: true
+    t.index ["experience_block_id"], name: "index_experience_minigame_submissions_on_experience_block_id"
+    t.index ["user_id"], name: "index_experience_minigame_submissions_on_user_id"
+  end
+
   create_table "experience_participant_segments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "experience_participant_id", null: false
     t.uuid "experience_segment_id", null: false
@@ -327,6 +353,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_17_000001) do
   add_foreign_key "experience_buzzer_submissions", "users", on_delete: :cascade
   add_foreign_key "experience_mad_lib_submissions", "experience_blocks", on_delete: :cascade
   add_foreign_key "experience_mad_lib_submissions", "users", on_delete: :cascade
+  add_foreign_key "experience_minigame_balloon_results", "experience_blocks", on_delete: :cascade
+  add_foreign_key "experience_minigame_balloon_results", "users", on_delete: :cascade
+  add_foreign_key "experience_minigame_submissions", "experience_blocks", on_delete: :cascade
+  add_foreign_key "experience_minigame_submissions", "users", on_delete: :cascade
   add_foreign_key "experience_participant_segments", "experience_participants", on_delete: :cascade
   add_foreign_key "experience_participant_segments", "experience_segments", on_delete: :cascade
   add_foreign_key "experience_participants", "experiences", on_delete: :cascade

--- a/spec/services/experiences/minigame_arithmetic_orchestrator_spec.rb
+++ b/spec/services/experiences/minigame_arithmetic_orchestrator_spec.rb
@@ -1,0 +1,179 @@
+require "rails_helper"
+
+RSpec.describe Experiences::Orchestrator, "minigame arithmetic" do
+  let(:experience) { create(:experience, status: :live) }
+  let(:host_user)  { create(:user) }
+  let!(:host)      { create(:experience_participant, :host, user: host_user, experience: experience) }
+  let!(:player)    { create(:experience_participant, :audience, experience: experience) }
+
+  subject(:orchestrator) { described_class.new(actor: host_user, experience: experience) }
+
+  describe "#add_block! for minigame_arithmetic" do
+    it "generates the questions and zeros the timestamps on creation" do
+      block = orchestrator.add_block!(
+        kind: ExperienceBlock::MINIGAME_ARITHMETIC,
+        payload: {
+          "duration_seconds" => 30,
+          "question_count"   => 5,
+          "leaderboard_size" => 3
+        }
+      )
+
+      expect(block.payload["variant"]).to eq("arithmetic")
+      expect(block.payload["questions"].size).to eq(5)
+      expect(block.payload["started_at"]).to be_nil
+      expect(block.payload["ended_at"]).to be_nil
+    end
+
+    it "raises when duration or question count is missing" do
+      expect {
+        orchestrator.add_block!(kind: ExperienceBlock::MINIGAME_ARITHMETIC, payload: {})
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#start_minigame_arithmetic!" do
+    let(:block) do
+      orchestrator.add_block!(
+        kind: ExperienceBlock::MINIGAME_ARITHMETIC,
+        payload: {
+          "duration_seconds" => 30,
+          "question_count"   => 5,
+          "leaderboard_size" => 3
+        }
+      )
+    end
+
+    it "sets started_at, opens the block, and schedules the end job" do
+      expect {
+        orchestrator.start_minigame_arithmetic!(block_id: block.id)
+      }.to have_enqueued_job(Minigames::EndArithmeticJob).with(block.id, kind_of(String))
+
+      block.reload
+      expect(block.payload["started_at"]).to be_present
+      expect(block.payload["ended_at"]).to be_nil
+      expect(block.status).to eq("open")
+    end
+  end
+
+  describe "#submit_minigame_arithmetic_response!" do
+    let(:block) do
+      orchestrator.add_block!(
+        kind: ExperienceBlock::MINIGAME_ARITHMETIC,
+        payload: {
+          "duration_seconds" => 30,
+          "question_count"   => 3,
+          "leaderboard_size" => 5
+        }
+      )
+    end
+
+    let(:player_orchestrator) do
+      described_class.new(actor: player.user, experience: experience)
+    end
+
+    before do
+      orchestrator.start_minigame_arithmetic!(block_id: block.id)
+    end
+
+    it "records correct answers" do
+      block.reload
+      first = block.payload["questions"].first
+
+      submission = player_orchestrator.submit_minigame_arithmetic_response!(
+        block_id:       block.id,
+        question_index: 0,
+        answer:         first["answer"].to_s
+      )
+
+      expect(submission.correct).to be(true)
+      expect(submission.question_index).to eq(0)
+    end
+
+    it "records wrong answers without telling the user" do
+      submission = player_orchestrator.submit_minigame_arithmetic_response!(
+        block_id:       block.id,
+        question_index: 0,
+        answer:         "-9999"
+      )
+
+      expect(submission.correct).to be(false)
+    end
+
+    it "treats blank answers as wrong but advances the player" do
+      submission = player_orchestrator.submit_minigame_arithmetic_response!(
+        block_id:       block.id,
+        question_index: 0,
+        answer:         ""
+      )
+
+      expect(submission.correct).to be(false)
+      expect(submission.submitted_answer).to eq("")
+    end
+
+    it "is idempotent per question index for a single player" do
+      player_orchestrator.submit_minigame_arithmetic_response!(
+        block_id: block.id, question_index: 0, answer: "1"
+      )
+
+      expect {
+        player_orchestrator.submit_minigame_arithmetic_response!(
+          block_id: block.id, question_index: 0, answer: "999"
+        )
+      }.not_to change { ExperienceMinigameSubmission.where(experience_block_id: block.id, user_id: player.user_id).count }
+    end
+
+    it "rejects submissions before start" do
+      block.reload
+      block.update!(payload: block.payload.merge("started_at" => nil))
+
+      expect {
+        player_orchestrator.submit_minigame_arithmetic_response!(
+          block_id: block.id, question_index: 0, answer: "1"
+        )
+      }.to raise_error(Experiences::InvalidTransitionError)
+    end
+
+    it "rejects submissions after end" do
+      orchestrator.end_minigame_arithmetic!(block_id: block.id)
+
+      expect {
+        player_orchestrator.submit_minigame_arithmetic_response!(
+          block_id: block.id, question_index: 0, answer: "1"
+        )
+      }.to raise_error(Experiences::InvalidTransitionError)
+    end
+  end
+
+  describe "#end_minigame_arithmetic!" do
+    let(:block) do
+      orchestrator.add_block!(
+        kind: ExperienceBlock::MINIGAME_ARITHMETIC,
+        payload: {
+          "duration_seconds" => 30,
+          "question_count"   => 3,
+          "leaderboard_size" => 5
+        }
+      )
+    end
+
+    before do
+      orchestrator.start_minigame_arithmetic!(block_id: block.id)
+    end
+
+    it "stamps ended_at and closes the block" do
+      orchestrator.end_minigame_arithmetic!(block_id: block.id)
+      block.reload
+      expect(block.payload["ended_at"]).to be_present
+      expect(block.status).to eq("closed")
+    end
+
+    it "is idempotent" do
+      orchestrator.end_minigame_arithmetic!(block_id: block.id)
+      first_ended_at = block.reload.payload["ended_at"]
+
+      orchestrator.end_minigame_arithmetic!(block_id: block.id)
+      expect(block.reload.payload["ended_at"]).to eq(first_ended_at)
+    end
+  end
+end

--- a/spec/services/experiences/minigame_balloon_pump_orchestrator_spec.rb
+++ b/spec/services/experiences/minigame_balloon_pump_orchestrator_spec.rb
@@ -1,0 +1,158 @@
+require "rails_helper"
+
+RSpec.describe Experiences::Orchestrator, "minigame balloon pump" do
+  let(:experience) { create(:experience, status: :live) }
+  let(:host_user)  { create(:user) }
+  let!(:host)      { create(:experience_participant, :host, user: host_user, experience: experience) }
+  let!(:player_a)  { create(:experience_participant, :audience, experience: experience) }
+  let!(:player_b)  { create(:experience_participant, :audience, experience: experience) }
+
+  subject(:orchestrator) { described_class.new(actor: host_user, experience: experience) }
+
+  describe "#add_block!" do
+    it "creates a balloon pump block with target_units and zeroed state" do
+      block = orchestrator.add_block!(
+        kind: ExperienceBlock::MINIGAME_BALLOON_PUMP,
+        payload: { "target_units" => 100 }
+      )
+
+      expect(block.payload["variant"]).to eq("balloon_pump")
+      expect(block.payload["target_units"]).to eq(100)
+      expect(block.payload["started_at"]).to be_nil
+      expect(block.payload["leader_fill"]).to eq(0)
+    end
+
+    it "raises when target_units is zero or negative" do
+      expect {
+        orchestrator.add_block!(kind: ExperienceBlock::MINIGAME_BALLOON_PUMP, payload: { "target_units" => 0 })
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#start_minigame_balloon_pump!" do
+    let(:block) do
+      orchestrator.add_block!(
+        kind: ExperienceBlock::MINIGAME_BALLOON_PUMP,
+        payload: { "target_units" => 50 }
+      )
+    end
+
+    it "stamps started_at, opens block, and clears any prior results" do
+      ExperienceMinigameBalloonResult.create!(
+        experience_block_id: block.id, user_id: player_a.user_id, fill_amount: 30
+      )
+
+      orchestrator.start_minigame_balloon_pump!(block_id: block.id)
+
+      block.reload
+      expect(block.payload["started_at"]).to be_present
+      expect(block.status).to eq("open")
+      expect(ExperienceMinigameBalloonResult.where(experience_block_id: block.id).count).to eq(0)
+    end
+  end
+
+  describe "#submit_balloon_pump_update!" do
+    let(:block) do
+      orchestrator.add_block!(
+        kind: ExperienceBlock::MINIGAME_BALLOON_PUMP,
+        payload: { "target_units" => 50 }
+      )
+    end
+
+    let(:player_a_orchestrator) { described_class.new(actor: player_a.user, experience: experience) }
+    let(:player_b_orchestrator) { described_class.new(actor: player_b.user, experience: experience) }
+
+    before { orchestrator.start_minigame_balloon_pump!(block_id: block.id) }
+
+    it "records the cumulative fill amount" do
+      player_a_orchestrator.submit_balloon_pump_update!(block_id: block.id, fill_amount: 20)
+      result = ExperienceMinigameBalloonResult.find_by(experience_block_id: block.id, user_id: player_a.user_id)
+      expect(result.fill_amount).to eq(20)
+    end
+
+    it "is monotonic — never decreases on a stale request" do
+      player_a_orchestrator.submit_balloon_pump_update!(block_id: block.id, fill_amount: 30)
+      player_a_orchestrator.submit_balloon_pump_update!(block_id: block.id, fill_amount: 15)
+
+      result = ExperienceMinigameBalloonResult.find_by(experience_block_id: block.id, user_id: player_a.user_id)
+      expect(result.fill_amount).to eq(30)
+    end
+
+    it "clamps fill at target_units" do
+      player_a_orchestrator.submit_balloon_pump_update!(block_id: block.id, fill_amount: 9999)
+      result = ExperienceMinigameBalloonResult.find_by(experience_block_id: block.id, user_id: player_a.user_id)
+      expect(result.fill_amount).to eq(50)
+    end
+
+    it "ends the block and marks the player as winner when they hit target" do
+      outcome = player_a_orchestrator.submit_balloon_pump_update!(block_id: block.id, fill_amount: 50)
+
+      block.reload
+      expect(block.payload["ended_at"]).to be_present
+      expect(block.status).to eq("closed")
+      expect(block.payload["winner_participant_ids"]).to eq([player_a.id])
+      expect(outcome[:winners].map(&:id)).to eq([player_a.id])
+    end
+
+    it "awards gold to multiple players who cross in the same close-out window" do
+      player_a_orchestrator.submit_balloon_pump_update!(block_id: block.id, fill_amount: 49)
+      player_b_orchestrator.submit_balloon_pump_update!(block_id: block.id, fill_amount: 49)
+
+      ExperienceMinigameBalloonResult
+        .where(experience_block_id: block.id, user_id: player_b.user_id)
+        .update_all(fill_amount: 50)
+
+      outcome = player_a_orchestrator.submit_balloon_pump_update!(block_id: block.id, fill_amount: 50)
+
+      expect(outcome[:winners].map(&:id)).to contain_exactly(player_a.id, player_b.id)
+      expect(block.reload.payload["winner_participant_ids"]).to contain_exactly(player_a.id, player_b.id)
+    end
+
+    it "ignores submissions before start" do
+      block.reload
+      block.update!(payload: block.payload.merge("started_at" => nil))
+      outcome = player_a_orchestrator.submit_balloon_pump_update!(block_id: block.id, fill_amount: 30)
+      expect(outcome[:result]).to eq(:ignored)
+    end
+
+    it "ignores submissions after end" do
+      orchestrator.end_minigame_balloon_pump!(block_id: block.id)
+      outcome = player_a_orchestrator.submit_balloon_pump_update!(block_id: block.id, fill_amount: 30)
+      expect(outcome[:result]).to eq(:ignored)
+    end
+
+    it "tracks the leader for monitor display" do
+      player_a_orchestrator.submit_balloon_pump_update!(block_id: block.id, fill_amount: 10)
+      player_b_orchestrator.submit_balloon_pump_update!(block_id: block.id, fill_amount: 25)
+
+      block.reload
+      expect(block.payload["leader_fill"]).to eq(25)
+      expect(block.payload["leader_participant_id"]).to eq(player_b.id)
+    end
+  end
+
+  describe "#end_minigame_balloon_pump!" do
+    let(:block) do
+      orchestrator.add_block!(
+        kind: ExperienceBlock::MINIGAME_BALLOON_PUMP,
+        payload: { "target_units" => 50 }
+      )
+    end
+
+    before { orchestrator.start_minigame_balloon_pump!(block_id: block.id) }
+
+    it "stamps ended_at and closes" do
+      orchestrator.end_minigame_balloon_pump!(block_id: block.id)
+      block.reload
+      expect(block.payload["ended_at"]).to be_present
+      expect(block.status).to eq("closed")
+    end
+
+    it "is idempotent" do
+      orchestrator.end_minigame_balloon_pump!(block_id: block.id)
+      first = block.reload.payload["ended_at"]
+      orchestrator.end_minigame_balloon_pump!(block_id: block.id)
+      expect(block.reload.payload["ended_at"]).to eq(first)
+    end
+  end
+end

--- a/spec/services/minigames/arithmetic_leaderboard_spec.rb
+++ b/spec/services/minigames/arithmetic_leaderboard_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe Minigames::ArithmeticLeaderboard do
+  let(:experience) { create(:experience, status: :live) }
+  let(:host) { create(:experience_participant, :host, experience: experience) }
+  let(:player_a) { create(:experience_participant, :audience, experience: experience) }
+  let(:player_b) { create(:experience_participant, :audience, experience: experience) }
+  let(:player_c) { create(:experience_participant, :audience, experience: experience) }
+
+  let(:block) do
+    create(
+      :experience_block,
+      experience: experience,
+      kind: ExperienceBlock::MINIGAME_ARITHMETIC,
+      payload: {
+        "variant" => "arithmetic",
+        "duration_seconds" => 60,
+        "question_count" => 5,
+        "leaderboard_size" => 5,
+        "questions" => [],
+        "started_at" => Time.current.iso8601,
+        "ended_at" => (Time.current + 1.minute).iso8601
+      }
+    )
+  end
+
+  before do
+    submit(player_a, 0, true,  Time.current)
+    submit(player_a, 1, true,  Time.current + 1.second)
+    submit(player_a, 2, false, Time.current + 2.seconds)
+
+    submit(player_b, 0, true,  Time.current)
+    submit(player_b, 1, true,  Time.current + 1.second)
+
+    submit(player_c, 0, false, Time.current)
+  end
+
+  it "ranks players by correct answers descending" do
+    result = described_class.compute(block: block)
+    expect(result.map { |r| r["participant_id"] }).to eq([player_a.id, player_b.id, player_c.id])
+  end
+
+  it "exposes correct/completed counts and rank" do
+    result = described_class.compute(block: block)
+
+    a, b, c = result
+    expect(a.slice("correct", "completed", "rank")).to eq("correct" => 2, "completed" => 3, "rank" => 1)
+    expect(b.slice("correct", "completed", "rank")).to eq("correct" => 2, "completed" => 2, "rank" => 1)
+    expect(c.slice("correct", "completed", "rank")).to eq("correct" => 0, "completed" => 1, "rank" => 3)
+  end
+
+  it "shares a rank between ties" do
+    result = described_class.compute(block: block)
+    expect(result.map { |r| r["rank"] }).to eq([1, 1, 3])
+  end
+
+  def submit(participant, index, correct, at)
+    ExperienceMinigameSubmission.create!(
+      experience_block_id: block.id,
+      user_id: participant.user_id,
+      question_index: index,
+      submitted_answer: correct ? "1" : "x",
+      correct: correct,
+      submitted_at: at
+    )
+  end
+end

--- a/spec/services/minigames/arithmetic_question_generator_spec.rb
+++ b/spec/services/minigames/arithmetic_question_generator_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe Minigames::ArithmeticQuestionGenerator do
+  describe ".generate" do
+    it "generates the requested number of questions" do
+      questions = described_class.generate(count: 25, seed: 1)
+      expect(questions.size).to eq(25)
+    end
+
+    it "returns sequential index values starting at zero" do
+      questions = described_class.generate(count: 5, seed: 1)
+      expect(questions.map { |q| q["index"] }).to eq([0, 1, 2, 3, 4])
+    end
+
+    it "computes correct answers for every question" do
+      questions = described_class.generate(count: 50, seed: 42)
+      questions.each do |q|
+        expected =
+          case q["op"]
+          when "+" then q["lhs"] + q["rhs"]
+          when "-" then q["lhs"] - q["rhs"]
+          when "*" then q["lhs"] * q["rhs"]
+          when "/" then q["lhs"] / q["rhs"]
+          end
+        expect(q["answer"]).to eq(expected), "mismatch on #{q.inspect}"
+      end
+    end
+
+    it "uses only + and - operators in the first 10 questions" do
+      questions = described_class.generate(count: 10, seed: 7)
+      ops = questions.map { |q| q["op"] }.uniq
+      expect(ops - %w[+ -]).to eq([])
+    end
+
+    it "may use multiplication or division in questions 11-20" do
+      questions = described_class.generate(count: 20, seed: 7).last(10)
+      ops = questions.map { |q| q["op"] }
+      expect(ops.all? { |op| %w[+ - * /].include?(op) }).to be(true)
+    end
+
+    it "produces integer-valued division (no remainders)" do
+      questions = described_class.generate(count: 60, seed: 2024)
+      div_questions = questions.select { |q| q["op"] == "/" }
+      div_questions.each do |q|
+        expect(q["lhs"] % q["rhs"]).to eq(0), "non-integer division: #{q.inspect}"
+      end
+    end
+
+    it "produces non-negative subtraction results" do
+      questions = described_class.generate(count: 40, seed: 99)
+      sub_questions = questions.select { |q| q["op"] == "-" }
+      sub_questions.each do |q|
+        expect(q["answer"]).to be >= 0
+      end
+    end
+
+    it "raises when count is not positive" do
+      expect { described_class.generate(count: 0) }.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
Introduces a Minigame umbrella with two initial variants. Arithmetic dispatches ascending-difficulty problems for a fixed duration with a top-N leaderboard. Balloon Pump is a real-time race where each player drags a spring-loaded pump handle to fill their balloon — first to burst wins, ties allowed, monitor shows the leader's balloon and a gold/silver/bronze podium on end.

Backend additions cover both variants: dedicated submission tables for high-throughput inserts, per-stream payload shaping in Visibility, a lightweight targeted WebSocket message for balloon pump leader updates (server-throttled to avoid melting the wire under 100-player load), and an end-of-game ActiveJob for arithmetic. Frontend uses Canvas-rendered pump fidelity, mirrors the existing FamilyFeud dispatch registry pattern for the leader-update message, and client-throttles pump submissions to 10Hz with trailing-edge flush.