### PR TITLE
Add default audience segment with auto-assignment on registration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ GEMINI_API_KEY=your_gemini_api_key_here
 # APP_BASE_URL=http://127.0.0.1:3000
 # DATABASE_NAME=cctv_development
 # TEST_DATABASE_NAME=cctv_test
+#
+CCTV_AWS_ACCESS_KEY_ID=your_aws_access_key_id
+CCTV_AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
+CCTV_AWS_S3_BUCKET=cctv-photo-bucket-dev

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ gem "action_policy"
 
 gem "image_processing", "~> 1.2"
 
+gem "aws-sdk-s3", require: false
+
 group :development, :test do
   gem "rspec-rails"
   gem "factory_bot_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,25 @@ GEM
       tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1249.0)
+    aws-sdk-core (3.247.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.125.0)
+      aws-sdk-core (~> 3, >= 3.247.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.222.0)
+      aws-sdk-core (~> 3, >= 3.247.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     bcrypt (3.1.22)
     benchmark (0.4.1)
@@ -137,6 +156,7 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jmespath (1.6.2)
     jwt (3.1.2)
       base64
     knapsack (4.0.0)
@@ -316,6 +336,7 @@ PLATFORMS
 
 DEPENDENCIES
   action_policy
+  aws-sdk-s3
   bootsnap
   cuprite
   factory_bot_rails

--- a/app/controllers/api/experience_segments_controller.rb
+++ b/app/controllers/api/experience_segments_controller.rb
@@ -19,7 +19,7 @@ class Api::ExperienceSegmentsController < Api::BaseController
     with_experience_orchestration do
       segment = orchestrator.create_segment!(
         name: segment_params[:name],
-        color: segment_params[:color] || '#6B7280'
+        color: segment_params[:color].presence || Experience::DEFAULT_SEGMENT_COLOR
       )
 
       broadcast_and_render(segment)

--- a/app/controllers/api/experiences_controller.rb
+++ b/app/controllers/api/experiences_controller.rb
@@ -28,6 +28,8 @@ class Api::ExperiencesController < Api::BaseController
       )
 
       if experience.save
