### PR TITLE
Display block kind labels in /manage

### DIFF
--- a/app/frontend/Pages/Manage/CreateBlock/CreateBlock.tsx
+++ b/app/frontend/Pages/Manage/CreateBlock/CreateBlock.tsx
@@ -2,7 +2,7 @@ import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { DialogDescription, DialogTitle, SegmentMultiSelect } from '@cctv/core';
 import { Button } from '@cctv/core/Button/Button';
 import { Dropdown } from '@cctv/core/Dropdown/Dropdown';
-import { BlockKind, ParticipantSummary } from '@cctv/types';
+import { BLOCK_KIND_LABELS, BlockKind, ParticipantSummary } from '@cctv/types';
 
 import CreateAnnouncement from './CreateAnnouncement/CreateAnnouncement';
 import { CreateBlockProvider, useCreateBlockContext } from './CreateBlockContext';
@@ -50,18 +50,10 @@ function CreateBlockForm({ onClose }: CreateBlockFormProps) {
 
       <Dropdown
         label="Kind"
-        options={[
-          { label: 'Poll', value: BlockKind.POLL },
-          { label: 'Question', value: BlockKind.QUESTION },
-          { label: 'Announcement', value: BlockKind.ANNOUNCEMENT },
-          { label: 'Family Feud', value: BlockKind.FAMILY_FEUD },
-          { label: 'Photo Upload', value: BlockKind.PHOTO_UPLOAD },
-          { label: 'Buzzer', value: BlockKind.BUZZER },
-          { label: 'Guess Who', value: BlockKind.GUESS_WHO },
-          { label: 'Minigame: Arithmetic', value: BlockKind.MINIGAME_ARITHMETIC },
-          { label: 'Minigame: Balloon Pump', value: BlockKind.MINIGAME_BALLOON_PUMP },
-          { label: 'The Scene', value: BlockKind.THE_SCENE },
-        ]}
+        options={Object.values(BlockKind).map((kind) => ({
+          label: BLOCK_KIND_LABELS[kind],
+          value: kind,
+        }))}
         value={blockData.kind}
         onChange={setKind}
         required

--- a/app/frontend/Pages/Manage/EditBlock/EditBlock.tsx
+++ b/app/frontend/Pages/Manage/EditBlock/EditBlock.tsx
@@ -2,7 +2,13 @@ import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { DialogDescription, DialogTitle } from '@cctv/core';
 import { Button } from '@cctv/core/Button/Button';
 import { SegmentBadge } from '@cctv/core/SegmentBadge/SegmentBadge';
-import { Block, BlockKind, FormBlockData, ParticipantSummary } from '@cctv/types';
+import {
+  BLOCK_KIND_LABELS,
+  Block,
+  BlockKind,
+  FormBlockData,
+  ParticipantSummary,
+} from '@cctv/types';
 
 import CreateAnnouncement from '../CreateBlock/CreateAnnouncement/CreateAnnouncement';
 import CreateBuzzer from '../CreateBlock/CreateBuzzer/CreateBuzzer';
@@ -41,19 +47,6 @@ interface EditBlockFormProps {
   block: Block;
 }
 
-const KIND_LABELS: Record<BlockKind, string> = {
-  [BlockKind.POLL]: 'Poll',
-  [BlockKind.QUESTION]: 'Question',
-  [BlockKind.ANNOUNCEMENT]: 'Announcement',
-  [BlockKind.FAMILY_FEUD]: 'Family Feud',
-  [BlockKind.PHOTO_UPLOAD]: 'Photo Upload',
-  [BlockKind.BUZZER]: 'Buzzer',
-  [BlockKind.GUESS_WHO]: 'Guess Who',
-  [BlockKind.MINIGAME_ARITHMETIC]: 'Minigame: Arithmetic',
-  [BlockKind.MINIGAME_BALLOON_PUMP]: 'Minigame: Balloon Pump',
-  [BlockKind.THE_SCENE]: 'The Scene',
-};
-
 function EditBlockForm({ onClose, block }: EditBlockFormProps) {
   const {
     submit,
@@ -68,9 +61,11 @@ function EditBlockForm({ onClose, block }: EditBlockFormProps) {
 
   return (
     <div className={styles.root}>
-      <DialogTitle className={styles.title}>Edit Block — {KIND_LABELS[block.kind]}</DialogTitle>
+      <DialogTitle className={styles.title}>
+        Edit Block — {BLOCK_KIND_LABELS[block.kind]}
+      </DialogTitle>
       <DialogDescription className="sr-only">
-        Edit this {KIND_LABELS[block.kind]} block
+        Edit this {BLOCK_KIND_LABELS[block.kind]} block
       </DialogDescription>
       {error && <div className={styles.error}>{error}</div>}
 

--- a/app/frontend/Pages/Manage/ParticipantsTab/SubmissionsDrawer/SubmissionsDrawer.tsx
+++ b/app/frontend/Pages/Manage/ParticipantsTab/SubmissionsDrawer/SubmissionsDrawer.tsx
@@ -3,7 +3,7 @@ import {
   ParticipantSubmissionEntry,
   useParticipantSubmissions,
 } from '@cctv/hooks/useParticipantSubmissions';
-import { ParticipantSummary } from '@cctv/types';
+import { BLOCK_KIND_LABELS, ParticipantSummary } from '@cctv/types';
 
 import styles from './SubmissionsDrawer.module.scss';
 
@@ -48,7 +48,7 @@ export default function SubmissionsDrawer({ participant, onClose }: SubmissionsD
             {entries.map((entry, index) => (
               <li key={`${entry.block_id}-${entry.submitted_at}-${index}`} className={styles.item}>
                 <div className={styles.itemHeader}>
-                  <span className={styles.kind}>{entry.block_kind.replace(/_/g, ' ')}</span>
+                  <span className={styles.kind}>{BLOCK_KIND_LABELS[entry.block_kind]}</span>
                   <span className={styles.position}>Block #{entry.position + 1}</span>
                 </div>
                 <div className={styles.prompt}>{entry.prompt || '(no prompt)'}</div>

--- a/app/frontend/Pages/Manage/Viewer/BlockDetailPanel.tsx
+++ b/app/frontend/Pages/Manage/Viewer/BlockDetailPanel.tsx
@@ -3,7 +3,14 @@ import { MessageSquare, Monitor, Pause, Play, SkipForward, User } from 'lucide-r
 import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { Button } from '@cctv/core/Button/Button';
 import { SegmentBadge } from '@cctv/core/SegmentBadge/SegmentBadge';
-import { AnnouncementPayload, Block, BlockKind, Experience, ParticipantSummary } from '@cctv/types';
+import {
+  AnnouncementPayload,
+  BLOCK_KIND_LABELS,
+  Block,
+  BlockKind,
+  Experience,
+  ParticipantSummary,
+} from '@cctv/types';
 
 import FamilyFeudManager from '../../Block/FamilyFeudManager/FamilyFeudManager';
 import BlockPreview from '../BlockPreview/BlockPreview';
@@ -60,7 +67,9 @@ export default function BlockDetailPanel({
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-xl font-semibold text-white">{selectedBlock.kind}</h2>
+          <h2 className="text-xl font-semibold text-white">
+            {BLOCK_KIND_LABELS[selectedBlock.kind]}
+          </h2>
           <div className="flex items-center gap-2 mt-1">
             <span className={`w-2 h-2 rounded-full ${getStatusColor(selectedBlock.status)}`} />
             <span className="text-sm text-[hsl(var(--muted-foreground))] capitalize">

--- a/app/frontend/Pages/Manage/Viewer/BlockSidebar.tsx
+++ b/app/frontend/Pages/Manage/Viewer/BlockSidebar.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import { ChevronLeft, ChevronRight, GripVertical, Plus } from 'lucide-react';
 
 import { Button } from '@cctv/core/Button/Button';
-import { Block } from '@cctv/types';
+import { BLOCK_KIND_LABELS, Block } from '@cctv/types';
 
 import styles from './BlockSidebar.module.scss';
 
@@ -119,11 +119,11 @@ export default function BlockSidebar({
                       [styles.hiddenBlock]: block.status === 'hidden',
                     })}
                     onClick={() => onSelectBlock(block.id)}
-                    title={`${block.kind} - ${block.status}`}
+                    title={`${BLOCK_KIND_LABELS[block.kind]} - ${block.status}`}
                   >
                     <span className={styles.statusBadge} data-status={block.status}>
                       <span className="sr-only">
-                        {block.kind} - {block.status}
+                        {BLOCK_KIND_LABELS[block.kind]} - {block.status}
                       </span>
                       <span className={styles.statusBadgeIndex}>{parentIndex + 1}</span>
                     </span>
@@ -138,11 +138,11 @@ export default function BlockSidebar({
                             [styles.hiddenBlock]: child.status === 'hidden',
                           })}
                           onClick={() => onSelectBlock(child.id)}
-                          title={`↳ ${child.kind} - ${child.status}`}
+                          title={`↳ ${BLOCK_KIND_LABELS[child.kind]} - ${child.status}`}
                         >
                           <span className={styles.statusBadge} data-status={child.status}>
                             <span className="sr-only">
-                              {child.kind} - {child.status}
+                              {BLOCK_KIND_LABELS[child.kind]} - {child.status}
                             </span>
                             <span className={styles.statusBadgeIndex}>{childIndex + 1}</span>
                           </span>
@@ -160,11 +160,11 @@ export default function BlockSidebar({
                       [styles.hiddenBlock]: block.status === 'hidden',
                     })}
                     onClick={() => onSelectBlock(block.id)}
-                    title={`${block.kind} - ${block.status}`}
+                    title={`${BLOCK_KIND_LABELS[block.kind]} - ${block.status}`}
                   >
                     <span className={styles.statusBadge} data-status={block.status}>
                       <span className="sr-only">
-                        {block.kind} - {block.status}
+                        {BLOCK_KIND_LABELS[block.kind]} - {block.status}
                       </span>
                       <span className={styles.statusBadgeIndex}>{parentIndex + 1}</span>
                     </span>
@@ -224,7 +224,9 @@ export default function BlockSidebar({
                               </span>
                               <span className={styles.blockIndex}>{parentIndex + 1}</span>
                               <span className={styles.statusDot} data-status={block.status} />
-                              <span className={styles.blockKind}>{block.kind}</span>
+                              <span className={styles.blockKind}>
+                                {BLOCK_KIND_LABELS[block.kind]}
+                              </span>
                               {block.status === 'open' && (
                                 <span className={styles.liveBadge}>Live</span>
                               )}
@@ -285,7 +287,9 @@ export default function BlockSidebar({
                                                 className={styles.statusDot}
                                                 data-status={child.status}
                                               />
-                                              <span className={styles.blockKind}>{child.kind}</span>
+                                              <span className={styles.blockKind}>
+                                                {BLOCK_KIND_LABELS[child.kind]}
+                                              </span>
                                               {child.status === 'open' && (
                                                 <span className={styles.liveBadge}>Live</span>
                                               )}

--- a/app/frontend/Pages/Manage/Viewer/DebugPanel/DebugPanel.tsx
+++ b/app/frontend/Pages/Manage/Viewer/DebugPanel/DebugPanel.tsx
@@ -8,7 +8,7 @@ import { DialogDescription, DialogTitle } from '@cctv/core';
 import { Button } from '@cctv/core/Button/Button';
 import { useDebugParticipants } from '@cctv/hooks/useDebugParticipants';
 import { useSimulateResponses } from '@cctv/hooks/useSimulateResponses';
-import { Block, BlockKind } from '@cctv/types';
+import { BLOCK_KIND_LABELS, Block, BlockKind } from '@cctv/types';
 
 import styles from './DebugPanel.module.scss';
 
@@ -395,7 +395,7 @@ export default function DebugPanel({ selectedBlock }: DebugPanelProps) {
 
           {selectedBlock && (
             <div className={styles.blockInfo}>
-              <span className={styles.blockKind}>{selectedBlock.kind}</span>
+              <span className={styles.blockKind}>{BLOCK_KIND_LABELS[selectedBlock.kind]}</span>
               <span className={styles.blockStatus}>{selectedBlock.status}</span>
             </div>
           )}

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -24,6 +24,19 @@ export enum BlockKind {
   THE_SCENE = 'the_scene',
 }
 
+export const BLOCK_KIND_LABELS: Record<BlockKind, string> = {
+  [BlockKind.POLL]: 'Poll',
+  [BlockKind.QUESTION]: 'Question',
+  [BlockKind.ANNOUNCEMENT]: 'Announcement',
+  [BlockKind.FAMILY_FEUD]: 'Family Feud',
+  [BlockKind.PHOTO_UPLOAD]: 'Photo Upload',
+  [BlockKind.BUZZER]: 'Buzzer',
+  [BlockKind.GUESS_WHO]: 'Guess Who',
+  [BlockKind.MINIGAME_ARITHMETIC]: 'Minigame: Arithmetic',
+  [BlockKind.MINIGAME_BALLOON_PUMP]: 'Minigame: Balloon Pump',
+  [BlockKind.THE_SCENE]: 'The Scene',
+};
+
 export interface ExperienceSegment {
   id: string;
   name: string;

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -142,10 +142,14 @@ module SystemHelpers
   end
 
   # Selects block N in the sidebar by clicking its kind button.
-  # kind is matched case-insensitively as a regex pattern against the button text.
+  # kind is a regex fragment matched against button text (e.g. "photo_upload"
+  # or "family.feud"). Underscores are translated to "[ _]" so callers can
+  # pass the snake_case ExperienceBlock kind even though buttons now render
+  # the human label ("Photo Upload").
   def select_block(n, kind:)
+    pattern = kind.gsub('_', '[ _]')
     within("li[aria-label='block #{n}']") do
-      find("button", text: /#{kind}/i).click
+      find("button", text: /#{pattern}/i).click
     end
   end
 


### PR DESCRIPTION
## Summary

Hosts were seeing raw enum values like \`Family_feud\` and \`The_scene\` throughout the /manage view. Centralizes a shared label map and sweeps the render sites.

- **\`BLOCK_KIND_LABELS: Record<BlockKind, string>\`** lives next to the \`BlockKind\` enum in \`types.ts\` (single source of truth).
- **EditBlock / CreateBlock**: dropped their local duplicates of the same map. CreateBlock's Kind dropdown is now generated from the shared map (\`Object.values(BlockKind).map(...)\`) so adding a new kind is one edit.
- **/manage sweep**: \`BlockSidebar\`, \`BlockDetailPanel\`, \`DebugPanel\`, \`SubmissionsDrawer\` all use the map now. The \`replace(/_/g, ' ')\` hack in SubmissionsDrawer is gone.

No data-model changes. No backend changes.

## Test plan
- [ ] \`yarn typecheck\`
- [ ] Manual: \`bin/dev\`, open /manage, queue blocks of various kinds — sidebar, detail header, debug panel, dropdown, and submissions drawer should all read "Family Feud", "The Scene", "Photo Upload", etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)