### PR TITLE
CHI-53 pass view context to photoupload

### DIFF
--- a/app/frontend/Experiences/ExperienceBlockContainer/ExperienceBlockContainer.tsx
+++ b/app/frontend/Experiences/ExperienceBlockContainer/ExperienceBlockContainer.tsx
@@ -68,6 +68,7 @@ export default function ExperienceBlockContainer({
           prompt={block.payload.prompt}
           responses={block.responses}
           disabled={disabled}
+          viewContext={viewContext}
         />
       );
     case BlockKind.BUZZER:

--- a/app/frontend/Experiences/PhotoUpload/PhotoUpload.tsx
+++ b/app/frontend/Experiences/PhotoUpload/PhotoUpload.tsx
@@ -14,6 +14,7 @@ interface PhotoUploadProps {
   prompt: string;
   responses?: PhotoUploadBlock['responses'];
   disabled?: boolean;
+  viewContext?: 'participant' | 'monitor' | 'manage';
 }
 
 export default function PhotoUpload({
@@ -21,6 +22,7 @@ export default function PhotoUpload({
   prompt,
   responses,
   disabled = false,
+  viewContext = 'participant',
 }: PhotoUploadProps) {
   const { upload, isUploading, progress } = useDirectUpload();
   const { submitPhotoUploadResponse, isLoading: isSubmitting } = useSubmitPhotoUploadResponse();
@@ -64,6 +66,14 @@ export default function PhotoUpload({
       setError(result.error || 'Submission failed');
     }
   }, [blockId, signedId, submitPhotoUploadResponse]);
+
+  if (viewContext === 'monitor') {
+    return (
+      <div className={styles.container}>
+        <p className={styles.prompt}>{prompt}</p>
+      </div>
+    );
+  }
 
   if (hasResponded) {
     return (


### PR DESCRIPTION
There was no view context provided for the photo upload block. The caused the monitor to render an upload section.

https://linear.app/chicago-comedy-tv/issue/CHI-53/remove-upload-from-photo-when-shown-on-monitor