+        experience.ensure_default_segment!(name: params[:experience][:default_segment_name])
+
         render json: {
           type: 'success',
           success: true,

--- a/app/frontend/Core/SegmentBadge/SegmentBadge.tsx
+++ b/app/frontend/Core/SegmentBadge/SegmentBadge.tsx
@@ -1,5 +1,7 @@
 import styles from './SegmentBadge.module.scss';
 
+export const DEFAULT_SEGMENT_COLOR = '#6B7280';
+
 interface SegmentBadgeProps {
   name: string;
   color: string;

--- a/app/frontend/Core/SegmentMultiSelect/SegmentMultiSelect.module.scss
+++ b/app/frontend/Core/SegmentMultiSelect/SegmentMultiSelect.module.scss
@@ -1,0 +1,29 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  width: 100%;
+}
+
+.label {
+  font-size: 0.85rem;
+  color: var(--hot-white);
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.placeholder {
+  font-size: 0.8rem;
+  color: var(--phosphor);
+  font-style: italic;
+}
+
+.select {
+  font-size: 0.75rem;
+  padding: 0.15rem 0.3rem;
+}

--- a/app/frontend/Core/SegmentMultiSelect/SegmentMultiSelect.tsx
+++ b/app/frontend/Core/SegmentMultiSelect/SegmentMultiSelect.tsx
@@ -1,0 +1,61 @@
+import { DEFAULT_SEGMENT_COLOR, SegmentBadge } from '@cctv/core/SegmentBadge/SegmentBadge';
+import { ExperienceSegment } from '@cctv/types';
+
+import styles from './SegmentMultiSelect.module.scss';
+
+interface SegmentMultiSelectProps {
+  segments: ExperienceSegment[];
+  value: string[];
+  onChange: (next: string[]) => void;
+  label?: string;
+  placeholder?: string;
+}
+
+export function SegmentMultiSelect({
+  segments,
+  value,
+  onChange,
+  label = 'Visible to segments',
+  placeholder = 'Visible to all participants',
+}: SegmentMultiSelectProps) {
+  const available = segments.filter((s) => !value.includes(s.name));
+
+  return (
+    <div className={styles.root}>
+      <label className={styles.label}>{label}</label>
+      <div className={styles.row}>
+        {value.length === 0 && <span className={styles.placeholder}>{placeholder}</span>}
+        {value.map((name) => {
+          const seg = segments.find((s) => s.name === name);
+          return (
+            <SegmentBadge
+              key={name}
+              name={name}
+              color={seg?.color || DEFAULT_SEGMENT_COLOR}
+              onRemove={() => onChange(value.filter((n) => n !== name))}
+            />
+          );
+        })}
+        {available.length > 0 && (
+          <select
+            aria-label="Add segment"
+            className={styles.select}
+            value=""
+            onChange={(e) => {
+              if (e.target.value) {
+                onChange([...value, e.target.value]);
+              }
+            }}
+          >
+            <option value="">+ Add segment...</option>
+            {available.map((s) => (
+              <option key={s.id} value={s.name}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/Core/index.ts
+++ b/app/frontend/Core/index.ts
@@ -35,3 +35,5 @@ export {
   DialogDescription,
 } from './Dialog/Dialog';
 export { Switch } from './Switch/Switch';
+export { SegmentMultiSelect } from './SegmentMultiSelect/SegmentMultiSelect';
+export { DEFAULT_SEGMENT_COLOR } from './SegmentBadge/SegmentBadge';

--- a/app/frontend/Pages/Create/Create.tsx
+++ b/app/frontend/Pages/Create/Create.tsx
@@ -45,9 +45,12 @@ export default function Create() {
 
   const handleCreate = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const formData = getFormData<{ code: string; name: string }>(e.currentTarget);
+    const formData = getFormData<{ code: string; name: string; default_segment_name?: string }>(
+      e.currentTarget,
+    );
     const code = formData.code;
     const name = formData.name;
+    const defaultSegmentName = formData.default_segment_name?.trim();
 
     if (!code || code.trim() === '') {
       setError('Please enter a code');
@@ -64,6 +67,7 @@ export default function Create() {
         experience: {
           code: code.trim(),
           name: name.trim(),
+          ...(defaultSegmentName && { default_segment_name: defaultSegmentName }),
         },
       }),
     );
@@ -126,6 +130,12 @@ export default function Create() {
             type="text"
             value={codeValue}
             onChange={handleCodeChange}
+          />
+          <TextInput
+            label="Default segment (optional)"
+            name="default_segment_name"
+            type="text"
+            placeholder="Audience"
           />
           {error && <p className={styles.error}>{error}</p>}
           <Button type="submit" loading={isLoading} loadingText="Creating...">

--- a/app/frontend/Pages/Manage/CreateBlock/CreateBlock.module.scss
+++ b/app/frontend/Pages/Manage/CreateBlock/CreateBlock.module.scss
@@ -76,11 +76,34 @@
   padding-top: 1.5rem;
 }
 
-.additionalDetails {
+.segmentSelector {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
+  gap: 0.35rem;
   width: 100%;
+}
+
+.segmentLabel {
+  font-size: 0.85rem;
+  color: var(--hot-white);
+}
+
+.segmentRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.segmentPlaceholder {
+  font-size: 0.8rem;
+  color: var(--phosphor);
+  font-style: italic;
+}
+
+.segmentSelect {
+  font-size: 0.75rem;
+  padding: 0.15rem 0.3rem;
 }
 
 .error {

--- a/app/frontend/Pages/Manage/CreateBlock/CreateBlock.tsx
+++ b/app/frontend/Pages/Manage/CreateBlock/CreateBlock.tsx
@@ -1,8 +1,7 @@
 import { useExperience } from '@cctv/contexts/ExperienceContext';
-import { DialogDescription, DialogTitle } from '@cctv/core';
+import { DialogDescription, DialogTitle, SegmentMultiSelect } from '@cctv/core';
 import { Button } from '@cctv/core/Button/Button';
 import { Dropdown } from '@cctv/core/Dropdown/Dropdown';
-import { SegmentBadge } from '@cctv/core/SegmentBadge/SegmentBadge';
 import { BlockKind, ParticipantSummary } from '@cctv/types';
 
 import CreateAnnouncement from './CreateAnnouncement/CreateAnnouncement';
@@ -69,7 +68,7 @@ function CreateBlockForm({ onClose }: CreateBlockFormProps) {
       />
 
       <BlockEditor />
-      {viewAdditionalDetails && <AdditionalDetails />}
+      <SegmentSelector />
 
       <div className={styles.actions}>
         <Button variant="secondary" onClick={onClose}>
@@ -127,50 +126,16 @@ function BlockEditor() {
   }
 }
 
-function AdditionalDetails() {
+function SegmentSelector() {
   const { visibleSegments, setVisibleSegments } = useCreateBlockContext();
   const { experience } = useExperience();
   const definedSegments = experience?.segments || [];
 
   return (
-    <div className={styles.additionalDetails}>
-      <div>
-        <label style={{ fontSize: '0.85rem' }}>Visible to segments</label>
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem', marginTop: '0.25rem' }}>
-          {visibleSegments.map((name) => {
-            const seg = definedSegments.find((s) => s.name === name);
-            return (
-              <SegmentBadge
-                key={name}
-                name={name}
-                color={seg?.color || '#6B7280'}
-                onRemove={() => setVisibleSegments(visibleSegments.filter((n) => n !== name))}
-              />
-            );
-          })}
-          {definedSegments.filter((s) => !visibleSegments.includes(s.name)).length > 0 && (
-            <select
-              aria-label="Visible to segments"
-              style={{ fontSize: '0.75rem', padding: '0.15rem 0.3rem' }}
-              value=""
-              onChange={(e) => {
-                if (e.target.value) {
-                  setVisibleSegments([...visibleSegments, e.target.value]);
-                }
-              }}
-            >
-              <option value="">+ Add segment...</option>
-              {definedSegments
-                .filter((s) => !visibleSegments.includes(s.name))
-                .map((s) => (
-                  <option key={s.id} value={s.name}>
-                    {s.name}
-                  </option>
-                ))}
-            </select>
-          )}
-        </div>
-      </div>
-    </div>
+    <SegmentMultiSelect
+      segments={definedSegments}
+      value={visibleSegments}
+      onChange={setVisibleSegments}
+    />
   );
 }

--- a/app/frontend/Pages/Manage/CreateBlock/CreateBlockContext.tsx
+++ b/app/frontend/Pages/Manage/CreateBlock/CreateBlockContext.tsx
@@ -145,10 +145,14 @@ export function CreateBlockProvider({
     getDefaultFormData(BlockKind.POLL),
   );
 
-  const [visibleSegments, setVisibleSegments] = useState<string[]>([]);
-  const [viewAdditionalDetails, setViewAdditionalDetails] = useState<boolean>(false);
-
   const { experience } = useExperience();
+
+  const defaultSegmentName =
+    experience?.segments?.find((s) => s.id === experience.default_segment_id)?.name ?? null;
+  const initialVisibleSegments = defaultSegmentName ? [defaultSegmentName] : [];
+
+  const [visibleSegments, setVisibleSegments] = useState<string[]>(initialVisibleSegments);
+  const [viewAdditionalDetails, setViewAdditionalDetails] = useState<boolean>(false);
 
   const {
     createExperienceBlock,
@@ -415,7 +419,7 @@ export function CreateBlockProvider({
 
       // Reset all form state
       setBlockData(getDefaultFormData(blockData.kind));
-      setVisibleSegments([]);
+      setVisibleSegments(initialVisibleSegments);
       setViewAdditionalDetails(false);
     },
     [
@@ -427,6 +431,8 @@ export function CreateBlockProvider({
       onEndCurrentBlock,
       setCreateError,
       getDefaultFormData,
+      experience,
+      initialVisibleSegments,
     ],
   );
 
@@ -440,6 +446,7 @@ export function CreateBlockProvider({
     error: createError,
     visibleSegments,
     setVisibleSegments,
+    defaultSegmentName,
     viewAdditionalDetails,
     setViewAdditionalDetails,
   };

--- a/app/frontend/Pages/Manage/ParticipantsTab/ParticipantsTab.tsx
+++ b/app/frontend/Pages/Manage/ParticipantsTab/ParticipantsTab.tsx
@@ -13,9 +13,14 @@ import styles from './ParticipantsTab.module.scss';
 interface ParticipantsTabProps {
   participants: ParticipantSummary[];
   segments: ExperienceSegment[];
+  defaultSegmentId?: string | null;
 }
 
-export default function ParticipantsTab({ participants, segments }: ParticipantsTabProps) {
+export default function ParticipantsTab({
+  participants,
+  segments,
+  defaultSegmentId,
+}: ParticipantsTabProps) {
   const { assignSegment } = useAssignSegment();
   const { kickParticipant } = useKickParticipant();
   const [assigningFor, setAssigningFor] = useState<string | null>(null);
@@ -129,7 +134,7 @@ export default function ParticipantsTab({ participants, segments }: Participants
 
   return (
     <div className={styles.root}>
-      <SegmentManager segments={segments} />
+      <SegmentManager segments={segments} defaultSegmentId={defaultSegmentId ?? null} />
       <Table columns={columns} data={participants} emptyState="No participants yet." />
       <SubmissionsDrawer participant={submissionsFor} onClose={() => setSubmissionsFor(null)} />
     </div>

--- a/app/frontend/Pages/Manage/ParticipantsTab/SegmentManager/SegmentManager.tsx
+++ b/app/frontend/Pages/Manage/ParticipantsTab/SegmentManager/SegmentManager.tsx
@@ -8,9 +8,10 @@ import styles from './SegmentManager.module.scss';
 
 interface SegmentManagerProps {
   segments: ExperienceSegment[];
+  defaultSegmentId?: string | null;
 }
 
-export default function SegmentManager({ segments }: SegmentManagerProps) {
+export default function SegmentManager({ segments, defaultSegmentId }: SegmentManagerProps) {
   const [isAdding, setIsAdding] = useState(false);
   const [newName, setNewName] = useState('');
   const [newColor, setNewColor] = useState('#6B7280');
@@ -88,12 +89,37 @@ export default function SegmentManager({ segments }: SegmentManagerProps) {
                 </button>
               </div>
             ) : (
-              <span key={seg.id} onClick={() => startEditing(seg)} style={{ cursor: 'pointer' }}>
+              <span
+                key={seg.id}
+                onClick={() => startEditing(seg)}
+                style={{
+                  cursor: 'pointer',
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '0.35rem',
+                }}
+              >
                 <SegmentBadge
                   name={seg.name}
                   color={seg.color}
                   onRemove={() => handleDelete(seg.id)}
                 />
+                {seg.id === defaultSegmentId && (
+                  <span
+                    title="Auto-assigned to new audience members"
+                    style={{
+                      fontSize: '0.65rem',
+                      letterSpacing: '0.08em',
+                      textTransform: 'uppercase',
+                      padding: '0.1rem 0.35rem',
+                      borderRadius: '0.25rem',
+                      border: '1px solid var(--phosphor)',
+                      color: 'var(--phosphor)',
+                    }}
+                  >
+                    Default
+                  </span>
+                )}
               </span>
             ),
           )}

--- a/app/frontend/Pages/Manage/Viewer/ManageViewer.tsx
+++ b/app/frontend/Pages/Manage/Viewer/ManageViewer.tsx
@@ -303,6 +303,7 @@ export default function ManageViewer() {
               <ParticipantsTab
                 participants={participantsCombined}
                 segments={experience?.segments || []}
+                defaultSegmentId={experience?.default_segment_id ?? null}
               />
             </div>
           </aside>

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -488,6 +488,7 @@ export interface Experience {
   playbill_enabled?: boolean;
   playbill?: PlaybillSection[];
   segments?: ExperienceSegment[];
+  default_segment_id?: string | null;
   created_at: string;
   updated_at: string;
   participant_block_active?: boolean;
@@ -1017,9 +1018,10 @@ export interface CreateBlockContextValue {
   isSubmitting: boolean;
   error: string | null;
 
-  // Additional form state
+  // Visibility — segments default to the experience's default segment.
   visibleSegments: string[];
   setVisibleSegments: (segments: string[]) => void;
+  defaultSegmentName: string | null;
   viewAdditionalDetails: boolean;
   setViewAdditionalDetails: (view: boolean) => void;
 }

--- a/app/models/experience.rb
+++ b/app/models/experience.rb
@@ -13,6 +13,14 @@ class Experience < ApplicationRecord
     -> { order(position: :asc) },
     dependent: :destroy
 
+  belongs_to :default_segment,
+    class_name: "ExperienceSegment",
+    optional: true
+
+  DEFAULT_SEGMENT_NAME  = "Audience".freeze
+  DEFAULT_SEGMENT_COLOR = "#6B7280".freeze
+  AUTO_ASSIGNED_ROLES   = %w[audience player].freeze
+
   has_many :experience_blocks,
     -> { order(position: :asc) },
     dependent: :destroy
@@ -80,10 +88,58 @@ class Experience < ApplicationRecord
   def register_user(user, name:)
     return if user_registered?(user)
 
-    experience_participants.create!(
-      user: user,
-      name: name,
-      avatar: user.most_recent_avatar.presence || {}
+    transaction do
+      participant = experience_participants.create!(
+        user: user,
+        name: name,
+        avatar: user.most_recent_avatar.presence || {}
+      )
+
+      attach_default_segment(participant)
+      participant
+    end
+  end
+
+  # Idempotently returns this experience's default segment, recreating it if
+  # the host previously deleted it (so registrations always have a target).
+  # Retries once on RecordNotUnique to absorb the find_or_create_by! race
+  # between concurrent registrations on a fresh experience.
+  def ensure_default_segment!(name: nil)
+    if default_segment_id.present?
+      existing = experience_segments.find_by(id: default_segment_id)
+      return existing if existing
+    end
+
+    desired_name = name.presence || default_segment&.name || DEFAULT_SEGMENT_NAME
+    attempts = 0
+
+    begin
+      segment = experience_segments.find_or_create_by!(name: desired_name) do |s|
+        s.color = DEFAULT_SEGMENT_COLOR
+        s.position = (experience_segments.maximum(:position) || -1) + 1
+      end
+    rescue ActiveRecord::RecordNotUnique
+      attempts += 1
+      retry if attempts < 2
+      raise
+    end
+
+    update_column(:default_segment_id, segment.id) if default_segment_id != segment.id
+    segment
+  end
+
+  def attach_default_segment(participant)
+    return unless AUTO_ASSIGNED_ROLES.include?(participant.role.to_s)
+
+    segment = ensure_default_segment!
+    return if ExperienceParticipantSegment.exists?(
+      experience_participant_id: participant.id,
+      experience_segment_id: segment.id
+    )
+
+    ExperienceParticipantSegment.create!(
+      experience_participant: participant,
+      experience_segment: segment
     )
   end
 

--- a/app/services/experiences/segment_orchestrator.rb
+++ b/app/services/experiences/segment_orchestrator.rb
@@ -1,6 +1,6 @@
 module Experiences
   class SegmentOrchestrator < BaseService
-    def create_segment!(name:, color: '#6B7280')
+    def create_segment!(name:, color: Experience::DEFAULT_SEGMENT_COLOR)
       position = (experience.experience_segments.maximum(:position) || -1) + 1
 
       experience.experience_segments.create!(

--- a/app/services/experiences/visibility.rb
+++ b/app/services/experiences/visibility.rb
@@ -576,9 +576,10 @@ module Experiences
         created_at:       @experience.created_at,
         updated_at:       @experience.updated_at,
         blocks:           blocks,
-        playbill_enabled: @experience.playbill_enabled,
-        playbill:         serialize_playbill,
-        segments:         serialize_segments,
+        playbill_enabled:   @experience.playbill_enabled,
+        playbill:           serialize_playbill,
+        segments:           serialize_segments,
+        default_segment_id: @experience.default_segment_id,
         hosts:            serialize_participants(participants.select { |p| p.role == "host" }),
         participants:     serialize_participants(participants)
       }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   config.action_view.annotate_rendered_view_with_filenames = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,7 +81,7 @@ Rails.application.configure do
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   config.action_mailer.default_url_options = {
     host: ENV.fetch("APP_HOST", "chicagocomedy.tv"), protocol: "https"

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,3 +1,10 @@
 local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
+
+amazon:
+  service: S3
+  access_key_id: <%= ENV["CCTV_AWS_ACCESS_KEY_ID"] %>
+  secret_access_key: <%= ENV["CCTV_AWS_SECRET_ACCESS_KEY"] %>
+  region: us-east-2
+  bucket: <%= ENV["CCTV_AWS_S3_BUCKET"] %>

--- a/db/migrate/20260506000001_add_default_segment_to_experiences.rb
+++ b/db/migrate/20260506000001_add_default_segment_to_experiences.rb
@@ -1,0 +1,9 @@
+class AddDefaultSegmentToExperiences < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :experiences,
+      :default_segment,
+      type: :uuid,
+      foreign_key: { to_table: :experience_segments, on_delete: :nullify },
+      null: true
+  end
+end

--- a/db/migrate/20260506000002_backfill_default_segments.rb
+++ b/db/migrate/20260506000002_backfill_default_segments.rb
@@ -1,0 +1,30 @@
+class BackfillDefaultSegments < ActiveRecord::Migration[7.2]
+  def up
+    Experience.where(default_segment_id: nil).find_each do |experience|
+      segment = experience.experience_segments.find_or_create_by!(name: Experience::DEFAULT_SEGMENT_NAME) do |s|
+        s.color = Experience::DEFAULT_SEGMENT_COLOR
+        s.position = (experience.experience_segments.maximum(:position) || -1) + 1
+      end
+
+      participant_ids = experience.experience_participants.where(role: Experience::AUTO_ASSIGNED_ROLES).pluck(:id)
+
+      existing_participant_ids = ExperienceParticipantSegment
+        .where(experience_segment_id: segment.id, experience_participant_id: participant_ids)
+        .pluck(:experience_participant_id)
+
+      missing = participant_ids - existing_participant_ids
+      if missing.any?
+        ExperienceParticipantSegment.insert_all(
+          missing.map { |pid| { experience_participant_id: pid, experience_segment_id: segment.id } }
+        )
+      end
+
+      experience.update_column(:default_segment_id, segment.id)
+    end
+  end
+
+  def down
+    # Data-only migration; no structural rollback. Removing the column
+    # is handled by AddDefaultSegmentToExperiences#down.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -252,8 +252,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_16_184105) do
     t.string "code_slug", null: false
     t.jsonb "playbill", default: [], null: false
     t.boolean "playbill_enabled", default: true, null: false
+    t.uuid "default_segment_id"
     t.index ["code_slug"], name: "index_experiences_on_code_slug", unique: true
     t.index ["creator_id"], name: "index_experiences_on_creator_id"
+    t.index ["default_segment_id"], name: "index_experiences_on_default_segment_id"
     t.index ["status"], name: "index_experiences_on_status"
   end
 
@@ -357,6 +359,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_16_184105) do
   add_foreign_key "experience_question_submissions", "experience_blocks", on_delete: :cascade
   add_foreign_key "experience_question_submissions", "users", on_delete: :cascade
   add_foreign_key "experience_segments", "experiences", on_delete: :cascade
+  add_foreign_key "experiences", "experience_segments", column: "default_segment_id", on_delete: :nullify
   add_foreign_key "experiences", "users", column: "creator_id", on_delete: :cascade
   add_foreign_key "follows", "performers", on_delete: :cascade
   add_foreign_key "follows", "users", on_delete: :cascade

--- a/spec/controllers/api/experiences_controller_spec.rb
+++ b/spec/controllers/api/experiences_controller_spec.rb
@@ -69,4 +69,35 @@ RSpec.describe Api::ExperiencesController, type: :controller do
   describe "PATCH #update_playbill" do
     it_behaves_like "requires manage_blocks or host access", :patch, :update_playbill, { playbill: [] }
   end
+
+  describe "POST #create" do
+    let(:base_params) do
+      { experience: { name: "Show", code: "SHOW#{rand(100_000)}" } }
+    end
+
+    it "seeds an Audience default segment when no name is provided" do
+      post :create, params: base_params, format: :json
+      expect(response).to be_successful
+
+      experience = Experience.find(JSON.parse(response.body)["experience"]["id"])
+      expect(experience.default_segment).to be_present
+      expect(experience.default_segment.name).to eq("Audience")
+    end
+
+    it "honors a custom default_segment_name" do
+      post :create, params: base_params.deep_merge(experience: { default_segment_name: "Crowd" }), format: :json
+      expect(response).to be_successful
+
+      experience = Experience.find(JSON.parse(response.body)["experience"]["id"])
+      expect(experience.default_segment.name).to eq("Crowd")
+    end
+
+    it "falls back to Audience when default_segment_name is blank" do
+      post :create, params: base_params.deep_merge(experience: { default_segment_name: "  " }), format: :json
+      expect(response).to be_successful
+
+      experience = Experience.find(JSON.parse(response.body)["experience"]["id"])
+      expect(experience.default_segment.name).to eq("Audience")
+    end
+  end
 end

--- a/spec/models/experience_default_segment_spec.rb
+++ b/spec/models/experience_default_segment_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+RSpec.describe Experience, "default segment" do
+  let(:creator) { create(:user) }
+  let(:experience) { create(:experience, creator: creator) }
+  let(:user) { create(:user) }
+
+  describe "#ensure_default_segment!" do
+    it "creates an Audience segment when none is configured" do
+      expect {
+        experience.ensure_default_segment!
+      }.to change { experience.experience_segments.count }.by(1)
+
+      experience.reload
+      expect(experience.default_segment.name).to eq("Audience")
+    end
+
+    it "honors a custom name on first call" do
+      experience.ensure_default_segment!(name: "Crowd")
+      expect(experience.reload.default_segment.name).to eq("Crowd")
+    end
+
+    it "is idempotent — repeated calls return the same segment" do
+      first  = experience.ensure_default_segment!
+      second = experience.ensure_default_segment!
+      expect(first.id).to eq(second.id)
+      expect(experience.experience_segments.count).to eq(1)
+    end
+
+    it "re-seeds when the default segment was deleted" do
+      seg = experience.ensure_default_segment!
+      seg.destroy!
+      experience.reload
+      expect(experience.default_segment_id).to be_nil
+
+      experience.ensure_default_segment!
+      experience.reload
+      expect(experience.default_segment).to be_present
+      expect(experience.default_segment.name).to eq("Audience")
+    end
+  end
+
+  describe "#register_user" do
+    before { experience.ensure_default_segment! }
+
+    it "auto-attaches new audience participants to the default segment" do
+      experience.register_user(user, name: "Test")
+
+      participant = experience.experience_participants.find_by(user_id: user.id)
+      expect(participant.experience_segments).to include(experience.default_segment)
+    end
+
+    it "does not attach hosts/moderators" do
+      participant = experience.experience_participants.create!(
+        user: user, name: "Host", role: :host
+      )
+
+      experience.attach_default_segment(participant)
+      expect(participant.reload.experience_segments).to be_empty
+    end
+
+    it "is a no-op for an already-attached participant" do
+      experience.register_user(user, name: "Test")
+      participant = experience.experience_participants.find_by(user_id: user.id)
+
+      expect {
+        experience.attach_default_segment(participant)
+      }.not_to change { participant.experience_segments.count }
+    end
+
+    it "re-seeds the default segment if the host deleted it before another registration" do
+      first_user  = create(:user)
+      experience.register_user(first_user, name: "First")
+      experience.default_segment.destroy!
+      experience.reload
+
+      second_user = create(:user)
+      experience.register_user(second_user, name: "Second")
+
+      experience.reload
+      expect(experience.default_segment).to be_present
+
+      participant = experience.experience_participants.find_by(user_id: second_user.id)
+      expect(participant.experience_segments).to include(experience.default_segment)
+    end
+
+    it "rolls back the participant if segment attachment fails" do
+      allow(experience).to receive(:attach_default_segment).and_raise(ActiveRecord::RecordInvalid)
+
+      expect {
+        expect { experience.register_user(user, name: "Test") }.to raise_error(ActiveRecord::RecordInvalid)
+      }.not_to change { experience.experience_participants.count }
+    end
+  end
+
+  describe "position assignment" do
+    it "uses MAX(position)+1 so deleted segments don't cause collisions" do
+      # Simulate a non-contiguous position sequence: positions 0 and 2 exist,
+      # position 1 was previously deleted. `count` would produce 2 and collide
+      # with the existing segment at position 2.
+      experience.experience_segments.create!(name: "A", color: "#111111", position: 0)
+      experience.experience_segments.create!(name: "B", color: "#222222", position: 2)
+
+      segment = experience.ensure_default_segment!
+      expect(segment.position).to eq(3)
+    end
+  end
+end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -171,6 +171,17 @@ module SystemHelpers
     present_block
   end
 
+  # Removes the default "Audience" segment from the Create/Edit Block form.
+  # Use inside `queue_block` (or an edit form) when a test needs the block
+  # to be visible to the monitor or to a non-audience segment in isolation —
+  # new blocks default to the experience's default segment, which hides them
+  # from the monitor view.
+  def clear_default_segment
+    if page.has_button?("Remove Audience", wait: 0)
+      click_button "Remove Audience"
+    end
+  end
+
   # Opens the edit form for the currently selected block.
   # Pre-asserts "Edit" is available; post-asserts "Edit Block" heading appears.
   def edit_block

--- a/spec/system/experiences/announcement_block_spec.rb
+++ b/spec/system/experiences/announcement_block_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Announcement Block", type: :system do
     queue_block(n: 1) do
       select "Announcement", from: "Kind"
       fill_in "Announcement Message", with: "Welcome {{ participant_name }} to the show!"
+      clear_default_segment
     end
 
     start_experience
@@ -73,6 +74,7 @@ RSpec.describe "Announcement Block", type: :system do
       queue_block(n: 1) do
         select "Announcement", from: "Kind"
         fill_in "Announcement Message", with: "Original message"
+        clear_default_segment
       end
 
       select_block(1, kind: "announcement")

--- a/spec/system/experiences/buzzer_block_spec.rb
+++ b/spec/system/experiences/buzzer_block_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "Buzzer Block", type: :system do
       select "Buzzer", from: "Kind"
       fill_in "Prompt", with: "Get ready to buzz in!"
       fill_in "Button Label (optional)", with: "Hit it!"
+      clear_default_segment
     end
 
     start_experience
@@ -57,6 +58,7 @@ RSpec.describe "Buzzer Block", type: :system do
       select "Buzzer", from: "Kind"
       fill_in "Prompt", with: "Get ready to buzz in!"
       fill_in "Button Label (optional)", with: "Hit it!"
+      clear_default_segment
     end
 
     start_experience
@@ -116,6 +118,7 @@ RSpec.describe "Buzzer Block", type: :system do
       queue_block(n: 1) do
         select "Buzzer", from: "Kind"
         fill_in "Prompt", with: "Original prompt"
+        clear_default_segment
       end
 
       select_block(1, kind: "buzzer")

--- a/spec/system/experiences/poll_block_spec.rb
+++ b/spec/system/experiences/poll_block_spec.rb
@@ -89,8 +89,8 @@ RSpec.describe "Poll Block", type: :system do
     queue_block(n: 2) do
       select "Announcement", from: "Kind"
       fill_in "Announcement Message", with: "Hello Team A!"
-      click_button "View Additional Details"
-      find("select[aria-label='Visible to segments']").select("Team A")
+      clear_default_segment
+      find("select[aria-label='Add segment']").select("Team A")
     end
 
     select_and_present(2, kind: "announcement")
@@ -108,8 +108,8 @@ RSpec.describe "Poll Block", type: :system do
     queue_block(n: 3) do
       select "Announcement", from: "Kind"
       fill_in "Announcement Message", with: "Hello Team B!"
-      click_button "View Additional Details"
-      find("select[aria-label='Visible to segments']").select("Team B")
+      clear_default_segment
+      find("select[aria-label='Add segment']").select("Team B")
     end
 
     select_and_present(3, kind: "announcement")
@@ -133,6 +133,7 @@ RSpec.describe "Poll Block", type: :system do
         fill_in "Poll Question", with: "Original question?"
         fill_in "Option 1", with: "yes"
         fill_in "Option 2", with: "no"
+        clear_default_segment
       end
 
       select_block(1, kind: "poll")

--- a/spec/system/experiences/question_block_spec.rb
+++ b/spec/system/experiences/question_block_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe "Question Block", type: :system do
       queue_block(n: 1) do
         select "Question", from: "Kind"
         fill_in "Question", with: "Original question?"
+        clear_default_segment
       end
 
       select_block(1, kind: "question")


### PR DESCRIPTION
Experiences now seed an "Audience" segment on creation (custom name optional via default_segment_name) and auto-attach new audience/player participants on register_user. The default is idempotent and re-seeds if a host deletes it. The Manage > Participants UI flags the default segment with a Default badge.