### PR TITLE
Allow deleting experience blocks from /manage

### DIFF
--- a/app/controllers/api/experience_blocks_controller.rb
+++ b/app/controllers/api/experience_blocks_controller.rb
@@ -1,6 +1,6 @@
 class Api::ExperienceBlocksController < Api::BaseController
   MANAGEMENT_ACTIONS = %i[
-    create update reorder set_column open close hide clear_buzzer_responses
+    create update destroy reorder set_column open close hide clear_buzzer_responses
     add_bucket rename_bucket delete_bucket assign_answer auto_categorize
     start_playing reveal_bucket show_x next_question restart_playing
     restart_categorizing restart_everything
@@ -104,6 +104,19 @@ class Api::ExperienceBlocksController < Api::BaseController
       Experiences::Broadcaster.new(@experience).broadcast_experience_update
 
       render json: { success: true, data: block }, status: 200
+    end
+  end
+
+  # DELETE /api/experiences/:experience_id/blocks/:id
+  def destroy
+    with_experience_orchestration do
+      Experiences::Orchestrator.new(experience: @experience, actor: @user)
+        .delete_block!(params[:id])
+
+      @experience.reload
+      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      render json: { success: true }, status: 200
     end
   end
 

--- a/app/frontend/Hooks/index.ts
+++ b/app/frontend/Hooks/index.ts
@@ -5,6 +5,7 @@ export { useGet } from './useGet';
 export { useJoinExperience } from './useJoinExperience';
 export { useRegisterExperience } from './useRegisterExperience';
 export { useCreateExperienceBlock } from './useCreateExperienceBlock';
+export { useDeleteExperienceBlock } from './useDeleteExperienceBlock';
 export { useSubmitPollResponse } from './useSubmitPollResponse';
 export { useSubmitQuestionResponse } from './useSubmitQuestionResponse';
 export { useChangeBlockStatus } from './useChangeBlockStatus';

--- a/app/frontend/Hooks/useDeleteExperienceBlock.ts
+++ b/app/frontend/Hooks/useDeleteExperienceBlock.ts
@@ -1,0 +1,48 @@
+import { useCallback, useState } from 'react';
+
+import { useAdminAuth } from '@cctv/contexts/AdminAuthContext';
+import { useExperience } from '@cctv/contexts/ExperienceContext';
+
+export function useDeleteExperienceBlock() {
+  const { code } = useExperience();
+  const { adminFetch } = useAdminAuth();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const deleteBlock = useCallback(
+    async (blockId: string): Promise<{ success: boolean; error?: string }> => {
+      if (!code) {
+        setError('Missing experience code');
+        return { success: false, error: 'Missing experience code' };
+      }
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const res = await adminFetch(
+          `/api/experiences/${encodeURIComponent(code)}/blocks/${encodeURIComponent(blockId)}`,
+          { method: 'DELETE' },
+        );
+        const data = await res.json();
+        if (!res.ok || data?.success === false) {
+          const msg = data?.error || 'Failed to delete block';
+          setError(msg);
+          return { success: false, error: msg };
+        }
+        return { success: true };
+      } catch (e: unknown) {
+        const msg =
+          e instanceof Error && e.message === 'Authentication expired'
+            ? 'Authentication expired'
+            : 'Connection error. Please try again.';
+        setError(msg);
+        return { success: false, error: msg };
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [code, adminFetch],
+  );
+
+  return { deleteBlock, isLoading, error, setError };
+}

--- a/app/frontend/Pages/Manage/Viewer/BlockDetailPanel.tsx
+++ b/app/frontend/Pages/Manage/Viewer/BlockDetailPanel.tsx
@@ -1,4 +1,6 @@
-import { MessageSquare, Monitor, Pause, Play, SkipForward, User } from 'lucide-react';
+import { useState } from 'react';
+
+import { MessageSquare, Monitor, Pause, Play, SkipForward, Trash2, User } from 'lucide-react';
 
 import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { Button } from '@cctv/core/Button/Button';
@@ -45,6 +47,8 @@ interface BlockDetailPanelProps {
   onViewModeChange: (mode: 'monitor' | 'participant' | 'responses') => void;
   onImpersonatedParticipantChange: (id: string) => void;
   onEdit: (block: Block) => void;
+  onDelete: (block: Block) => void;
+  deletingBlockId?: string;
 }
 
 export default function BlockDetailPanel({
@@ -62,7 +66,13 @@ export default function BlockDetailPanel({
   onViewModeChange,
   onImpersonatedParticipantChange,
   onEdit,
+  onDelete,
+  deletingBlockId,
 }: BlockDetailPanelProps) {
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const isDeleting = deletingBlockId === selectedBlock.id;
+  const canDelete = selectedBlock.status !== 'open';
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -115,6 +125,39 @@ export default function BlockDetailPanel({
                 <Play size={16} />
                 <span>Present</span>
               </span>
+            </Button>
+          )}
+          {confirmingDelete ? (
+            <>
+              <Button
+                variant="destructive"
+                onClick={() => {
+                  onDelete(selectedBlock);
+                  setConfirmingDelete(false);
+                }}
+                loading={isDeleting}
+                loadingText="Deleting..."
+              >
+                Confirm Delete
+              </Button>
+              <Button
+                variant="ghost"
+                onClick={() => setConfirmingDelete(false)}
+                disabled={isDeleting}
+              >
+                Cancel
+              </Button>
+            </>
+          ) : (
+            <Button
+              variant="destructive"
+              onClick={() => setConfirmingDelete(true)}
+              disabled={!canDelete || isDeleting}
+              title={canDelete ? 'Delete block' : 'Stop presenting before deleting'}
+              icon={<Trash2 size={16} />}
+              hideLabel
+            >
+              Delete
             </Button>
           )}
         </div>

--- a/app/frontend/Pages/Manage/Viewer/ManageViewer.tsx
+++ b/app/frontend/Pages/Manage/Viewer/ManageViewer.tsx
@@ -6,6 +6,7 @@ import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { Button, Drawer, DrawerBody, DrawerContent } from '@cctv/core';
 import { Pill } from '@cctv/core/Pill/Pill';
 import { useBlockPresentation } from '@cctv/hooks/useBlockPresentation';
+import { useDeleteExperienceBlock } from '@cctv/hooks/useDeleteExperienceBlock';
 import { useExperiencePause } from '@cctv/hooks/useExperiencePause';
 import { useExperienceResume } from '@cctv/hooks/useExperienceResume';
 import { useExperienceStart } from '@cctv/hooks/useExperienceStart';
@@ -125,6 +126,21 @@ export default function ManageViewer() {
 
   const { reorder: reorderBlock } = useReorderBlock();
 
+  const { deleteBlock, error: deleteError } = useDeleteExperienceBlock();
+  const [deletingBlockId, setDeletingBlockId] = useState<string | undefined>();
+
+  const handleDeleteBlock = useCallback(
+    async (block: Block) => {
+      setDeletingBlockId(block.id);
+      const result = await deleteBlock(block.id);
+      setDeletingBlockId(undefined);
+      if (result.success && selectedBlockId === block.id) {
+        setSelectedBlockId(null);
+      }
+    },
+    [deleteBlock, selectedBlockId],
+  );
+
   const handleReorderBlock = useCallback(
     (blockId: string, newIndex: number, _parentBlockId?: string) => {
       reorderBlock(blockId, newIndex);
@@ -184,7 +200,8 @@ export default function ManageViewer() {
   }
 
   const errorMessage =
-    !dismissedError && (experienceError || startError || pauseError || resumeError || statusError);
+    !dismissedError &&
+    (experienceError || startError || pauseError || resumeError || statusError || deleteError);
   const statusLabel = experience?.status
     ? experience.status.charAt(0).toUpperCase() + experience.status.slice(1)
     : '';
@@ -278,6 +295,8 @@ export default function ManageViewer() {
                 onViewModeChange={setViewMode}
                 onImpersonatedParticipantChange={setImpersonatedParticipantId}
                 onEdit={setEditingBlock}
+                onDelete={handleDeleteBlock}
+                deletingBlockId={deletingBlockId}
               />
             ) : (
               <div className="flex items-center justify-center h-full text-[hsl(var(--muted-foreground))]">

--- a/app/services/experiences/orchestrator.rb
+++ b/app/services/experiences/orchestrator.rb
@@ -102,6 +102,12 @@ module Experiences
       block
     end
 
+    def delete_block!(block_id)
+      block = experience.experience_blocks.find(block_id)
+      block.destroy!
+      block
+    end
+
     def reorder_block!(block_id:, position:)
       transaction do
         block = experience.experience_blocks.find(block_id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,7 +63,7 @@ Rails.application.routes.draw do
       resources(
         :blocks,
         controller: "experience_blocks",
-        only: [:create, :update]
+        only: [:create, :update, :destroy]
       ) do
         member do
           post :open

--- a/spec/controllers/api/experience_blocks_controller_spec.rb
+++ b/spec/controllers/api/experience_blocks_controller_spec.rb
@@ -297,6 +297,45 @@ RSpec.describe Api::ExperienceBlocksController, type: :controller do
     end
   end
 
+  describe "DELETE #destroy" do
+    let!(:block) { create(:experience_block, experience: experience, status: :hidden) }
+
+    subject do
+      delete(
+        :destroy,
+        params: { experience_id: experience.code_slug, id: block.id },
+        format: :json
+      )
+    end
+
+    it "removes the block and returns 200" do
+      block_id = block.id
+      subject
+
+      expect(response.status).to eql(200)
+      expect(ExperienceBlock.find_by(id: block_id)).to be_nil
+    end
+
+    context "when the actor is not authorized" do
+      let(:regular_user) { create(:user, :user) }
+      let(:participant) { create(:experience_participant, user: regular_user, experience: experience, role: :audience) }
+
+      before do
+        participant
+        jwt = Experiences::AuthService.jwt_for_participant(experience: experience, user: regular_user)
+        request.headers["Authorization"] = "Bearer #{jwt}"
+      end
+
+      it "returns 403 and keeps the block" do
+        block_id = block.id
+        subject
+
+        expect(response.status).to eql(403)
+        expect(ExperienceBlock.find_by(id: block_id)).to be_present
+      end
+    end
+  end
+
   describe "POST #submit_poll_response" do
     let(:audience_user) { create(:user, :user) }
     let!(:audience_participant) { create(:experience_participant, user: audience_user, experience: experience, role: :audience) }

--- a/spec/services/experiences/orchestrator_spec.rb
+++ b/spec/services/experiences/orchestrator_spec.rb
@@ -313,6 +313,49 @@ RSpec.describe Experiences::Orchestrator do
     end
   end
 
+  describe "#delete_block!" do
+    let(:participant_role) { ExperienceParticipant.roles[:host] }
+
+    subject do
+      described_class.new(actor: user, experience: experience).delete_block!(block.id)
+    end
+
+    context "when deleting a top-level block" do
+      let!(:block) do
+        create(:experience_block, experience: experience, status: :hidden)
+      end
+
+      it "removes the block from the experience" do
+        block_id = block.id
+        subject
+
+        expect(ExperienceBlock.find_by(id: block_id)).to be_nil
+      end
+    end
+
+    context "when deleting a FamilyFeud block with child questions" do
+      let!(:block) do
+        create(
+          :experience_block,
+          :family_feud,
+          experience: experience,
+          status: :hidden,
+          question_count: 2
+        )
+      end
+
+      it "removes the parent and its child question blocks" do
+        block_id = block.id
+        child_ids = block.child_blocks.pluck(:id)
+
+        subject
+
+        expect(ExperienceBlock.find_by(id: block_id)).to be_nil
+        expect(ExperienceBlock.where(id: child_ids)).to be_empty
+      end
+    end
+  end
+
   describe "#add_block!" do
     let(:participant_role) { ExperienceParticipant.roles[:host] }
     let(:kind) { "poll" }


### PR DESCRIPTION
## Summary

Adds a delete affordance so hosts can remove blocks they no longer need. Previously blocks could only be hidden via status changes — there was no destroy endpoint or UI.

- New `DELETE /api/experiences/:id/blocks/:id` endpoint, wired to existing `manage_blocks` authorization. Existing `dependent: :destroy` on child_blocks handles FamilyFeud question cleanup.
- BlockDetailPanel gets a destructive Delete button (icon-only) with a two-step confirm. Disabled while the block is open — host must stop presenting first.
- ManageViewer clears selection when the deleted block was selected and surfaces delete errors in the existing error banner.

## Test plan

- [ ] Backend specs pass (`bundle exec rspec spec/services/experiences/orchestrator_spec.rb spec/controllers/api/experience_blocks_controller_spec.rb`).
- [ ] In /manage, select a hidden block → Delete button visible → click → "Confirm Delete" appears → confirm → block disappears.
- [ ] Open block → Delete button disabled with tooltip "Stop presenting before deleting".
- [ ] Delete a FamilyFeud parent → its question children are also removed.
- [ ] Non-host participant gets 403 on the endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)