### PR TITLE
Add The Scene block — improv suggestion + voting loop

### DIFF
--- a/app/controllers/api/experience_blocks_controller.rb
+++ b/app/controllers/api/experience_blocks_controller.rb
@@ -7,12 +7,15 @@ class Api::ExperienceBlocksController < Api::BaseController
     next_guess_who_slide previous_guess_who_slide reveal_guess_who
     start_minigame_arithmetic end_minigame_arithmetic
     start_minigame_balloon_pump end_minigame_balloon_pump
+    advance_the_scene_phase start_next_the_scene
+    clear_the_scene_top clear_the_scene_suggestion clear_the_scene_all
   ].freeze
 
   SUBMISSION_ACTIONS = %i[
     submit_poll_response submit_question_response
     submit_mad_lib_response submit_photo_upload_response submit_buzzer_response
     submit_minigame_arithmetic_response submit_minigame_balloon_pump_update
+    submit_the_scene_suggestion submit_the_scene_vote
   ].freeze
 
   before_action :authenticate_and_set_user_and_experience
@@ -664,6 +667,112 @@ class Api::ExperienceBlocksController < Api::BaseController
       Experiences::Broadcaster.new(@experience).broadcast_experience_update
 
       render json: { success: true }, status: 200
+    end
+  end
+
+  # POST /api/experiences/:experience_id/blocks/:id/the_scene/phase
+  def advance_the_scene_phase
+    with_experience_orchestration do
+      block = Experiences::Orchestrator.new(
+        experience: @experience, actor: @user
+      ).advance_the_scene_phase!(block_id: params[:id], phase: params[:phase])
+
+      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      render json: { success: true, data: block }, status: 200
+    end
+  end
+
+  # POST /api/experiences/:experience_id/blocks/:id/the_scene/next
+  def start_next_the_scene
+    with_experience_orchestration do
+      block = Experiences::Orchestrator.new(
+        experience: @experience, actor: @user
+      ).start_next_scene!(block_id: params[:id])
+
+      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      render json: { success: true, data: block }, status: 200
+    end
+  end
+
+  # POST /api/experiences/:experience_id/blocks/:id/the_scene/clear_top
+  def clear_the_scene_top
+    with_experience_orchestration do
+      Experiences::Orchestrator.new(
+        experience: @experience, actor: @user
+      ).clear_the_scene_top!(block_id: params[:id])
+
+      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      render json: { success: true }, status: 200
+    end
+  end
+
+  # POST /api/experiences/:experience_id/blocks/:id/the_scene/clear/:suggestion_id
+  def clear_the_scene_suggestion
+    with_experience_orchestration do
+      Experiences::Orchestrator.new(
+        experience: @experience, actor: @user
+      ).clear_the_scene_suggestion!(
+        block_id: params[:id],
+        suggestion_id: params[:suggestion_id]
+      )
+
+      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      render json: { success: true }, status: 200
+    end
+  end
+
+  # POST /api/experiences/:experience_id/blocks/:id/the_scene/clear_all
+  def clear_the_scene_all
+    with_experience_orchestration do
+      Experiences::Orchestrator.new(
+        experience: @experience, actor: @user
+      ).clear_the_scene_all!(block_id: params[:id])
+
+      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      render json: { success: true }, status: 200
+    end
+  end
+
+  # POST /api/experiences/:experience_id/blocks/:id/the_scene/suggestions
+  def submit_the_scene_suggestion
+    with_experience_orchestration do
+      suggestion = Experiences::Orchestrator.new(
+        experience: @experience, actor: @user
+      ).submit_the_scene_suggestion!(
+        block_id: params[:id],
+        text: params[:text]
+      )
+
+      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      render json: {
+        success: true,
+        suggestion: { id: suggestion.id, text: suggestion.text }
+      }, status: 200
+    end
+  end
+
+  # POST /api/experiences/:experience_id/blocks/:id/the_scene/votes
+  def submit_the_scene_vote
+    with_experience_orchestration do
+      vote = Experiences::Orchestrator.new(
+        experience: @experience, actor: @user
+      ).submit_the_scene_vote!(
+        block_id: params[:id],
+        suggestion_id: params[:suggestion_id]
+      )
+
+      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      render json: {
+        success: true,
+        vote: { id: vote.id, improv_suggestion_id: vote.improv_suggestion_id }
+      }, status: 200
     end
   end
 

--- a/app/frontend/Experiences/ExperienceBlockContainer/ExperienceBlockContainer.tsx
+++ b/app/frontend/Experiences/ExperienceBlockContainer/ExperienceBlockContainer.tsx
@@ -10,6 +10,7 @@ import MinigameBalloonPump from '../MinigameBalloonPump/MinigameBalloonPump';
 import PhotoUpload from '../PhotoUpload/PhotoUpload';
 import Poll from '../Poll/Poll';
 import Question from '../Question/Question';
