### PR TITLE
Add Open Graph metadata for shared URLs

### DIFF
--- a/app/controllers/spa_controller.rb
+++ b/app/controllers/spa_controller.rb
@@ -1,7 +1,89 @@
 class SpaController < ApplicationController
+  SITE_NAME = "chicagocomedy.tv".freeze
+  DEFAULT_TITLE = "chicagocomedy.tv".freeze
+  DEFAULT_DESCRIPTION = "Interactive comedy experiences for live audiences.".freeze
+
   def index
-    # Invidual routes (not api routes) that point to this action should set up
-    # any required metatags here and ensure the view (app/views/spa.html.erb)
-    # renders them correctly.
+    @og_site_name = SITE_NAME
+    @og_url = request.original_url
+    @og_image = "#{request.base_url}/icon.png"
+    @og_type = "website"
+    @og_title = DEFAULT_TITLE
+    @og_description = DEFAULT_DESCRIPTION
+
+    apply_route_metadata
+  end
+
+  private
+
+  def apply_route_metadata
+    case request.path
+    when %r{\A/experiences/(?<code>[^/]+)(?<rest>/.*)?\z}
+      code = Regexp.last_match[:code]
+      rest = Regexp.last_match[:rest].to_s
+      return if code == "register"
+
+      experience = Experience.find_by_code_or_slug(code)
+      return unless experience
+
+      base_title = experience.name.presence || "Live experience"
+      @og_title =
+        if rest.start_with?("/register")
+          "Join \"#{base_title}\""
+        elsif rest.start_with?("/monitor")
+          "#{base_title} — Monitor"
+        else
+          base_title
+        end
+      @og_description =
+        experience.description.presence ||
+        "Join \"#{base_title}\" — a live interactive experience on #{SITE_NAME}."
+    when %r{\A/events/(?<slug>[^/]+)\z}
+      event = Event.published.find_by(slug: Regexp.last_match[:slug])
+      return unless event
+
+      @og_type = "article"
+      @og_title = event.title
+      @og_description = build_event_description(event)
+    when %r{\A/performers/(?<slug>[^/]+)\z}
+      performer = Performer.find_by(slug: Regexp.last_match[:slug])
+      return unless performer
+
+      @og_type = "profile"
+      @og_title = performer.name
+      @og_description = performer.bio.presence ||
+                        "#{performer.name} on #{SITE_NAME}."
+      if performer.photo.attached?
+        @og_image = Rails.application.routes.url_helpers.rails_blob_url(
+          performer.photo,
+          host: request.base_url
+        )
+      end
+    when "/events"
+      @og_title = "Events"
+      @og_description = "Upcoming live comedy events on #{SITE_NAME}."
+    when "/performers"
+      @og_title = "Performers"
+      @og_description = "Comedians and performers on #{SITE_NAME}."
+    when "/about"
+      @og_title = "About"
+      @og_description = DEFAULT_DESCRIPTION
+    when "/join"
+      @og_title = "Join a show"
+      @og_description = "Enter a code to join a live experience on #{SITE_NAME}."
+    end
+  end
+
+  def build_event_description(event)
+    parts = []
+    parts << event.starts_at.strftime("%A, %B %-d · %-l:%M %p") if event.starts_at
+    parts << event.venue_name if event.venue_name.present?
+    summary = parts.join(" · ")
+
+    if event.description.present?
+      [summary.presence, event.description].compact.join(" — ")
+    else
+      summary.presence || "Live event on #{SITE_NAME}."
+    end
   end
 end

--- a/app/views/spa/index.html.erb
+++ b/app/views/spa/index.html.erb
@@ -1,1 +1,18 @@
+<% content_for :title, @og_title %>
+<% content_for :head do %>
+  <meta name="description" content="<%= @og_description %>">
+
+  <meta property="og:site_name" content="<%= @og_site_name %>">
+  <meta property="og:title" content="<%= @og_title %>">
+  <meta property="og:description" content="<%= @og_description %>">
+  <meta property="og:url" content="<%= @og_url %>">
+  <meta property="og:image" content="<%= @og_image %>">
+  <meta property="og:type" content="<%= @og_type %>">
+
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="<%= @og_title %>">
+  <meta name="twitter:description" content="<%= @og_description %>">
+  <meta name="twitter:image" content="<%= @og_image %>">
+<% end %>
+
 <div id="root"></div>

--- a/spec/controllers/spa_controller_spec.rb
+++ b/spec/controllers/spa_controller_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe SpaController, type: :controller do
+  render_views
+
+  describe "GET #index" do
+    context "default site" do
+      it "renders site-level OG metadata" do
+        get :index
+        expect(response).to be_successful
+        expect(response.body).to include('property="og:site_name"')
+        expect(response.body).to include('content="chicagocomedy.tv"')
+        expect(response.body).to include('property="og:title"')
+        expect(response.body).to include('property="og:description"')
+        expect(response.body).to include('property="og:image"')
+      end
+    end
+
+    context "experience lobby" do
+      let(:experience) do
+        create(:experience, name: "Improv Night", description: "Live unscripted comedy")
+      end
+
+      it "uses the experience name and description" do
+        request.path = "/experiences/#{experience.code_slug}"
+        get :index
+        expect(response.body).to include('property="og:title"')
+        expect(response.body).to include("Improv Night")
+        expect(response.body).to include("Live unscripted comedy")
+      end
+
+      it "frames the register URL as a join CTA" do
+        request.path = "/experiences/#{experience.code_slug}/register"
+        get :index
+        expect(response.body).to include(%(content="Join &quot;Improv Night&quot;"))
+      end
+
+      it "falls back to defaults for an unknown experience" do
+        request.path = "/experiences/does-not-exist"
+        get :index
+        expect(response.body).to include("chicagocomedy.tv")
+        expect(response).to be_successful
+      end
+    end
+  end
+end

--- a/spec/controllers/spa_controller_spec.rb
+++ b/spec/controllers/spa_controller_spec.rb
@@ -1,18 +1,20 @@
 require "rails_helper"
 
 RSpec.describe SpaController, type: :controller do
-  render_views
+  def og(name)
+    controller.instance_variable_get(:"@og_#{name}")
+  end
 
   describe "GET #index" do
     context "default site" do
-      it "renders site-level OG metadata" do
+      it "sets site-level OG metadata" do
         get :index
         expect(response).to be_successful
-        expect(response.body).to include('property="og:site_name"')
-        expect(response.body).to include('content="chicagocomedy.tv"')
-        expect(response.body).to include('property="og:title"')
-        expect(response.body).to include('property="og:description"')
-        expect(response.body).to include('property="og:image"')
+        expect(og(:site_name)).to eq("chicagocomedy.tv")
+        expect(og(:title)).to eq("chicagocomedy.tv")
+        expect(og(:description)).to be_present
+        expect(og(:image)).to end_with("/icon.png")
+        expect(og(:type)).to eq("website")
       end
     end
 
@@ -24,22 +26,21 @@ RSpec.describe SpaController, type: :controller do
       it "uses the experience name and description" do
         request.path = "/experiences/#{experience.code_slug}"
         get :index
-        expect(response.body).to include('property="og:title"')
-        expect(response.body).to include("Improv Night")
-        expect(response.body).to include("Live unscripted comedy")
+        expect(og(:title)).to eq("Improv Night")
+        expect(og(:description)).to eq("Live unscripted comedy")
       end
 
       it "frames the register URL as a join CTA" do
         request.path = "/experiences/#{experience.code_slug}/register"
         get :index
-        expect(response.body).to include(%(content="Join &quot;Improv Night&quot;"))
+        expect(og(:title)).to eq('Join "Improv Night"')
       end
 
       it "falls back to defaults for an unknown experience" do
         request.path = "/experiences/does-not-exist"
         get :index
-        expect(response.body).to include("chicagocomedy.tv")
         expect(response).to be_successful
+        expect(og(:title)).to eq("chicagocomedy.tv")
       end
     end
   end


### PR DESCRIPTION
## Summary
- Server-renders `og:*`, `twitter:*`, and `<meta name="description">` tags in the SPA layout so shared links (iMessage, Slack, Twitter, etc.) display a rich preview instead of just the slug.
- `SpaController#index` resolves the relevant record by slug for `/experiences/:code`, `/experiences/:code/register`, `/events/:slug`, and `/performers/:slug` (with appropriate titles/descriptions), plus static metadata for `/events`, `/performers`, `/about`, and `/join`. Falls back to site defaults otherwise.
- Image defaults to `/icon.png`; performer pages use the attached photo when present.

## Test plan
- [x] `bundle exec rspec spec/controllers/spa_controller_spec.rb` (4 examples, 0 failures)
- [ ] Manually verify a shared experience URL renders a rich preview in iMessage/Slack