+import TheScene from '../TheScene/TheScene';
 
 interface ExperienceBlockContainerProps {
   block: Block;
@@ -80,6 +81,8 @@ export default function ExperienceBlockContainer({
       return <MinigameArithmetic block={block} viewContext={viewContext} />;
     case BlockKind.MINIGAME_BALLOON_PUMP:
       return <MinigameBalloonPump block={block} viewContext={viewContext} />;
+    case BlockKind.THE_SCENE:
+      return <TheScene block={block} viewContext={viewContext} />;
     default:
       const exhaustiveCheck: never = block;
       return (

--- a/app/frontend/Experiences/TheScene/TheScene.module.scss
+++ b/app/frontend/Experiences/TheScene/TheScene.module.scss
@@ -1,0 +1,287 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 1.5rem;
+  padding: 1.25rem;
+  min-height: 60vh;
+}
+
+.heading {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  letter-spacing: 0.05em;
+  text-align: center;
+  color: var(--phosphor);
+  text-shadow: var(--tv-glow);
+}
+
+.subheading {
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  text-align: center;
+  opacity: 0.8;
+}
+
+.suggestionForm {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: min(28rem, 100%);
+}
+
+.input {
+  font-family: var(--font-body);
+  font-size: 1.15rem;
+  padding: 0.75rem 1rem;
+  background: transparent;
+  color: var(--foreground);
+  border: 2px solid var(--phosphor);
+  border-radius: 0.5rem;
+
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 4px var(--phosphor-glow);
+  }
+}
+
+.charCount {
+  font-family: var(--font-body);
+  font-size: 0.8rem;
+  opacity: 0.6;
+  text-align: right;
+}
+
+.patience {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 2rem 1rem;
+  font-family: var(--font-body);
+  text-align: center;
+}
+
+.patienceTitle {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  letter-spacing: 0.05em;
+  color: var(--phosphor);
+  text-shadow: var(--tv-glow);
+}
+
+.ownSuggestion {
+  font-family: var(--font-body);
+  font-size: 1rem;
+  padding: 0.75rem 1rem;
+  border: 1px dashed var(--phosphor-glow-medium);
+  border-radius: 0.5rem;
+  width: min(28rem, 100%);
+  text-align: center;
+  font-style: italic;
+}
+
+.dotPulse {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--phosphor);
+  margin: 0 0.15rem;
+  animation: pulse 1.4s infinite ease-in-out both;
+}
+
+.dotPulse:nth-child(2) {
+  animation-delay: 0.2s;
+}
+.dotPulse:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes pulse {
+  0%,
+  80%,
+  100% {
+    opacity: 0.2;
+    transform: scale(0.7);
+  }
+  40% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.votingList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: min(36rem, 100%);
+}
+
+.voteRow {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.85rem 1rem;
+  border: 2px solid transparent;
+  border-radius: 0.5rem;
+  background: var(--card);
+  font-family: var(--font-body);
+  font-size: 1.05rem;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
+  color: inherit;
+
+  &:hover {
+    border-color: var(--phosphor-glow-medium);
+  }
+}
+
+.voteRowActive {
+  border-color: var(--phosphor);
+  background: color-mix(in srgb, var(--phosphor) 12%, transparent);
+}
+
+.voteCount {
+  font-family: var(--font-display);
+  font-size: 1.15rem;
+  letter-spacing: 0.05em;
+  color: var(--phosphor);
+  min-width: 2.5rem;
+  text-align: right;
+}
+
+// Monitor
+
+.monitorRoot {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 3rem;
+  min-height: 70vh;
+}
+
+.monitorTitle {
+  font-family: var(--font-display);
+  font-size: 2.5rem;
+  letter-spacing: 0.1em;
+  color: var(--foreground);
+  opacity: 0.85;
+  text-align: center;
+}
+
+.monitorPhase {
+  font-family: var(--font-body);
+  font-size: 1.1rem;
+  opacity: 0.6;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+}
+
+.monitorLeaderboard {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: min(56rem, 100%);
+}
+
+.leaderboardRow {
+  position: absolute;
+  left: 0;
+  right: 0;
+  display: grid;
+  grid-template-columns: 4rem 1fr auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  border: 2px solid var(--phosphor-glow-medium);
+  border-radius: 0.5rem;
+  background: var(--card);
+  transition:
+    top 0.4s cubic-bezier(0.22, 1, 0.36, 1),
+    background 0.3s ease,
+    border-color 0.3s ease;
+}
+
+.leaderboardRow[data-rank='1'] {
+  border-color: var(--phosphor);
+  box-shadow: 0 0 18px var(--phosphor-glow);
+}
+
+.leaderboardRank {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  letter-spacing: 0.05em;
+  color: var(--phosphor);
+}
+
+.leaderboardText {
+  font-family: var(--font-body);
+  font-size: 1.5rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.leaderboardVotes {
+  font-family: var(--font-display);
+  font-size: 1.75rem;
+  letter-spacing: 0.05em;
+  color: var(--phosphor);
+}
+
+// Manage
+
+.manageRoot {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.manageRow {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.manageStat {
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  opacity: 0.85;
+}
+
+.manageList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  max-height: 18rem;
+  overflow-y: auto;
+  padding: 0.5rem;
+  border: 1px dashed var(--phosphor-glow-medium);
+  border-radius: 0.5rem;
+}
+
+.manageListRow {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  gap: 0.75rem;
+  align-items: center;
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+  padding: 0.25rem 0.4rem;
+}
+
+.manageListRowText {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/app/frontend/Experiences/TheScene/TheScene.tsx
+++ b/app/frontend/Experiences/TheScene/TheScene.tsx
@@ -1,0 +1,256 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+
+import { Button } from '@cctv/core/Button/Button';
+import { useTheScene } from '@cctv/hooks/useTheScene';
+import { TheSceneBlock, TheSceneSuggestion } from '@cctv/types';
+
+import styles from './TheScene.module.scss';
+
+const MAX_SUGGESTION_LENGTH = 100;
+
+interface Props {
+  block: TheSceneBlock;
+  viewContext?: 'participant' | 'monitor' | 'manage';
+}
+
+export default function TheScene({ block, viewContext = 'participant' }: Props) {
+  switch (viewContext) {
+    case 'monitor':
+      return <MonitorView block={block} />;
+    case 'manage':
+      return <ManageView block={block} />;
+    default:
+      return <ParticipantView block={block} />;
+  }
+}
+
+function ParticipantView({ block }: { block: TheSceneBlock }) {
+  const { submitSuggestion, submitVote, isSubmitting } = useTheScene();
+  const { phase, own_suggestion, votable_suggestions, own_vote_suggestion_id } = block.payload;
+  const [text, setText] = useState('');
+
+  // Reset local input whenever the user has no active own suggestion (i.e. between scenes / after clear).
+  useEffect(() => {
+    if (!own_suggestion) setText('');
+  }, [own_suggestion]);
+
+  if (phase === 'idle') {
+    return (
+      <div className={styles.root}>
+        <p className={styles.heading}>Waiting for the next scene…</p>
+      </div>
+    );
+  }
+
+  if (phase === 'ended') {
+    return (
+      <div className={styles.root}>
+        <p className={styles.heading}>Scene ended</p>
+        <p className={styles.subheading}>See the monitor for the winning suggestion.</p>
+      </div>
+    );
+  }
+
+  // No suggestion yet → input.
+  if (!own_suggestion) {
+    const remaining = MAX_SUGGESTION_LENGTH - text.length;
+    const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      const trimmed = text.trim();
+      if (!trimmed) return;
+      const result = await submitSuggestion(block.id, trimmed);
+      if (result?.success) setText('');
+    };
+
+    return (
+      <div className={styles.root}>
+        <p className={styles.heading}>Drop a suggestion</p>
+        <p className={styles.subheading}>One per scene. Make it weird, make it specific.</p>
+        <form className={styles.suggestionForm} onSubmit={handleSubmit}>
+          <input
+            className={styles.input}
+            type="text"
+            maxLength={MAX_SUGGESTION_LENGTH}
+            placeholder="A wedding on the moon…"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            disabled={isSubmitting}
+            autoFocus
+          />
+          <span className={styles.charCount}>{remaining} characters left</span>
+          <Button type="submit" loading={isSubmitting} loadingText="Submitting...">
+            Submit suggestion
+          </Button>
+        </form>
+      </div>
+    );
+  }
+
+  // Submitted but voting isn't open yet → patience screen.
+  if (phase === 'collecting') {
+    return (
+      <div className={styles.root}>
+        <p className={styles.patienceTitle}>You're in!</p>
+        <div className={styles.ownSuggestion}>"{own_suggestion.text}"</div>
+        <div className={styles.patience}>
+          <span>Waiting for the voting to open</span>
+          <span>
+            <span className={styles.dotPulse} />
+            <span className={styles.dotPulse} />
+            <span className={styles.dotPulse} />
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  // phase === 'voting' and we have own_suggestion → render voting list (excludes own).
+  const choices = votable_suggestions ?? [];
+  return (
+    <div className={styles.root}>
+      <p className={styles.heading}>Vote</p>
+      <p className={styles.subheading}>Tap to vote. Tap a different one to change your mind.</p>
+      <div className={styles.ownSuggestion}>Your suggestion: "{own_suggestion.text}"</div>
+      <div className={styles.votingList}>
+        {choices.length === 0 && (
+          <p className={styles.subheading}>No other suggestions yet — hang tight.</p>
+        )}
+        {choices.map((s) => {
+          const active = own_vote_suggestion_id === s.id;
+          return (
+            <button
+              key={s.id}
+              type="button"
+              className={`${styles.voteRow} ${active ? styles.voteRowActive : ''}`}
+              onClick={() => submitVote(block.id, s.id)}
+            >
+              <span>{s.text}</span>
+              <span className={styles.voteCount}>{s.vote_count}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+const ROW_HEIGHT_PX = 76;
+
+function MonitorView({ block }: { block: TheSceneBlock }) {
+  const { phase, leaderboard, leaderboard_size } = block.payload;
+  const top = leaderboard.slice(0, leaderboard_size);
+
+  if (phase === 'idle') {
+    return (
+      <div className={styles.monitorRoot}>
+        <p className={styles.monitorTitle}>The Scene</p>
+        <p className={styles.monitorPhase}>Waiting for the next scene</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.monitorRoot}>
+      <p className={styles.monitorTitle}>{phase === 'ended' ? 'Scene ended' : 'The Scene'}</p>
+      <p className={styles.monitorPhase}>
+        {phase === 'collecting' && 'Collecting suggestions'}
+        {phase === 'voting' && 'Voting'}
+        {phase === 'ended' && 'Final results'}
+      </p>
+      <Leaderboard suggestions={top} />
+    </div>
+  );
+}
+
+function Leaderboard({ suggestions }: { suggestions: TheSceneSuggestion[] }) {
+  // Maintain stable index-positions per suggestion id so rows can transition
+  // between rank slots smoothly even when their list index changes.
+  const containerHeight = Math.max(suggestions.length * ROW_HEIGHT_PX, ROW_HEIGHT_PX);
+
+  return (
+    <div className={styles.monitorLeaderboard} style={{ height: containerHeight }}>
+      {suggestions.map((s, index) => (
+        <div
+          key={s.id}
+          className={styles.leaderboardRow}
+          data-rank={s.rank}
+          style={{ top: `${index * ROW_HEIGHT_PX}px` }}
+        >
+          <span className={styles.leaderboardRank}>#{s.rank}</span>
+          <span className={styles.leaderboardText}>{s.text}</span>
+          <span className={styles.leaderboardVotes}>{s.vote_count}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ManageView({ block }: { block: TheSceneBlock }) {
+  const { advancePhase, nextScene, clearTop, clearAll, clearSuggestion } = useTheScene();
+  const { phase, all_suggestions = [] } = block.payload;
+  const totalVotes = useMemo(
+    () => all_suggestions.reduce((sum, s) => sum + s.vote_count, 0),
+    [all_suggestions],
+  );
+
+  return (
+    <div className={styles.manageRoot}>
+      <p className={styles.manageStat}>
+        Phase: <strong>{phase}</strong> • Active suggestions: {all_suggestions.length} • Votes this
+        scene: {totalVotes}
+      </p>
+
+      <div className={styles.manageRow}>
+        {phase === 'idle' && (
+          <Button onClick={() => advancePhase(block.id, 'collecting')}>Open scene</Button>
+        )}
+        {phase === 'collecting' && (
+          <>
+            <Button onClick={() => advancePhase(block.id, 'voting')}>Open voting</Button>
+            <Button variant="secondary" onClick={() => advancePhase(block.id, 'ended')}>
+              End scene
+            </Button>
+          </>
+        )}
+        {phase === 'voting' && (
+          <Button variant="secondary" onClick={() => advancePhase(block.id, 'ended')}>
+            End scene
+          </Button>
+        )}
+        {phase === 'ended' && <Button onClick={() => nextScene(block.id)}>Next scene</Button>}
+      </div>
+
+      <div className={styles.manageRow}>
+        <Button
+          variant="secondary"
+          onClick={() => clearTop(block.id)}
+          disabled={all_suggestions.length === 0}
+        >
+          Clear top
+        </Button>
+        <Button
+          variant="secondary"
+          onClick={() => clearAll(block.id)}
+          disabled={all_suggestions.length === 0}
+        >
+          Clear all
+        </Button>
+      </div>
+
+      {all_suggestions.length > 0 && (
+        <div className={styles.manageList}>
+          {all_suggestions.map((s) => (
+            <div key={s.id} className={styles.manageListRow}>
+              <span>#{s.rank}</span>
+              <span className={styles.manageListRowText}>{s.text}</span>
+              <span>{s.vote_count}</span>
+              <Button variant="secondary" onClick={() => clearSuggestion(block.id, s.id)}>
+                Clear
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/frontend/Experiences/index.ts
+++ b/app/frontend/Experiences/index.ts
@@ -6,3 +6,4 @@ export { default as Buzzer } from './Buzzer/Buzzer';
 export { default as GuessWho } from './GuessWho/GuessWho';
 export { default as MinigameArithmetic } from './MinigameArithmetic/MinigameArithmetic';
 export { default as MinigameBalloonPump } from './MinigameBalloonPump/MinigameBalloonPump';
+export { default as TheScene } from './TheScene/TheScene';

--- a/app/frontend/Hooks/index.ts
+++ b/app/frontend/Hooks/index.ts
@@ -39,3 +39,4 @@ export { usePerformer } from './usePerformer';
 export { useFollowPerformer } from './useFollowPerformer';
 export { useMinigameArithmetic } from './useMinigameArithmetic';
 export { useMinigameBalloonPump, useBalloonPumpLeader } from './useMinigameBalloonPump';
+export { useTheScene } from './useTheScene';

--- a/app/frontend/Hooks/useTheScene.ts
+++ b/app/frontend/Hooks/useTheScene.ts
@@ -1,0 +1,142 @@
+import { useCallback, useState } from 'react';
+
+import { useAdminAuth } from '@cctv/contexts/AdminAuthContext';
+import { useExperience } from '@cctv/contexts/ExperienceContext';
+import { TheScenePhase } from '@cctv/types';
+
+interface ActionResult {
+  success: boolean;
+  error?: string;
+}
+
+export function useTheScene() {
+  const { code, experienceFetch } = useExperience();
+  const { adminFetch } = useAdminAuth();
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const buildAdminUrl = useCallback(
+    (blockId: string, path: string) =>
+      `/api/experiences/${encodeURIComponent(code ?? '')}/blocks/${encodeURIComponent(blockId)}/the_scene/${path}`,
+    [code],
+  );
+
+  const buildParticipantUrl = useCallback(
+    (blockId: string, path: string) =>
+      `/api/experiences/${encodeURIComponent(code ?? '')}/blocks/${encodeURIComponent(blockId)}/the_scene/${path}`,
+    [code],
+  );
+
+  const adminPost = useCallback(
+    async (blockId: string, path: string, body?: object): Promise<ActionResult> => {
+      if (!code) return { success: false, error: 'Missing experience code' };
+      setError(null);
+      try {
+        const res = await adminFetch(buildAdminUrl(blockId, path), {
+          method: 'POST',
+          ...(body !== undefined && { body: JSON.stringify(body) }),
+        });
+        const data = await res.json();
+        if (!res.ok || !data?.success) {
+          const msg = data?.error || `Failed to ${path}`;
+          setError(msg);
+          return { success: false, error: msg };
+        }
+        return { success: true };
+      } catch (e: unknown) {
+        const msg =
+          e instanceof Error && e.message === 'Authentication expired'
+            ? 'Authentication expired'
+            : 'Connection error. Please try again.';
+        setError(msg);
+        return { success: false, error: msg };
+      }
+    },
+    [code, adminFetch, buildAdminUrl],
+  );
+
+  const advancePhase = useCallback(
+    (blockId: string, phase: TheScenePhase) => adminPost(blockId, 'phase', { phase }),
+    [adminPost],
+  );
+
+  const nextScene = useCallback((blockId: string) => adminPost(blockId, 'next'), [adminPost]);
+  const clearTop = useCallback((blockId: string) => adminPost(blockId, 'clear_top'), [adminPost]);
+  const clearAll = useCallback((blockId: string) => adminPost(blockId, 'clear_all'), [adminPost]);
+  const clearSuggestion = useCallback(
+    (blockId: string, suggestionId: string) =>
+      adminPost(blockId, `clear/${encodeURIComponent(suggestionId)}`),
+    [adminPost],
+  );
+
+  const submitSuggestion = useCallback(
+    async (blockId: string, text: string): Promise<ActionResult> => {
+      if (!code) return { success: false, error: 'Missing experience code' };
+      setIsSubmitting(true);
+      setError(null);
+      try {
+        const res = await experienceFetch(buildParticipantUrl(blockId, 'suggestions'), {
+          method: 'POST',
+          body: JSON.stringify({ text }),
+        });
+        const data = await res.json();
+        if (!res.ok || !data?.success) {
+          const msg = data?.error || 'Failed to submit suggestion';
+          setError(msg);
+          return { success: false, error: msg };
+        }
+        return { success: true };
+      } catch (e: unknown) {
+        const msg =
+          e instanceof Error && e.message === 'Authentication expired'
+            ? 'Authentication expired'
+            : 'Connection error. Please try again.';
+        setError(msg);
+        return { success: false, error: msg };
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [code, experienceFetch, buildParticipantUrl],
+  );
+
+  const submitVote = useCallback(
+    async (blockId: string, suggestionId: string): Promise<ActionResult> => {
+      if (!code) return { success: false, error: 'Missing experience code' };
+      setError(null);
+      try {
+        const res = await experienceFetch(buildParticipantUrl(blockId, 'votes'), {
+          method: 'POST',
+          body: JSON.stringify({ suggestion_id: suggestionId }),
+        });
+        const data = await res.json();
+        if (!res.ok || !data?.success) {
+          const msg = data?.error || 'Failed to submit vote';
+          setError(msg);
+          return { success: false, error: msg };
+        }
+        return { success: true };
+      } catch (e: unknown) {
+        const msg =
+          e instanceof Error && e.message === 'Authentication expired'
+            ? 'Authentication expired'
+            : 'Connection error. Please try again.';
+        setError(msg);
+        return { success: false, error: msg };
+      }
+    },
+    [code, experienceFetch, buildParticipantUrl],
+  );
+
+  return {
+    advancePhase,
+    nextScene,
+    clearTop,
+    clearAll,
+    clearSuggestion,
+    submitSuggestion,
+    submitVote,
+    isSubmitting,
+    error,
+  };
+}

--- a/app/frontend/Pages/Manage/CreateBlock/CreateBlock.tsx
+++ b/app/frontend/Pages/Manage/CreateBlock/CreateBlock.tsx
@@ -16,6 +16,7 @@ import CreateMinigameBalloonPump from './CreateMinigameBalloonPump/CreateMinigam
 import CreatePhotoUpload from './CreatePhotoUpload/CreatePhotoUpload';
 import CreatePoll from './CreatePoll/CreatePoll';
 import CreateQuestion from './CreateQuestion/CreateQuestion';
+import CreateTheScene from './CreateTheScene/CreateTheScene';
 
 import styles from './CreateBlock.module.scss';
 
@@ -69,6 +70,7 @@ function CreateBlockForm({ onClose }: CreateBlockFormProps) {
           { label: 'Guess Who', value: BlockKind.GUESS_WHO },
           { label: 'Minigame: Arithmetic', value: BlockKind.MINIGAME_ARITHMETIC },
           { label: 'Minigame: Balloon Pump', value: BlockKind.MINIGAME_BALLOON_PUMP },
+          { label: 'The Scene', value: BlockKind.THE_SCENE },
         ]}
         value={blockData.kind}
         onChange={setKind}
@@ -135,6 +137,8 @@ function BlockEditor() {
       return <CreateMinigameArithmetic data={blockData.data} onChange={onChange} />;
     case BlockKind.MINIGAME_BALLOON_PUMP:
       return <CreateMinigameBalloonPump data={blockData.data} onChange={onChange} />;
+    case BlockKind.THE_SCENE:
+      return <CreateTheScene data={blockData.data} onChange={onChange} />;
     default:
       const exhaustiveCheck: never = blockData;
       return <div className={styles.details}>Unknown block type: {exhaustiveCheck}</div>;

--- a/app/frontend/Pages/Manage/CreateBlock/CreateBlockContext.tsx
+++ b/app/frontend/Pages/Manage/CreateBlock/CreateBlockContext.tsx
@@ -77,6 +77,13 @@ import {
   processQuestionBeforeSubmit,
   validateQuestion,
 } from './CreateQuestion/CreateQuestion';
+import {
+  buildTheScenePayload,
+  canTheSceneOpenImmediately,
+  getDefaultTheSceneState,
+  processTheSceneBeforeSubmit,
+  validateTheScene,
+} from './CreateTheScene/CreateTheScene';
 
 const CreateBlockContext = createContext<CreateBlockContextValue | null>(null);
 
@@ -129,6 +136,8 @@ export function CreateBlockProvider({
           kind: BlockKind.MINIGAME_BALLOON_PUMP,
           data: getDefaultMinigameBalloonPumpState(),
         };
+      case BlockKind.THE_SCENE:
+        return { kind: BlockKind.THE_SCENE, data: getDefaultTheSceneState() };
       default: {
         const _exhaust: never = blockKind;
         throw new Error(`Unknown block kind: ${_exhaust}`);
@@ -202,6 +211,12 @@ export function CreateBlockProvider({
             validationError = 'A segment is required for balloon pump minigames';
           }
           break;
+        case BlockKind.THE_SCENE:
+          validationError = validateTheScene(blockData.data);
+          if (!validationError && visibleSegments.length === 0) {
+            validationError = 'A segment is required for The Scene';
+          }
+          break;
         default: {
           const _exhaust: never = blockData;
           validationError = `Unknown block kind: ${(_exhaust as FormBlockData).kind}`;
@@ -244,6 +259,9 @@ export function CreateBlockProvider({
           break;
         case BlockKind.MINIGAME_BALLOON_PUMP:
           canOpenImmediately = canMinigameBalloonPumpOpenImmediately(blockData.data, participants);
+          break;
+        case BlockKind.THE_SCENE:
+          canOpenImmediately = canTheSceneOpenImmediately(blockData.data, participants);
           break;
         default: {
           const _exhaust: never = blockData;
@@ -323,6 +341,12 @@ export function CreateBlockProvider({
             data: processMinigameBalloonPumpBeforeSubmit(blockData.data, status, participants),
           };
           break;
+        case BlockKind.THE_SCENE:
+          processedFormData = {
+            kind: BlockKind.THE_SCENE,
+            data: processTheSceneBeforeSubmit(blockData.data, status, participants),
+          };
+          break;
         default: {
           const _exhaust: never = blockData;
           processedFormData = _exhaust as FormBlockData;
@@ -364,6 +388,9 @@ export function CreateBlockProvider({
           break;
         case BlockKind.MINIGAME_BALLOON_PUMP:
           payload = buildMinigameBalloonPumpPayload(processedFormData.data);
+          break;
+        case BlockKind.THE_SCENE:
+          payload = buildTheScenePayload(processedFormData.data);
           break;
         default: {
           const _exhaust: never = processedFormData;

--- a/app/frontend/Pages/Manage/CreateBlock/CreateTheScene/CreateTheScene.tsx
+++ b/app/frontend/Pages/Manage/CreateBlock/CreateTheScene/CreateTheScene.tsx
@@ -1,0 +1,68 @@
+import { TextInput } from '@cctv/core/TextInput/TextInput';
+import {
+  BlockComponentProps,
+  BlockKind,
+  BlockStatus,
+  ParticipantSummary,
+  TheSceneApiPayload,
+  TheSceneData,
+  TheScenePayload,
+} from '@cctv/types';
+
+import sharedStyles from '../CreateBlock.module.scss';
+
+export const getDefaultTheSceneState = (): TheSceneData => ({
+  leaderboard_size: 5,
+});
+
+export const validateTheScene = (data: TheSceneData): string | null => {
+  if (!Number.isInteger(data.leaderboard_size) || data.leaderboard_size <= 0) {
+    return 'Leaderboard size must be a positive whole number';
+  }
+  return null;
+};
+
+export const buildTheScenePayload = (data: TheSceneData): TheSceneApiPayload => ({
+  type: BlockKind.THE_SCENE,
+  leaderboard_size: data.leaderboard_size,
+});
+
+export const canTheSceneOpenImmediately = (
+  _data: TheSceneData,
+  _participants: ParticipantSummary[],
+): boolean => false;
+
+export const processTheSceneBeforeSubmit = (
+  data: TheSceneData,
+  _status: BlockStatus,
+  _participants: ParticipantSummary[],
+): TheSceneData => data;
+
+export const theScenePayloadToFormData = (payload: TheScenePayload): TheSceneData => ({
+  leaderboard_size: payload.leaderboard_size,
+});
+
+export default function CreateTheScene({ data, onChange }: BlockComponentProps<TheSceneData>) {
+  return (
+    <div className={sharedStyles.container}>
+      <TextInput
+        label="Leaderboard size"
+        type="number"
+        min={1}
+        value={data.leaderboard_size || ''}
+        onChange={(e) => {
+          const value = parseInt(e.target.value, 10);
+          onChange?.({ leaderboard_size: Number.isNaN(value) ? 0 : value });
+        }}
+      />
+      <p style={{ fontSize: '0.85rem', opacity: 0.8 }}>
+        How many top suggestions show on the monitor leaderboard. The audience can vote on any
+        active suggestion — the leaderboard just controls how many ranks render publicly.
+      </p>
+      <p style={{ fontSize: '0.85rem', opacity: 0.8 }}>
+        A segment is required — set it under "Additional Details". Suggestions persist across scenes
+        unless cleared. Votes reset each scene.
+      </p>
+    </div>
+  );
+}

--- a/app/frontend/Pages/Manage/EditBlock/EditBlock.tsx
+++ b/app/frontend/Pages/Manage/EditBlock/EditBlock.tsx
@@ -14,6 +14,7 @@ import CreateMinigameBalloonPump from '../CreateBlock/CreateMinigameBalloonPump/
 import CreatePhotoUpload from '../CreateBlock/CreatePhotoUpload/CreatePhotoUpload';
 import CreatePoll from '../CreateBlock/CreatePoll/CreatePoll';
 import CreateQuestion from '../CreateBlock/CreateQuestion/CreateQuestion';
+import CreateTheScene from '../CreateBlock/CreateTheScene/CreateTheScene';
 import { EditBlockProvider, useEditBlockContext } from './EditBlockContext';
 
 import styles from './EditBlock.module.scss';
@@ -52,6 +53,7 @@ const KIND_LABELS: Record<BlockKind, string> = {
   [BlockKind.GUESS_WHO]: 'Guess Who',
   [BlockKind.MINIGAME_ARITHMETIC]: 'Minigame: Arithmetic',
   [BlockKind.MINIGAME_BALLOON_PUMP]: 'Minigame: Balloon Pump',
+  [BlockKind.THE_SCENE]: 'The Scene',
 };
 
 function EditBlockForm({ onClose, block }: EditBlockFormProps) {
@@ -143,6 +145,8 @@ function BlockEditor() {
       return <CreateMinigameArithmetic data={blockData.data} onChange={onChange} />;
     case BlockKind.MINIGAME_BALLOON_PUMP:
       return <CreateMinigameBalloonPump data={blockData.data} onChange={onChange} />;
+    case BlockKind.THE_SCENE:
+      return <CreateTheScene data={blockData.data} onChange={onChange} />;
     default: {
       const _exhaust: never = blockData;
       return <div>Unknown block type: {(_exhaust as { kind: string }).kind}</div>;

--- a/app/frontend/Pages/Manage/EditBlock/EditBlockContext.tsx
+++ b/app/frontend/Pages/Manage/EditBlock/EditBlockContext.tsx
@@ -60,6 +60,11 @@ import {
   questionPayloadToFormData,
   validateQuestion,
 } from '../CreateBlock/CreateQuestion/CreateQuestion';
+import {
+  buildTheScenePayload,
+  theScenePayloadToFormData,
+  validateTheScene,
+} from '../CreateBlock/CreateTheScene/CreateTheScene';
 
 const EditBlockContext = createContext<EditBlockContextValue | null>(null);
 
@@ -119,6 +124,11 @@ function blockToFormData(block: Block, participants: ParticipantSummary[]): Form
         kind: BlockKind.MINIGAME_BALLOON_PUMP,
         data: minigameBalloonPumpPayloadToFormData(block.payload),
       };
+    case BlockKind.THE_SCENE:
+      return {
+        kind: BlockKind.THE_SCENE,
+        data: theScenePayloadToFormData(block.payload),
+      };
     default: {
       const _exhaust: never = block;
       throw new Error(`Unknown block kind: ${(_exhaust as Block).kind}`);
@@ -165,6 +175,8 @@ function buildUpdatePayload(blockData: FormBlockData): {
       return { payload: buildMinigameArithmeticPayload(blockData.data) };
     case BlockKind.MINIGAME_BALLOON_PUMP:
       return { payload: buildMinigameBalloonPumpPayload(blockData.data) };
+    case BlockKind.THE_SCENE:
+      return { payload: buildTheScenePayload(blockData.data) };
     default: {
       const _exhaust: never = blockData;
       throw new Error(`Unknown block kind: ${(_exhaust as FormBlockData).kind}`);
@@ -268,6 +280,9 @@ export function EditBlockProvider({
         break;
       case BlockKind.MINIGAME_BALLOON_PUMP:
         validationError = validateMinigameBalloonPump(blockData.data);
+        break;
+      case BlockKind.THE_SCENE:
+        validationError = validateTheScene(blockData.data);
         break;
       default: {
         const _exhaust: never = blockData;

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -22,6 +22,7 @@ export enum BlockKind {
   GUESS_WHO = 'guess_who',
   MINIGAME_ARITHMETIC = 'minigame_arithmetic',
   MINIGAME_BALLOON_PUMP = 'minigame_balloon_pump',
+  THE_SCENE = 'the_scene',
 }
 
 export interface ExperienceSegment {
@@ -174,6 +175,27 @@ export interface MinigameBalloonPumpLiveResult {
   fill_amount: number;
 }
 
+export type TheScenePhase = 'idle' | 'collecting' | 'voting' | 'ended';
+
+export interface TheSceneSuggestion {
+  id: string;
+  text: string;
+  user_id: string;
+  vote_count: number;
+  rank: number;
+}
+
+export interface TheScenePayload {
+  phase: TheScenePhase;
+  scene_started_at: string | null;
+  leaderboard_size: number;
+  leaderboard: TheSceneSuggestion[];
+  own_suggestion?: { id: string; text: string } | null;
+  own_vote_suggestion_id?: string | null;
+  votable_suggestions?: TheSceneSuggestion[];
+  all_suggestions?: TheSceneSuggestion[];
+}
+
 export interface MinigameBalloonPumpPayload {
   variant: 'balloon_pump';
   target_units: number;
@@ -289,6 +311,11 @@ export interface MinigameArithmeticApiPayload {
   leaderboard_size: number;
 }
 
+export interface TheSceneApiPayload {
+  type: 'the_scene';
+  leaderboard_size: number;
+}
+
 export interface MinigameBalloonPumpApiPayload {
   type: 'minigame_balloon_pump';
   variant: 'balloon_pump';
@@ -306,7 +333,8 @@ export type ApiPayload =
   | BuzzerApiPayload
   | GuessWhoApiPayload
   | MinigameArithmeticApiPayload
-  | MinigameBalloonPumpApiPayload;
+  | MinigameBalloonPumpApiPayload
+  | TheSceneApiPayload;
 
 // ===== PLAYBILL TYPES =====
 
@@ -485,6 +513,15 @@ export interface MinigameBalloonPumpBlock extends BaseBlock {
   };
 }
 
+export interface TheSceneBlock extends BaseBlock {
+  kind: BlockKind.THE_SCENE;
+  payload: TheScenePayload;
+  responses?: {
+    total: number;
+    vote_count?: number;
+  };
+}
+
 export type Block =
   | PollBlock
   | QuestionBlock
@@ -495,7 +532,8 @@ export type Block =
   | BuzzerBlock
   | GuessWhoBlock
   | MinigameArithmeticBlock
-  | MinigameBalloonPumpBlock;
+  | MinigameBalloonPumpBlock
+  | TheSceneBlock;
 
 export interface Experience {
   id: string;
@@ -558,7 +596,8 @@ export interface CreateBlockPayload {
     | BuzzerPayload
     | GuessWhoPayload
     | MinigameArithmeticPayload
-    | MinigameBalloonPumpPayload;
+    | MinigameBalloonPumpPayload
+    | TheScenePayload;
   visible_to_segment_ids?: string[];
   status?: BlockStatus;
   open_immediately?: boolean;
@@ -979,6 +1018,10 @@ export interface MinigameBalloonPumpData {
   target_units: number;
 }
 
+export interface TheSceneData {
+  leaderboard_size: number;
+}
+
 // Union type for all block component data
 export type BlockComponentData =
   | PollData
@@ -990,7 +1033,8 @@ export type BlockComponentData =
   | BuzzerData
   | GuessWhoData
   | MinigameArithmeticData
-  | MinigameBalloonPumpData;
+  | MinigameBalloonPumpData
+  | TheSceneData;
 
 // Discriminated union for form block data
 export type FormBlockData =
@@ -1003,7 +1047,8 @@ export type FormBlockData =
   | { kind: BlockKind.BUZZER; data: BuzzerData }
   | { kind: BlockKind.GUESS_WHO; data: GuessWhoData }
   | { kind: BlockKind.MINIGAME_ARITHMETIC; data: MinigameArithmeticData }
-  | { kind: BlockKind.MINIGAME_BALLOON_PUMP; data: MinigameBalloonPumpData };
+  | { kind: BlockKind.MINIGAME_BALLOON_PUMP; data: MinigameBalloonPumpData }
+  | { kind: BlockKind.THE_SCENE; data: TheSceneData };
 
 export interface UpdateBlockPayload {
   payload: ApiPayload | Record<string, unknown>;

--- a/app/models/experience_block.rb
+++ b/app/models/experience_block.rb
@@ -11,7 +11,8 @@ class ExperienceBlock < ApplicationRecord
     BUZZER = "buzzer",
     GUESS_WHO = "guess_who",
     MINIGAME_ARITHMETIC = "minigame_arithmetic",
-    MINIGAME_BALLOON_PUMP = "minigame_balloon_pump"
+    MINIGAME_BALLOON_PUMP = "minigame_balloon_pump",
+    THE_SCENE = "the_scene"
   ]
 
   belongs_to :experience
@@ -32,6 +33,8 @@ class ExperienceBlock < ApplicationRecord
   has_many :experience_buzzer_submissions, dependent: :destroy
   has_many :experience_minigame_submissions, dependent: :destroy
   has_many :experience_minigame_balloon_results, dependent: :destroy
+  has_many :improv_suggestions, dependent: :destroy
+  has_many :improv_votes, dependent: :destroy
 
   has_many :parent_links,
     class_name: "ExperienceBlockLink",

--- a/app/models/improv_suggestion.rb
+++ b/app/models/improv_suggestion.rb
@@ -1,0 +1,20 @@
+class ImprovSuggestion < ApplicationRecord
+  MAX_LENGTH = 100
+
+  belongs_to :experience_block
+  belongs_to :user
+  has_many :improv_votes, dependent: :destroy
+
+  validates :text, presence: true, length: { maximum: MAX_LENGTH }
+
+  scope :active, -> { where(cleared_at: nil) }
+  scope :cleared, -> { where.not(cleared_at: nil) }
+
+  def cleared?
+    cleared_at.present?
+  end
+
+  def clear!
+    update!(cleared_at: Time.current)
+  end
+end

--- a/app/models/improv_vote.rb
+++ b/app/models/improv_vote.rb
@@ -1,0 +1,18 @@
+class ImprovVote < ApplicationRecord
+  belongs_to :experience_block
+  belongs_to :user
+  belongs_to :improv_suggestion
+
+  validates :scene_started_at, presence: true
+  validate :user_cannot_vote_for_own_suggestion
+
+  private
+
+  def user_cannot_vote_for_own_suggestion
+    return unless improv_suggestion && user_id
+
+    if improv_suggestion.user_id == user_id
+      errors.add(:improv_suggestion_id, "cannot be your own suggestion")
+    end
+  end
+end

--- a/app/policies/experience_block_policy.rb
+++ b/app/policies/experience_block_policy.rb
@@ -27,6 +27,14 @@ class ExperienceBlockPolicy < ApplicationPolicy
     user_allowed_to_interact_with_block?
   end
 
+  def submit_the_scene_suggestion?
+    user_allowed_to_interact_with_block?
+  end
+
+  def submit_the_scene_vote?
+    user_allowed_to_interact_with_block?
+  end
+
   private
 
   def user_allowed_to_interact_with_block?

--- a/app/services/experiences/orchestrator.rb
+++ b/app/services/experiences/orchestrator.rb
@@ -70,6 +70,13 @@ module Experiences
         payload["leader_fill"]               = 0
         payload["leader_participant_id"]     = nil
         payload["leader_last_broadcast_at"]  = nil
+      when ExperienceBlock::THE_SCENE
+        leaderboard_size = payload["leaderboard_size"].to_i
+        raise ArgumentError, "leaderboard_size must be positive" unless leaderboard_size.positive?
+
+        payload["leaderboard_size"] = leaderboard_size
+        payload["phase"]            = "idle"
+        payload["scene_started_at"] = nil
       end
 
       payload
@@ -755,6 +762,134 @@ module Experiences
 
       { result: :accepted, winners: winners, leader_changed: leader_changed }
     end
+
+    # The Scene -------------------------------------------------------------
+
+    SCENE_PHASES = %w[idle collecting voting ended].freeze
+
+    def advance_the_scene_phase!(block_id:, phase:)
+      raise ArgumentError, "Unknown phase: #{phase}" unless SCENE_PHASES.include?(phase.to_s)
+
+      block = experience.experience_blocks.find(block_id)
+      raise ArgumentError, "Block is not a Scene" unless block.kind == ExperienceBlock::THE_SCENE
+
+      transaction do
+        payload = block.payload || {}
+        payload["phase"] = phase.to_s
+
+        # First time we leave idle, stamp scene_started_at so votes scope cleanly.
+        if payload["phase"] != "idle" && payload["scene_started_at"].blank?
+          payload["scene_started_at"] = Time.current.iso8601(6)
+        end
+
+        new_status =
+          case payload["phase"]
+          when "idle"   then :hidden
+          when "ended"  then :closed
+          else               :open
+          end
+
+        block.update!(payload: payload, status: new_status)
+      end
+
+      block
+    end
+
+    def start_next_scene!(block_id:)
+      block = experience.experience_blocks.find(block_id)
+      raise ArgumentError, "Block is not a Scene" unless block.kind == ExperienceBlock::THE_SCENE
+
+      transaction do
+        payload = block.payload || {}
+        prior = payload["scene_started_at"]
+        candidate = Time.current.iso8601(6)
+
+        # Guarantee strict monotonic increase even if the host clicks
+        # twice in the same microsecond.
+        if prior.present? && candidate <= prior
+          candidate = (Time.iso8601(prior) + 0.001.seconds).iso8601(6)
+        end
+
+        payload["phase"]            = "collecting"
+        payload["scene_started_at"] = candidate
+        block.update!(payload: payload, status: :open)
+      end
+
+      block
+    end
+
+    def submit_the_scene_suggestion!(block_id:, text:)
+      block = experience.experience_blocks.find(block_id)
+      raise ArgumentError, "Block is not a Scene" unless block.kind == ExperienceBlock::THE_SCENE
+
+      payload = block.payload || {}
+      raise Experiences::InvalidTransitionError, "Scene is not collecting suggestions" unless %w[collecting voting].include?(payload["phase"])
+
+      trimmed = text.to_s.strip
+      raise ArgumentError, "Suggestion cannot be blank" if trimmed.empty?
+      raise ArgumentError, "Suggestion is too long (#{ImprovSuggestion::MAX_LENGTH} max)" if trimmed.length > ImprovSuggestion::MAX_LENGTH
+
+      transaction do
+        existing = block.improv_suggestions.active.find_by(user_id: actor.id)
+        raise Experiences::InvalidTransitionError, "You already submitted this scene" if existing
+
+        block.improv_suggestions.create!(user_id: actor.id, text: trimmed)
+      end
+    end
+
+    def submit_the_scene_vote!(block_id:, suggestion_id:)
+      block = experience.experience_blocks.find(block_id)
+      raise ArgumentError, "Block is not a Scene" unless block.kind == ExperienceBlock::THE_SCENE
+
+      payload = block.payload || {}
+      raise Experiences::InvalidTransitionError, "Voting is not open" unless payload["phase"] == "voting"
+
+      scene_started_at = payload["scene_started_at"]
+      raise Experiences::InvalidTransitionError, "Scene has not started" if scene_started_at.blank?
+
+      suggestion = block.improv_suggestions.active.find(suggestion_id)
+      raise ArgumentError, "Cannot vote for your own suggestion" if suggestion.user_id == actor.id
+
+      transaction do
+        vote = ImprovVote
+          .where(experience_block_id: block.id, user_id: actor.id, scene_started_at: scene_started_at)
+          .first_or_initialize
+
+        vote.improv_suggestion_id = suggestion.id
+        vote.save!
+        vote
+      end
+    end
+
+    def clear_the_scene_top!(block_id:)
+      block = experience.experience_blocks.find(block_id)
+      raise ArgumentError, "Block is not a Scene" unless block.kind == ExperienceBlock::THE_SCENE
+
+      top = TheScene::Tally.top(block: block, scene_started_at: block.payload["scene_started_at"])&.first
+      return block unless top
+
+      top.clear!
+      block
+    end
+
+    def clear_the_scene_suggestion!(block_id:, suggestion_id:)
+      block = experience.experience_blocks.find(block_id)
+      raise ArgumentError, "Block is not a Scene" unless block.kind == ExperienceBlock::THE_SCENE
+
+      suggestion = block.improv_suggestions.active.find(suggestion_id)
+      suggestion.clear!
+      block
+    end
+
+    def clear_the_scene_all!(block_id:)
+      block = experience.experience_blocks.find(block_id)
+      raise ArgumentError, "Block is not a Scene" unless block.kind == ExperienceBlock::THE_SCENE
+
+      block.improv_suggestions.active.update_all(cleared_at: Time.current)
+      block
+    end
+
+    # -----------------------------------------------------------------------
 
     def update_block!(block_id:, payload:, visible_to_segment_ids:, variables: nil, questions: nil)
       transaction do

--- a/app/services/experiences/visibility.rb
+++ b/app/services/experiences/visibility.rb
@@ -95,6 +95,7 @@ module Experiences
     def monitor_visibility_ok?(block)
       return true if block.kind == ExperienceBlock::MINIGAME_ARITHMETIC
       return true if block.kind == ExperienceBlock::MINIGAME_BALLOON_PUMP
+      return true if block.kind == ExperienceBlock::THE_SCENE
       !block.has_visibility_rules?
     end
 
@@ -182,9 +183,67 @@ module Experiences
         shape_minigame_arithmetic_payload(block, participant_role, user, view_context)
       when ExperienceBlock::MINIGAME_BALLOON_PUMP
         shape_minigame_balloon_pump_payload(block, participant_role, user, view_context)
+      when ExperienceBlock::THE_SCENE
+        shape_the_scene_payload(block, participant_role, user, view_context)
       else
         block.payload
       end
+    end
+
+    def shape_the_scene_payload(block, participant_role, user, view_context)
+      payload          = block.payload.deep_dup || {}
+      phase            = payload["phase"] || "idle"
+      scene_started_at = payload["scene_started_at"]
+      leaderboard_size = payload["leaderboard_size"].to_i
+
+      privileged =
+        view_context == :admin ||
+        (view_context == :participant && (mod_or_host?(participant_role) || admin_user?(user)))
+
+      tally = TheScene::Tally.full(block: block, scene_started_at: scene_started_at)
+
+      shaped = {
+        "phase"            => phase,
+        "scene_started_at" => scene_started_at,
+        "leaderboard_size" => leaderboard_size,
+        "leaderboard"      => tally.first(leaderboard_size).map { |entry| serialize_tally_entry(entry) }
+      }
+
+      if view_context == :participant && !privileged && user
+        own = block.improv_suggestions.active.find_by(user_id: user.id)
+        shaped["own_suggestion"] = own && { "id" => own.id, "text" => own.text }
+
+        own_vote = nil
+        if scene_started_at.present?
+          own_vote = block.improv_votes.find_by(
+            user_id: user.id,
+            scene_started_at: scene_started_at
+          )
+        end
+        shaped["own_vote_suggestion_id"] = own_vote&.improv_suggestion_id
+
+        if phase == "voting" && own.present?
+          shaped["votable_suggestions"] = tally
+            .reject { |entry| entry.suggestion.user_id == user.id }
+            .map { |entry| serialize_tally_entry(entry) }
+        end
+      end
+
+      if privileged
+        shaped["all_suggestions"] = tally.map { |entry| serialize_tally_entry(entry) }
+      end
+
+      shaped
+    end
+
+    def serialize_tally_entry(entry)
+      {
+        "id"         => entry.suggestion.id,
+        "text"       => entry.suggestion.text,
+        "user_id"    => entry.suggestion.user_id,
+        "vote_count" => entry.vote_count,
+        "rank"       => entry.rank
+      }
     end
 
     def shape_minigame_balloon_pump_payload(block, participant_role, user, view_context)
@@ -480,6 +539,16 @@ module Experiences
       when ExperienceBlock::MINIGAME_BALLOON_PUMP
         results = block.experience_minigame_balloon_results.to_a
         { total: results.count }
+
+      when ExperienceBlock::THE_SCENE
+        suggestion_count = block.improv_suggestions.active.count
+        vote_count =
+          if block.payload["scene_started_at"].present?
+            block.improv_votes.where(scene_started_at: block.payload["scene_started_at"]).count
+          else
+            0
+          end
+        { total: suggestion_count, vote_count: vote_count }
 
       when ExperienceBlock::BUZZER
         submissions = block.experience_buzzer_submissions.order(Arel.sql("answer->>'buzzed_at' ASC")).to_a

--- a/app/services/the_scene/shortlist.rb
+++ b/app/services/the_scene/shortlist.rb
@@ -1,0 +1,15 @@
+module TheScene
+  # Determines which suggestions are eligible for voting in a given scene.
+  #
+  # TODO: in a future iteration, run AI clustering over the active suggestions
+  #       to collapse near-duplicates ("a wedding" / "wedding scene" / "marriage
+  #       party") into a single representative entry, optionally surfacing only
+  #       the top-N by frequency. Wiring point: replace `active_for(block:)`
+  #       with the clustered output. Frontend already trusts whatever this
+  #       service returns as the votable pool.
+  class Shortlist
+    def self.active_for(block:)
+      block.improv_suggestions.active.order(created_at: :asc)
+    end
+  end
+end

--- a/app/services/the_scene/tally.rb
+++ b/app/services/the_scene/tally.rb
@@ -1,0 +1,60 @@
+module TheScene
+  # Ranks the active suggestions for a block by current-scene vote count.
+  # Suggestions with zero votes are included at the tail in submission order
+  # so the leaderboard renders deterministically before any votes arrive.
+  class Tally
+    Entry = Struct.new(:suggestion, :vote_count, :rank, keyword_init: true)
+
+    def self.full(block:, scene_started_at:)
+      new(block: block, scene_started_at: scene_started_at).full
+    end
+
+    def self.top(block:, scene_started_at:, limit: 1)
+      full(block: block, scene_started_at: scene_started_at).first(limit).map(&:suggestion)
+    end
+
+    def initialize(block:, scene_started_at:)
+      @block            = block
+      @scene_started_at = scene_started_at
+    end
+
+    def full
+      suggestions = TheScene::Shortlist.active_for(block: @block).to_a
+      counts      = vote_counts
+
+      ranked = suggestions
+        .map { |s| { suggestion: s, vote_count: counts[s.id].to_i } }
+        .sort_by.with_index { |entry, idx| [-entry[:vote_count], idx] }
+
+      assign_ranks(ranked).map { |e| Entry.new(**e) }
+    end
+
+    private
+
+    def vote_counts
+      return {} if @scene_started_at.blank?
+
+      ImprovVote
+        .where(experience_block_id: @block.id, scene_started_at: @scene_started_at)
+        .group(:improv_suggestion_id)
+        .count
+    end
+
+    def assign_ranks(entries)
+      previous_count = nil
+      previous_rank  = 0
+
+      entries.each_with_index do |entry, index|
+        if entry[:vote_count] == previous_count
+          entry[:rank] = previous_rank
+        else
+          entry[:rank]    = index + 1
+          previous_rank   = entry[:rank]
+          previous_count  = entry[:vote_count]
+        end
+      end
+
+      entries
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,14 @@ Rails.application.routes.draw do
           post 'minigame/balloon_pump/start', action: :start_minigame_balloon_pump
           post 'minigame/balloon_pump/end', action: :end_minigame_balloon_pump
           post 'minigame/balloon_pump/pump', action: :submit_minigame_balloon_pump_update
+
+          post 'the_scene/phase', action: :advance_the_scene_phase
+          post 'the_scene/next', action: :start_next_the_scene
+          post 'the_scene/clear_top', action: :clear_the_scene_top
+          post 'the_scene/clear/:suggestion_id', action: :clear_the_scene_suggestion
+          post 'the_scene/clear_all', action: :clear_the_scene_all
+          post 'the_scene/suggestions', action: :submit_the_scene_suggestion
+          post 'the_scene/votes', action: :submit_the_scene_vote
         end
 
         # collection do

--- a/db/migrate/20260505000003_create_improv_suggestions.rb
+++ b/db/migrate/20260505000003_create_improv_suggestions.rb
@@ -1,0 +1,23 @@
+class CreateImprovSuggestions < ActiveRecord::Migration[7.2]
+  def change
+    create_table :improv_suggestions, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      t.uuid :experience_block_id, null: false
+      t.uuid :user_id, null: false
+      t.text :text, null: false
+      t.datetime :cleared_at
+
+      t.timestamps
+    end
+
+    add_index :improv_suggestions, :experience_block_id
+    add_index :improv_suggestions, :user_id
+    add_index :improv_suggestions,
+      [:experience_block_id, :user_id],
+      where: "cleared_at IS NULL",
+      unique: true,
+      name: "index_improv_suggestions_one_active_per_user"
+
+    add_foreign_key :improv_suggestions, :experience_blocks, on_delete: :cascade
+    add_foreign_key :improv_suggestions, :users, on_delete: :cascade
+  end
+end

--- a/db/migrate/20260505000004_create_improv_votes.rb
+++ b/db/migrate/20260505000004_create_improv_votes.rb
@@ -1,0 +1,27 @@
+class CreateImprovVotes < ActiveRecord::Migration[7.2]
+  def change
+    create_table :improv_votes, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      t.uuid :experience_block_id, null: false
+      t.uuid :user_id, null: false
+      t.uuid :improv_suggestion_id, null: false
+      t.datetime :scene_started_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :improv_votes, :experience_block_id
+    add_index :improv_votes, :user_id
+    add_index :improv_votes, :improv_suggestion_id
+    add_index :improv_votes,
+      [:experience_block_id, :user_id, :scene_started_at],
+      unique: true,
+      name: "index_improv_votes_one_per_user_per_scene"
+    add_index :improv_votes,
+      [:experience_block_id, :scene_started_at, :improv_suggestion_id],
+      name: "index_improv_votes_for_tally"
+
+    add_foreign_key :improv_votes, :experience_blocks, on_delete: :cascade
+    add_foreign_key :improv_votes, :users, on_delete: :cascade
+    add_foreign_key :improv_votes, :improv_suggestions, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_05_000002) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_05_000004) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -298,6 +298,32 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_05_000002) do
     t.index ["user_id", "performer_id"], name: "index_follows_on_user_id_and_performer_id", unique: true
   end
 
+  create_table "improv_suggestions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "experience_block_id", null: false
+    t.uuid "user_id", null: false
+    t.text "text", null: false
+    t.datetime "cleared_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["experience_block_id", "user_id"], name: "index_improv_suggestions_one_active_per_user", unique: true, where: "(cleared_at IS NULL)"
+    t.index ["experience_block_id"], name: "index_improv_suggestions_on_experience_block_id"
+    t.index ["user_id"], name: "index_improv_suggestions_on_user_id"
+  end
+
+  create_table "improv_votes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "experience_block_id", null: false
+    t.uuid "user_id", null: false
+    t.uuid "improv_suggestion_id", null: false
+    t.datetime "scene_started_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["experience_block_id", "scene_started_at", "improv_suggestion_id"], name: "index_improv_votes_for_tally"
+    t.index ["experience_block_id", "user_id", "scene_started_at"], name: "index_improv_votes_one_per_user_per_scene", unique: true
+    t.index ["experience_block_id"], name: "index_improv_votes_on_experience_block_id"
+    t.index ["improv_suggestion_id"], name: "index_improv_votes_on_improv_suggestion_id"
+    t.index ["user_id"], name: "index_improv_votes_on_user_id"
+  end
+
   create_table "passwordless_sessions", force: :cascade do |t|
     t.string "authenticatable_type"
     t.uuid "authenticatable_id"
@@ -371,5 +397,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_05_000002) do
   add_foreign_key "experiences", "users", column: "creator_id", on_delete: :cascade
   add_foreign_key "follows", "performers", on_delete: :cascade
   add_foreign_key "follows", "users", on_delete: :cascade
+  add_foreign_key "improv_suggestions", "experience_blocks", on_delete: :cascade
+  add_foreign_key "improv_suggestions", "users", on_delete: :cascade
+  add_foreign_key "improv_votes", "experience_blocks", on_delete: :cascade
+  add_foreign_key "improv_votes", "improv_suggestions", on_delete: :cascade
+  add_foreign_key "improv_votes", "users", on_delete: :cascade
   add_foreign_key "performers", "users", on_delete: :cascade
 end

--- a/spec/services/experiences/the_scene_orchestrator_spec.rb
+++ b/spec/services/experiences/the_scene_orchestrator_spec.rb
@@ -1,0 +1,218 @@
+require "rails_helper"
+
+RSpec.describe Experiences::Orchestrator, "the scene" do
+  let(:experience) { create(:experience, status: :live) }
+  let(:host_user)  { create(:user) }
+  let!(:host)      { create(:experience_participant, :host, user: host_user, experience: experience) }
+  let!(:player_a)  { create(:experience_participant, :audience, experience: experience) }
+  let!(:player_b)  { create(:experience_participant, :audience, experience: experience) }
+  let!(:player_c)  { create(:experience_participant, :audience, experience: experience) }
+
+  subject(:orchestrator) { described_class.new(actor: host_user, experience: experience) }
+
+  let(:block) do
+    orchestrator.add_block!(
+      kind: ExperienceBlock::THE_SCENE,
+      payload: { "leaderboard_size" => 5 }
+    )
+  end
+
+  def player_orchestrator(participant)
+    described_class.new(actor: participant.user, experience: experience)
+  end
+
+  describe "#add_block!" do
+    it "creates a Scene block in idle phase with the configured leaderboard size" do
+      expect(block.payload["phase"]).to eq("idle")
+      expect(block.payload["leaderboard_size"]).to eq(5)
+      expect(block.payload["scene_started_at"]).to be_nil
+    end
+
+    it "raises when leaderboard_size is missing" do
+      expect {
+        orchestrator.add_block!(kind: ExperienceBlock::THE_SCENE, payload: {})
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#advance_the_scene_phase!" do
+    it "transitions through phases and stamps scene_started_at" do
+      orchestrator.advance_the_scene_phase!(block_id: block.id, phase: "collecting")
+      block.reload
+      expect(block.payload["phase"]).to eq("collecting")
+      expect(block.payload["scene_started_at"]).to be_present
+      expect(block.status).to eq("open")
+    end
+
+    it "preserves scene_started_at across collecting → voting" do
+      orchestrator.advance_the_scene_phase!(block_id: block.id, phase: "collecting")
+      first_stamp = block.reload.payload["scene_started_at"]
+
+      orchestrator.advance_the_scene_phase!(block_id: block.id, phase: "voting")
+      expect(block.reload.payload["scene_started_at"]).to eq(first_stamp)
+    end
+
+    it "rejects unknown phases" do
+      expect {
+        orchestrator.advance_the_scene_phase!(block_id: block.id, phase: "garbage")
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#submit_the_scene_suggestion!" do
+    before { orchestrator.advance_the_scene_phase!(block_id: block.id, phase: "collecting") }
+
+    it "creates an active suggestion for the participant" do
+      suggestion = player_orchestrator(player_a).submit_the_scene_suggestion!(
+        block_id: block.id, text: "  a wedding  "
+      )
+      expect(suggestion.text).to eq("a wedding")
+      expect(suggestion.cleared_at).to be_nil
+    end
+
+    it "rejects blank suggestions" do
+      expect {
+        player_orchestrator(player_a).submit_the_scene_suggestion!(block_id: block.id, text: "   ")
+      }.to raise_error(ArgumentError)
+    end
+
+    it "rejects a second suggestion in the same scene" do
+      player_orchestrator(player_a).submit_the_scene_suggestion!(block_id: block.id, text: "first")
+
+      expect {
+        player_orchestrator(player_a).submit_the_scene_suggestion!(block_id: block.id, text: "second")
+      }.to raise_error(Experiences::InvalidTransitionError)
+    end
+
+    it "allows resubmission after admin clears the prior one" do
+      first = player_orchestrator(player_a).submit_the_scene_suggestion!(block_id: block.id, text: "first")
+      orchestrator.clear_the_scene_suggestion!(block_id: block.id, suggestion_id: first.id)
+
+      second = player_orchestrator(player_a).submit_the_scene_suggestion!(block_id: block.id, text: "second")
+      expect(second.text).to eq("second")
+      expect(second.id).not_to eq(first.id)
+    end
+
+    it "rejects when phase is idle or ended" do
+      orchestrator.advance_the_scene_phase!(block_id: block.id, phase: "ended")
+      expect {
+        player_orchestrator(player_a).submit_the_scene_suggestion!(block_id: block.id, text: "no")
+      }.to raise_error(Experiences::InvalidTransitionError)
+    end
+  end
+
+  describe "#submit_the_scene_vote!" do
+    let(:suggestion_a) { player_orchestrator(player_a).submit_the_scene_suggestion!(block_id: block.id, text: "a wedding") }
+    let(:suggestion_b) { player_orchestrator(player_b).submit_the_scene_suggestion!(block_id: block.id, text: "a circus") }
+
+    before do
+      orchestrator.advance_the_scene_phase!(block_id: block.id, phase: "collecting")
+      suggestion_a
+      suggestion_b
+      orchestrator.advance_the_scene_phase!(block_id: block.id, phase: "voting")
+    end
+
+    it "records a vote" do
+      vote = player_orchestrator(player_c).submit_the_scene_vote!(
+        block_id: block.id, suggestion_id: suggestion_a.id
+      )
+      expect(vote.improv_suggestion_id).to eq(suggestion_a.id)
+    end
+
+    it "allows changing a vote" do
+      player_orchestrator(player_c).submit_the_scene_vote!(block_id: block.id, suggestion_id: suggestion_a.id)
+      player_orchestrator(player_c).submit_the_scene_vote!(block_id: block.id, suggestion_id: suggestion_b.id)
+
+      votes = ImprovVote.where(experience_block_id: block.id, user_id: player_c.user_id).to_a
+      expect(votes.size).to eq(1)
+      expect(votes.first.improv_suggestion_id).to eq(suggestion_b.id)
+    end
+
+    it "rejects voting for own suggestion" do
+      expect {
+        player_orchestrator(player_a).submit_the_scene_vote!(block_id: block.id, suggestion_id: suggestion_a.id)
+      }.to raise_error(ArgumentError)
+    end
+
+    it "rejects voting outside the voting phase" do
+      orchestrator.advance_the_scene_phase!(block_id: block.id, phase: "ended")
+      expect {
+        player_orchestrator(player_c).submit_the_scene_vote!(block_id: block.id, suggestion_id: suggestion_a.id)
+      }.to raise_error(Experiences::InvalidTransitionError)
+    end
+  end
+
+  describe "#start_next_scene!" do
+    let(:suggestion_a) { player_orchestrator(player_a).submit_the_scene_suggestion!(block_id: block.id, text: "a wedding") }
+    let(:suggestion_b) { player_orchestrator(player_b).submit_the_scene_suggestion!(block_id: block.id, text: "a circus") }
+
+    before do
+      orchestrator.advance_the_scene_phase!(block_id: block.id, phase: "collecting")
+      suggestion_a
+      suggestion_b
+      orchestrator.advance_the_scene_phase!(block_id: block.id, phase: "voting")
+      player_orchestrator(player_c).submit_the_scene_vote!(block_id: block.id, suggestion_id: suggestion_a.id)
+    end
+
+    it "preserves active suggestions across scenes (rolls forward)" do
+      orchestrator.start_next_scene!(block_id: block.id)
+      active_ids = block.improv_suggestions.active.pluck(:id)
+      expect(active_ids).to contain_exactly(suggestion_a.id, suggestion_b.id)
+    end
+
+    it "scopes votes to the new scene_started_at, leaving prior votes inert" do
+      first_stamp = block.reload.payload["scene_started_at"]
+
+      orchestrator.start_next_scene!(block_id: block.id)
+      second_stamp = block.reload.payload["scene_started_at"]
+      expect(second_stamp).not_to eq(first_stamp)
+
+      tally = TheScene::Tally.full(block: block.reload, scene_started_at: second_stamp)
+      expect(tally.map(&:vote_count).sum).to eq(0)
+    end
+
+    it "lets a participant submit a fresh suggestion in the next scene" do
+      orchestrator.start_next_scene!(block_id: block.id)
+
+      expect {
+        player_orchestrator(player_a).submit_the_scene_suggestion!(block_id: block.id, text: "another")
+      }.to raise_error(Experiences::InvalidTransitionError),
+        "active suggestion from prior scene should still block resubmission"
+
+      orchestrator.clear_the_scene_suggestion!(block_id: block.id, suggestion_id: suggestion_a.id)
+      fresh = player_orchestrator(player_a).submit_the_scene_suggestion!(block_id: block.id, text: "another")
+      expect(fresh).to be_persisted
+    end
+  end
+
+  describe "clear actions" do
+    let(:suggestion_a) { player_orchestrator(player_a).submit_the_scene_suggestion!(block_id: block.id, text: "a wedding") }
+    let(:suggestion_b) { player_orchestrator(player_b).submit_the_scene_suggestion!(block_id: block.id, text: "a circus") }
+
+    before do
+      orchestrator.advance_the_scene_phase!(block_id: block.id, phase: "collecting")
+      suggestion_a
+      suggestion_b
+      orchestrator.advance_the_scene_phase!(block_id: block.id, phase: "voting")
+      player_orchestrator(player_c).submit_the_scene_vote!(block_id: block.id, suggestion_id: suggestion_a.id)
+    end
+
+    it "clear_top removes the highest-voted suggestion" do
+      orchestrator.clear_the_scene_top!(block_id: block.id)
+      expect(suggestion_a.reload.cleared_at).to be_present
+      expect(suggestion_b.reload.cleared_at).to be_nil
+    end
+
+    it "clear_specific removes the named suggestion" do
+      orchestrator.clear_the_scene_suggestion!(block_id: block.id, suggestion_id: suggestion_b.id)
+      expect(suggestion_b.reload.cleared_at).to be_present
+      expect(suggestion_a.reload.cleared_at).to be_nil
+    end
+
+    it "clear_all removes every active suggestion" do
+      orchestrator.clear_the_scene_all!(block_id: block.id)
+      expect(suggestion_a.reload.cleared_at).to be_present
+      expect(suggestion_b.reload.cleared_at).to be_present
+    end
+  end
+end


### PR DESCRIPTION
Live-improv companion: audience drops free-text suggestions, votes for others' (not their own), monitor renders a top-N leaderboard that re-orders in real time as votes flip ranks. Phases (collecting → voting → ended → next) are admin-driven; suggestions roll forward across scenes unless cleared, while votes are scene-scoped via a monotonic scene_started_at stamp.

Soft-deleted suggestions (cleared_at) preserve audit and let participants resubmit only after their prior entry is cleared. The TheScene::Shortlist service stubs out the suggestion pool with a TODO comment for a future AI clustering pass.