### PR TITLE
[Parked] Source/Consumer block relationship — reference branch for Jared

### DIFF
--- a/app/controllers/api/experience_blocks_controller.rb
+++ b/app/controllers/api/experience_blocks_controller.rb
@@ -1,6 +1,7 @@
 class Api::ExperienceBlocksController < Api::BaseController
   MANAGEMENT_ACTIONS = %i[
     create update reorder set_column open close hide clear_buzzer_responses
+    attach_source detach_source reorder_sources
     add_bucket rename_bucket delete_bucket assign_answer auto_categorize
     start_playing reveal_bucket show_x next_question restart_playing
     restart_categorizing restart_everything
@@ -34,14 +35,15 @@ class Api::ExperienceBlocksController < Api::BaseController
 
       segment_ids = create_params[:visible_to_segment_ids] || []
 
-      block = if create_params[:questions].present?
+      block = if create_params[:questions].present? || create_params[:source_block_ids].present?
         orchestrator.add_block_with_dependencies!(
           kind: create_params[:kind],
           payload: create_params[:payload] || {},
           visible_to_roles: create_params[:visible_to_roles] || [],
           target_user_ids: create_params[:target_user_ids] || [],
           status: create_params[:status] || :hidden,
-          questions: create_params[:questions] || []
+          questions: create_params[:questions] || [],
+          source_block_ids: create_params[:source_block_ids] || []
         )
       else
         orchestrator.add_block!(
@@ -59,24 +61,6 @@ class Api::ExperienceBlocksController < Api::BaseController
         ExperienceBlockSegment.insert_all(
           segment_ids.map { |sid| { experience_block_id: block.id, experience_segment_id: sid } }
         )
-      end
-
-      if create_params[:parent_block_id].present?
-        parent_block = @experience.experience_blocks.find_by(id: create_params[:parent_block_id])
-        if parent_block&.kind == 'family_feud'
-          Experiences::Broadcaster.new(@experience).broadcast_family_feud_update(
-            block_id: parent_block.id,
-            operation: 'question_added',
-            data: {
-              question: {
-                questionId: block.id,
-                questionText: block.payload['question'] || 'Question',
-                buckets: [],
-                unassignedAnswers: []
-              }
-            }
-          )
-        end
       end
 
       @experience.reload
@@ -219,10 +203,10 @@ class Api::ExperienceBlocksController < Api::BaseController
         answer: params[:answer]
       )
 
-      parent_block = @block.parent_block
-      if parent_block&.kind == 'family_feud'
+      family_feud_consumers = @block.consumers.where(kind: ExperienceBlock::FAMILY_FEUD)
+      family_feud_consumers.each do |consumer|
         Experiences::Broadcaster.new(@experience).broadcast_family_feud_update(
-          block_id: parent_block.id,
+          block_id: consumer.id,
           operation: 'answer_received',
           data: {
             questionId: @block.id,
@@ -268,6 +252,57 @@ class Api::ExperienceBlocksController < Api::BaseController
       Experiences::Broadcaster.new(@experience).broadcast_experience_update
 
       render json: { success: true }, status: 200
+    end
+  end
+
+  # POST /api/experiences/:experience_id/blocks/:id/sources
+  def attach_source
+    with_experience_orchestration do
+      block = Experiences::Orchestrator.new(
+        experience: @experience, actor: @user
+      ).attach_source!(
+        consumer_block_id: params[:id],
+        source_block_id: params[:source_block_id]
+      )
+
+      @experience.reload
+      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      render json: { success: true, data: block }, status: 200
+    end
+  end
+
+  # DELETE /api/experiences/:experience_id/blocks/:id/sources/:source_block_id
+  def detach_source
+    with_experience_orchestration do
+      block = Experiences::Orchestrator.new(
+        experience: @experience, actor: @user
+      ).detach_source!(
+        consumer_block_id: params[:id],
+        source_block_id: params[:source_block_id]
+      )
+
+      @experience.reload
+      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      render json: { success: true, data: block }, status: 200
+    end
+  end
+
+  # PATCH /api/experiences/:experience_id/blocks/:id/sources
+  def reorder_sources
+    with_experience_orchestration do
+      block = Experiences::Orchestrator.new(
+        experience: @experience, actor: @user
+      ).reorder_sources!(
+        consumer_block_id: params[:id],
+        source_block_ids: params[:source_block_ids] || []
+      )
+
+      @experience.reload
+      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      render json: { success: true, data: block }, status: 200
     end
   end
 
@@ -790,6 +825,7 @@ class Api::ExperienceBlocksController < Api::BaseController
 
     permitted[:payload] = params[:block][:payload] if params[:block][:payload]
     permitted[:questions] = params[:block][:questions] if params[:block][:questions]
+    permitted[:source_block_ids] = params[:block][:source_block_ids] if params[:block][:source_block_ids]
 
     permitted
   end

--- a/app/frontend/Core/SourcesPanel/SourcesPanel.module.scss
+++ b/app/frontend/Core/SourcesPanel/SourcesPanel.module.scss
@@ -1,0 +1,90 @@
+.count {
+  font-size: 0.85rem;
+  opacity: 0.75;
+}
+
+.empty {
+  font-size: 0.9rem;
+  opacity: 0.7;
+  margin: 0;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.5rem;
+  background: hsl(var(--card));
+}
+
+.itemMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.kind {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.7;
+}
+
+.label {
+  font-size: 0.95rem;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.status {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  opacity: 0.6;
+  letter-spacing: 0.05em;
+}
+
+.itemActions {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-shrink: 0;
+}
+
+.attach {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.attachLabel {
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+
+.select {
+  flex: 1 1 auto;
+  min-width: 12rem;
+  padding: 0.4rem 0.5rem;
+  font-size: 0.9rem;
+  border-radius: 0.4rem;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--input));
+  color: hsl(var(--foreground));
+}

--- a/app/frontend/Core/SourcesPanel/SourcesPanel.stories.tsx
+++ b/app/frontend/Core/SourcesPanel/SourcesPanel.stories.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Block, BlockKind } from '@cctv/types';
+
+import { SourcesPanel } from './SourcesPanel';
+
+const meta: Meta<typeof SourcesPanel> = {
+  title: 'Core/SourcesPanel',
+  component: SourcesPanel,
+  tags: ['autodocs'],
+};
+export default meta;
+
+type Story = StoryObj<typeof SourcesPanel>;
+
+const makeQuestion = (id: string, question: string, status: Block['status'] = 'hidden'): Block =>
+  ({
+    id,
+    kind: BlockKind.QUESTION,
+    status,
+    position: 0,
+    payload: { question, formKey: `f_${id}`, inputType: 'text' },
+  }) as Block;
+
+const makePoll = (id: string, question: string, status: Block['status'] = 'hidden'): Block =>
+  ({
+    id,
+    kind: BlockKind.POLL,
+    status,
+    position: 0,
+    payload: { question, options: ['A', 'B'], pollType: 'single' },
+  }) as Block;
+
+export const Empty: Story = {
+  args: {
+    sources: [],
+    candidates: [
+      makeQuestion('q-1', 'Name a fruit'),
+      makeQuestion('q-2', 'Name a movie'),
+      makePoll('p-1', 'Favorite color?'),
+    ],
+    onAttach: () => undefined,
+    onDetach: () => undefined,
+    onReorder: () => undefined,
+  },
+};
+
+export const Populated: Story = {
+  args: {
+    sources: [
+      makeQuestion('q-1', 'Name a fruit', 'closed'),
+      makeQuestion('q-2', 'Name a movie', 'open'),
+      makePoll('p-1', 'Favorite color?', 'hidden'),
+    ],
+    candidates: [makeQuestion('q-3', 'Name a country')],
+    onAttach: () => undefined,
+    onDetach: () => undefined,
+    onReorder: () => undefined,
+  },
+};
+
+export const NoCandidates: Story = {
+  args: {
+    sources: [makeQuestion('q-1', 'Already attached', 'closed')],
+    candidates: [],
+    onAttach: () => undefined,
+    onDetach: () => undefined,
+    onReorder: () => undefined,
+  },
+};
+
+export const Busy: Story = {
+  args: {
+    sources: [makeQuestion('q-1', 'Saving in progress', 'hidden')],
+    candidates: [makeQuestion('q-2', 'Another option')],
+    busy: true,
+    onAttach: () => undefined,
+    onDetach: () => undefined,
+    onReorder: () => undefined,
+  },
+};
+
+export const Interactive: Story = {
+  render: () => {
+    const [sources, setSources] = useState<Block[]>([
+      makeQuestion('q-1', 'Name a fruit', 'closed'),
+      makeQuestion('q-2', 'Name a movie', 'open'),
+    ]);
+    const [pool, setPool] = useState<Block[]>([
+      makeQuestion('q-3', 'Name a country'),
+      makePoll('p-1', 'Favorite color?'),
+    ]);
+
+    return (
+      <SourcesPanel
+        sources={sources}
+        candidates={pool}
+        onAttach={(id) => {
+          const moved = pool.find((b) => b.id === id);
+          if (!moved) return;
+          setSources([...sources, moved]);
+          setPool(pool.filter((b) => b.id !== id));
+        }}
+        onDetach={(id) => {
+          const moved = sources.find((b) => b.id === id);
+          if (!moved) return;
+          setSources(sources.filter((b) => b.id !== id));
+          setPool([...pool, moved]);
+        }}
+        onReorder={(orderedIds) => {
+          const byId = new Map(sources.map((s) => [s.id, s]));
+          setSources(orderedIds.map((id) => byId.get(id)!).filter(Boolean));
+        }}
+      />
+    );
+  },
+};

--- a/app/frontend/Core/SourcesPanel/SourcesPanel.tsx
+++ b/app/frontend/Core/SourcesPanel/SourcesPanel.tsx
@@ -1,0 +1,149 @@
+import { ArrowDown, ArrowUp, X } from 'lucide-react';
+
+import { BLOCK_KIND_LABELS, Block } from '@cctv/types';
+
+import { Button } from '../Button/Button';
+import { Panel } from '../Panel/Panel';
+
+import styles from './SourcesPanel.module.scss';
+
+export interface SourcesPanelProps {
+  sources: Block[];
+  candidates: Block[];
+  onAttach: (sourceBlockId: string) => unknown;
+  onDetach: (sourceBlockId: string) => unknown;
+  onReorder: (orderedIds: string[]) => unknown;
+  busy?: boolean;
+  emptyMessage?: string;
+}
+
+export function SourcesPanel({
+  sources,
+  candidates,
+  onAttach,
+  onDetach,
+  onReorder,
+  busy = false,
+  emptyMessage = 'No sources attached yet.',
+}: SourcesPanelProps) {
+  const move = (index: number, delta: number) => {
+    const target = index + delta;
+    if (target < 0 || target >= sources.length) return;
+    const next = sources.map((s) => s.id);
+    const [moved] = next.splice(index, 1);
+    next.splice(target, 0, moved);
+    onReorder(next);
+  };
+
+  return (
+    <Panel
+      title="Sources"
+      headerContent={<span className={styles.count}>{sources.length} attached</span>}
+    >
+      {sources.length === 0 ? (
+        <p className={styles.empty}>{emptyMessage}</p>
+      ) : (
+        <ol className={styles.list}>
+          {sources.map((source, index) => {
+            const label =
+              (source.payload as { question?: string; title?: string; message?: string })
+                .question ??
+              (source.payload as { title?: string }).title ??
+              (source.payload as { message?: string }).message ??
+              '(untitled)';
+
+            return (
+              <li key={source.id} className={styles.item} aria-label={`source ${index + 1}`}>
+                <div className={styles.itemMeta}>
+                  <span className={styles.kind}>{BLOCK_KIND_LABELS[source.kind]}</span>
+                  <span className={styles.label}>{label}</span>
+                  <span className={styles.status}>{source.status}</span>
+                </div>
+                <div className={styles.itemActions}>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    icon={<ArrowUp size={14} />}
+                    hideLabel
+                    disabled={busy || index === 0}
+                    onClick={() => move(index, -1)}
+                  >
+                    Move up
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    icon={<ArrowDown size={14} />}
+                    hideLabel
+                    disabled={busy || index === sources.length - 1}
+                    onClick={() => move(index, 1)}
+                  >
+                    Move down
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    icon={<X size={14} />}
+                    hideLabel
+                    disabled={busy}
+                    onClick={() => onDetach(source.id)}
+                  >
+                    Detach
+                  </Button>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+
+      <AttachControl candidates={candidates} onAttach={onAttach} disabled={busy} />
+    </Panel>
+  );
+}
+
+interface AttachControlProps {
+  candidates: Block[];
+  onAttach: (id: string) => unknown;
+  disabled?: boolean;
+}
+
+function AttachControl({ candidates, onAttach, disabled }: AttachControlProps) {
+  if (candidates.length === 0) {
+    return <p className={styles.empty}>No compatible blocks available to attach.</p>;
+  }
+
+  return (
+    <div className={styles.attach}>
+      <label htmlFor="attach-source" className={styles.attachLabel}>
+        Attach source
+      </label>
+      <select
+        id="attach-source"
+        className={styles.select}
+        value=""
+        disabled={disabled}
+        onChange={(e) => {
+          if (e.target.value) {
+            onAttach(e.target.value);
+            e.target.value = '';
+          }
+        }}
+      >
+        <option value="">Select a block…</option>
+        {candidates.map((c) => {
+          const label =
+            (c.payload as { question?: string; title?: string; message?: string }).question ??
+            (c.payload as { title?: string }).title ??
+            (c.payload as { message?: string }).message ??
+            '(untitled)';
+          return (
+            <option key={c.id} value={c.id}>
+              {BLOCK_KIND_LABELS[c.kind]} — {label}
+            </option>
+          );
+        })}
+      </select>
+    </div>
+  );
+}

--- a/app/frontend/Core/index.ts
+++ b/app/frontend/Core/index.ts
@@ -49,4 +49,6 @@ export {
 } from './Drawer/Drawer';
 export { Switch } from './Switch/Switch';
 export { SegmentMultiSelect } from './SegmentMultiSelect/SegmentMultiSelect';
+export { SourcesPanel } from './SourcesPanel/SourcesPanel';
+export type { SourcesPanelProps } from './SourcesPanel/SourcesPanel';
 export { DEFAULT_SEGMENT_COLOR } from './SegmentBadge/SegmentBadge';

--- a/app/frontend/Hooks/useBlockSources.ts
+++ b/app/frontend/Hooks/useBlockSources.ts
@@ -1,0 +1,82 @@
+import { useCallback, useState } from 'react';
+
+import { useAdminAuth } from '@cctv/contexts/AdminAuthContext';
+import { useExperience } from '@cctv/contexts/ExperienceContext';
+import { ApiResponse } from '@cctv/types';
+
+export function useBlockSources(consumerBlockId: string) {
+  const { code } = useExperience();
+  const { adminFetch } = useAdminAuth();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const baseUrl = code
+    ? `/api/experiences/${encodeURIComponent(code)}/blocks/${encodeURIComponent(consumerBlockId)}/sources`
+    : null;
+
+  const handleResponse = async (res: Response) => {
+    const data: ApiResponse = await res.json();
+    if (!data?.success) {
+      const msg = data?.error || 'Source operation failed';
+      setError(msg);
+      throw new Error(msg);
+    }
+    setError(null);
+    return data;
+  };
+
+  const attach = useCallback(
+    async (sourceBlockId: string) => {
+      if (!baseUrl) return null;
+      setIsLoading(true);
+      try {
+        return await handleResponse(
+          await adminFetch(baseUrl, {
+            method: 'POST',
+            body: JSON.stringify({ source_block_id: sourceBlockId }),
+          }),
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [baseUrl, adminFetch],
+  );
+
+  const detach = useCallback(
+    async (sourceBlockId: string) => {
+      if (!baseUrl) return null;
+      setIsLoading(true);
+      try {
+        return await handleResponse(
+          await adminFetch(`${baseUrl}/${encodeURIComponent(sourceBlockId)}`, {
+            method: 'DELETE',
+          }),
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [baseUrl, adminFetch],
+  );
+
+  const reorder = useCallback(
+    async (orderedIds: string[]) => {
+      if (!baseUrl) return null;
+      setIsLoading(true);
+      try {
+        return await handleResponse(
+          await adminFetch(baseUrl, {
+            method: 'PATCH',
+            body: JSON.stringify({ source_block_ids: orderedIds }),
+          }),
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [baseUrl, adminFetch],
+  );
+
+  return { attach, detach, reorder, isLoading, error };
+}

--- a/app/frontend/Pages/Block/FamilyFeudManager/FamilyFeudManager.tsx
+++ b/app/frontend/Pages/Block/FamilyFeudManager/FamilyFeudManager.tsx
@@ -73,7 +73,7 @@ export default function FamilyFeudManager({ block }: FamilyFeudManagerProps) {
   const [questionsState, dispatch] = useReducer(familyFeudReducer, []);
   const { addBucket, renameBucket, deleteBucket, assignAnswer, autoCategorize } =
     useFamilyFeudBuckets(block.id, dispatch);
-  const childQuestions = block.children ?? [];
+  const childQuestions = block.sources ?? [];
   const [editingBucketNames, setEditingBucketNames] = useState<Record<string, string>>({});
   const renameTimeoutRef = useRef<Record<string, NodeJS.Timeout>>({});
   const [addingBucketForQuestion, setAddingBucketForQuestion] = useState<string | null>(null);

--- a/app/frontend/Pages/Manage/EditBlock/EditBlock.tsx
+++ b/app/frontend/Pages/Manage/EditBlock/EditBlock.tsx
@@ -1,7 +1,8 @@
 import { useExperience } from '@cctv/contexts/ExperienceContext';
-import { DialogDescription, DialogTitle } from '@cctv/core';
+import { DialogDescription, DialogTitle, SourcesPanel } from '@cctv/core';
 import { Button } from '@cctv/core/Button/Button';
 import { SegmentBadge } from '@cctv/core/SegmentBadge/SegmentBadge';
+import { useBlockSources } from '@cctv/hooks/useBlockSources';
 import {
   BLOCK_KIND_LABELS,
   Block,
@@ -84,6 +85,7 @@ function EditBlockForm({ onClose, block }: EditBlockFormProps) {
       )}
 
       <BlockEditor />
+      {block.kind === BlockKind.FAMILY_FEUD && <BlockSourcesPanel block={block} />}
       {viewAdditionalDetails && <AdditionalDetails />}
 
       <div className={styles.actions}>
@@ -143,6 +145,32 @@ function BlockEditor() {
       return <div>Unknown block type: {(_exhaust as { kind: string }).kind}</div>;
     }
   }
+}
+
+const SOURCE_COMPATIBLE_KINDS: BlockKind[] = [BlockKind.QUESTION, BlockKind.POLL];
+
+function BlockSourcesPanel({ block }: { block: Block }) {
+  const { experience } = useExperience();
+  const { attach, detach, reorder, isLoading } = useBlockSources(block.id);
+
+  const sources = block.sources ?? [];
+  const attachedIds = new Set(sources.map((s) => s.id));
+
+  const candidates = (experience?.blocks ?? []).filter(
+    (b) => b.id !== block.id && !attachedIds.has(b.id) && SOURCE_COMPATIBLE_KINDS.includes(b.kind),
+  );
+
+  return (
+    <SourcesPanel
+      sources={sources}
+      candidates={candidates}
+      onAttach={attach}
+      onDetach={detach}
+      onReorder={reorder}
+      busy={isLoading}
+      emptyMessage="No sources attached. Attach Question or Poll blocks below."
+    />
+  );
 }
 
 function AdditionalDetails() {

--- a/app/frontend/Pages/Manage/EditBlock/EditBlockContext.tsx
+++ b/app/frontend/Pages/Manage/EditBlock/EditBlockContext.tsx
@@ -91,7 +91,7 @@ function blockToFormData(block: Block): FormBlockData {
     case BlockKind.FAMILY_FEUD:
       return {
         kind: BlockKind.FAMILY_FEUD,
-        data: familyFeudPayloadToFormData(block.payload as FamilyFeudPayload, block.children),
+        data: familyFeudPayloadToFormData(block.payload as FamilyFeudPayload, block.sources),
       };
     case BlockKind.PHOTO_UPLOAD:
       return { kind: BlockKind.PHOTO_UPLOAD, data: photoUploadPayloadToFormData(block.payload) };

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -223,7 +223,7 @@ export interface BlockLink {
   id: string;
   parent_block_id: string;
   child_block_id: string;
-  relationship: 'depends_on';
+  relationship: 'depends_on' | 'source';
   position: number;
 }
 
@@ -376,6 +376,9 @@ interface BaseBlock {
   child_block_ids?: string[];
   parent_block_ids?: string[];
   children?: Block[];
+  source_block_ids?: string[];
+  consumer_block_ids?: string[];
+  sources?: Block[];
   responses?: {
     total: number;
     user_responded?: boolean;
@@ -559,6 +562,7 @@ export interface CreateBlockPayload {
   questions?: Array<{
     payload: Record<string, string>;
   }>;
+  source_block_ids?: string[];
 }
 
 export interface CreateExperienceBlockRequest {

--- a/app/models/experience_block.rb
+++ b/app/models/experience_block.rb
@@ -35,19 +35,38 @@ class ExperienceBlock < ApplicationRecord
   has_many :improv_votes, dependent: :destroy
 
   has_many :parent_links,
+    -> { where(relationship: "depends_on") },
     class_name: "ExperienceBlockLink",
     foreign_key: :child_block_id,
     dependent: :destroy
   has_many :parents, through: :parent_links, source: :parent_block
 
   has_many :child_links,
+    -> { where(relationship: "depends_on").order(position: :asc) },
     class_name: "ExperienceBlockLink",
     foreign_key: :parent_block_id,
     dependent: :destroy
   has_many :children,
-    -> { order(position: :asc) },
+    -> { order("experience_block_links.position ASC") },
     through: :child_links,
     source: :child_block
+
+  has_many :source_links,
+    -> { where(relationship: "source").order(position: :asc) },
+    class_name: "ExperienceBlockLink",
+    foreign_key: :parent_block_id,
+    dependent: :destroy
+  has_many :sources,
+    -> { order("experience_block_links.position ASC") },
+    through: :source_links,
+    source: :child_block
+
+  has_many :consumer_links,
+    -> { where(relationship: "source") },
+    class_name: "ExperienceBlockLink",
+    foreign_key: :child_block_id,
+    dependent: :destroy
+  has_many :consumers, through: :consumer_links, source: :parent_block
 
   has_many :experience_block_segments, dependent: :destroy
   has_many :experience_segments, through: :experience_block_segments
@@ -105,16 +124,20 @@ class ExperienceBlock < ApplicationRecord
   end
 
   # Family Feud specific methods
+  def family_feud_question_blocks
+    sources.where(kind: QUESTION)
+  end
+
   def clear_family_feud_bucket_assignments!
     return unless kind == FAMILY_FEUD
 
-    child_blocks.each do |child_block|
-      child_payload = child_block.payload || {}
-      if child_payload["buckets"]
-        child_payload["buckets"].each do |bucket|
+    family_feud_question_blocks.each do |source_block|
+      source_payload = source_block.payload || {}
+      if source_payload["buckets"]
+        source_payload["buckets"].each do |bucket|
           bucket["answer_ids"] = []
         end
-        child_block.update!(payload: child_payload)
+        source_block.update!(payload: source_payload)
       end
     end
   end
@@ -122,10 +145,10 @@ class ExperienceBlock < ApplicationRecord
   def clear_all_family_feud_buckets!
     return unless kind == FAMILY_FEUD
 
-    child_blocks.each do |child_block|
-      child_payload = child_block.payload || {}
-      child_payload["buckets"] = []
-      child_block.update!(payload: child_payload)
+    family_feud_question_blocks.each do |source_block|
+      source_payload = source_block.payload || {}
+      source_payload["buckets"] = []
+      source_block.update!(payload: source_payload)
     end
   end
 
@@ -207,10 +230,11 @@ class ExperienceBlock < ApplicationRecord
   private
 
   def sync_parent_from_links
-    if parent_links.any? && parent_block_id.nil?
-      link = parent_links.first
-      update_column(:parent_block_id, link.parent_block_id)
-    end
+    link = ExperienceBlockLink.depends_on.find_by(child_block_id: id)
+    return unless link
+    return unless parent_block_id.nil?
+
+    update_column(:parent_block_id, link.parent_block_id)
   end
 
   def visibility_roles

--- a/app/models/experience_block_link.rb
+++ b/app/models/experience_block_link.rb
@@ -3,16 +3,47 @@ class ExperienceBlockLink < ApplicationRecord
   belongs_to :child_block, class_name: "ExperienceBlock"
 
   enum :relationship, {
-    depends_on: "depends_on"
+    depends_on: "depends_on",
+    source: "source"
   }
 
-  validates :parent_block_id, :child_block_id, presence: true
-  validates :child_block_id, uniqueness: true
-  validate :no_self_loops
-  validate :no_cycles
-  validate :depth_limit
+  scope :sources, -> { where(relationship: "source") }
+  scope :depends_on, -> { where(relationship: "depends_on") }
+  scope :ordered, -> { order(position: :asc) }
 
-  after_commit :sync_child_parent_id, on: [:create, :update]
+  validates :parent_block_id, :child_block_id, presence: true
+  validates :child_block_id,
+    uniqueness: { scope: [:parent_block_id, :relationship] }
+  validate :no_self_loops
+  validate :no_cycles, if: :depends_on?
+  validate :depth_limit, if: :depends_on?
+  validate :child_has_single_parent_link, if: :depends_on?
+
+  after_commit :sync_child_parent_id, on: [:create, :update], if: :depends_on?
+
+  def self.would_create_cycle?(parent_id, child_id)
+    sql = <<~SQL
+      WITH RECURSIVE ancestors(ancestor_id) AS (
+        SELECT parent_block_id
+        FROM experience_block_links
+        WHERE child_block_id = :child_id AND relationship = 'depends_on'
+
+        UNION
+
+        SELECT ebl.parent_block_id
+        FROM experience_block_links ebl
+        JOIN ancestors a ON ebl.child_block_id = a.ancestor_id
+        WHERE ebl.relationship = 'depends_on'
+      )
+      SELECT 1 FROM ancestors WHERE ancestor_id = :parent_id LIMIT 1
+    SQL
+
+    result = connection.execute(
+      sanitize_sql([sql, { parent_id: parent_id, child_id: child_id }])
+    )
+
+    result.any?
+  end
 
   private
 
@@ -42,27 +73,15 @@ class ExperienceBlockLink < ApplicationRecord
     end
   end
 
-  def self.would_create_cycle?(parent_id, child_id)
-    sql = <<~SQL
-      WITH RECURSIVE ancestors(ancestor_id) AS (
-        SELECT parent_block_id
-        FROM experience_block_links
-        WHERE child_block_id = :child_id
+  def child_has_single_parent_link
+    return unless child_block_id
 
-        UNION
+    conflict = self.class.depends_on
+      .where(child_block_id: child_block_id)
+      .where.not(id: id)
+      .exists?
 
-        SELECT ebl.parent_block_id
-        FROM experience_block_links ebl
-        JOIN ancestors a ON ebl.child_block_id = a.ancestor_id
-      )
-      SELECT 1 FROM ancestors WHERE ancestor_id = :parent_id LIMIT 1
-    SQL
-
-    result = connection.execute(
-      sanitize_sql([sql, { parent_id: parent_id, child_id: child_id }])
-    )
-
-    result.any?
+    errors.add(:base, "Block already has a parent dependency") if conflict
   end
 
   def sync_child_parent_id

--- a/app/services/experiences/orchestrator.rb
+++ b/app/services/experiences/orchestrator.rb
@@ -385,10 +385,10 @@ module Experiences
       transaction do
         current_payload = block.payload || {}
 
-        questions = block.child_blocks.map do |child_block|
-          buckets = child_block.payload["buckets"] || []
+        questions = block.family_feud_question_blocks.map do |source_block|
+          buckets = source_block.payload["buckets"] || []
 
-          submissions = ExperienceQuestionSubmission.where(experience_block_id: child_block.id)
+          submissions = ExperienceQuestionSubmission.where(experience_block_id: source_block.id)
           total_answers = submissions.count
           submission_ids = submissions.pluck(:id).map(&:to_s)
 
@@ -408,8 +408,8 @@ module Experiences
           question_buckets.sort_by! { |b| -b["percentage"] }
 
           {
-            "question_id" => child_block.id,
-            "question_text" => child_block.payload["question"] || "Question",
+            "question_id" => source_block.id,
+            "question_text" => source_block.payload["question"] || "Question",
             "buckets" => question_buckets
           }
         end
@@ -524,8 +524,8 @@ module Experiences
       block = experience.experience_blocks.find(block_id)
 
       transaction do
-        child_block_ids = block.child_blocks.pluck(:id)
-        ExperienceQuestionSubmission.where(experience_block_id: child_block_ids).delete_all
+        source_ids = block.family_feud_question_blocks.pluck(:id)
+        ExperienceQuestionSubmission.where(experience_block_id: source_ids).delete_all
 
         block.clear_all_family_feud_buckets!
 
@@ -894,9 +894,9 @@ module Experiences
 
         if block.kind == ExperienceBlock::FAMILY_FEUD && questions.present?
           questions.each do |q|
-            child = block.child_blocks.find_by(id: q[:id])
-            next unless child
-            child.update!(payload: child.payload.merge("question" => q[:question]))
+            source = block.sources.find_by(id: q[:id])
+            next unless source
+            source.update!(payload: source.payload.merge("question" => q[:question]))
           end
         end
 
@@ -910,12 +910,13 @@ module Experiences
       visible_to_roles: [],
       target_user_ids: [],
       status: :hidden,
-      questions: []
+      questions: [],
+      source_block_ids: []
     )
       transaction do
         max_position = experience.experience_blocks.parent_blocks.maximum(:position) || -1
 
-        parent_block = experience.experience_blocks.create!(
+        consumer_block = experience.experience_blocks.create!(
           kind: kind,
           status: status,
           payload: payload.except(:questions),
@@ -927,16 +928,71 @@ module Experiences
 
         if kind == ExperienceBlock::FAMILY_FEUD && questions.present?
           questions.each_with_index do |question_spec, index|
-            create_family_feud_question(
-              parent_block: parent_block,
+            create_family_feud_source_question(
+              consumer_block: consumer_block,
               question_spec: question_spec,
-              position: index
+              position: max_position + 2 + index
             )
           end
         end
 
-        parent_block
+        attach_sources!(consumer_block, source_block_ids) if source_block_ids.present?
+
+        consumer_block
       end
+    end
+
+    def attach_sources!(consumer_block, source_block_ids)
+      base_position = consumer_block.source_links.maximum(:position) || -1
+
+      Array(source_block_ids).each_with_index do |source_id, index|
+        source = experience.experience_blocks.find(source_id)
+        ExperienceBlockLink.create!(
+          parent_block: consumer_block,
+          child_block: source,
+          relationship: :source,
+          position: base_position + 1 + index
+        )
+      end
+
+      consumer_block.reload
+    end
+
+    def attach_source!(consumer_block_id:, source_block_id:)
+      consumer = experience.experience_blocks.find(consumer_block_id)
+      attach_sources!(consumer, [source_block_id])
+    end
+
+    def detach_source!(consumer_block_id:, source_block_id:)
+      consumer = experience.experience_blocks.find(consumer_block_id)
+      link = consumer.source_links.find_by(child_block_id: source_block_id)
+      raise ActiveRecord::RecordNotFound, "Source not attached" unless link
+
+      transaction do
+        link.destroy!
+        consumer.source_links.ordered.each_with_index do |l, idx|
+          l.update_column(:position, idx) if l.position != idx
+        end
+      end
+
+      consumer.reload
+    end
+
+    def reorder_sources!(consumer_block_id:, source_block_ids:)
+      consumer = experience.experience_blocks.find(consumer_block_id)
+
+      transaction do
+        ordered_ids = Array(source_block_ids).map(&:to_s)
+        links = consumer.source_links.to_a.index_by { |l| l.child_block_id.to_s }
+
+        ordered_ids.each_with_index do |source_id, idx|
+          link = links[source_id]
+          next unless link
+          link.update_column(:position, idx) if link.position != idx
+        end
+      end
+
+      consumer.reload
     end
 
     private
@@ -1024,27 +1080,32 @@ module Experiences
       slides
     end
 
-    def create_family_feud_question(parent_block:, question_spec:, position:)
-      child_block = experience.experience_blocks.create!(
+    def create_family_feud_source_question(consumer_block:, question_spec:, position:)
+      source_payload = question_spec[:payload] || question_spec["payload"] || {}
+      source_payload = source_payload.to_unsafe_h if source_payload.respond_to?(:to_unsafe_h)
+
+      source_block = experience.experience_blocks.create!(
         kind: ExperienceBlock::QUESTION,
-        status: parent_block.status,
-        payload: question_spec["payload"] || {},
-        visible_to_roles: parent_block.visible_to_roles,
+        status: :hidden,
+        payload: source_payload,
+        visible_to_roles: consumer_block.visible_to_roles,
         target_user_ids: [],
-        parent_block_id: parent_block.id,
         position: position,
         show_in_lobby: true
       )
 
-      copy_block_segments(from: parent_block, to: child_block)
+      copy_block_segments(from: consumer_block, to: source_block)
+
+      link_position = consumer_block.source_links.maximum(:position) || -1
 
       ExperienceBlockLink.create!(
-        parent_block: parent_block,
-        child_block: child_block,
-        relationship: :depends_on
+        parent_block: consumer_block,
+        child_block: source_block,
+        relationship: :source,
+        position: link_position + 1
       )
 
-      child_block
+      source_block
     end
 
     def apply_poll_segment_assignments(block, old_selected, new_selected)

--- a/app/services/experiences/visibility.rb
+++ b/app/services/experiences/visibility.rb
@@ -170,7 +170,10 @@ module Experiences
       return [] if active_block_ids.empty?
 
       child_block_ids  = ExperienceBlock.where(parent_block_id: active_block_ids).pluck(:id)
-      all_block_ids    = active_block_ids + child_block_ids
+      source_block_ids = ExperienceBlockLink.sources
+        .where(parent_block_id: active_block_ids)
+        .pluck(:child_block_id)
+      all_block_ids    = active_block_ids + child_block_ids + source_block_ids
 
       responded_user_ids = [
         ExperiencePollSubmission,
@@ -544,12 +547,20 @@ module Experiences
       if mod_or_host?(participant_role) || admin_user?(user)
         metadata = {
           child_block_ids:  block.children.map(&:id),
-          parent_block_ids: block.parents.map(&:id)
+          parent_block_ids: block.parents.map(&:id),
+          source_block_ids: block.sources.map(&:id),
+          consumer_block_ids: block.consumers.map(&:id)
         }
 
         if depth == 0 && block.children.any?
           metadata[:children] = block.children.map do |child|
             serialize_block(child, participant_role: participant_role, user: user, depth: depth + 1, view_context: :admin)
+          end
+        end
+
+        if depth == 0 && block.sources.any?
+          metadata[:sources] = block.sources.map do |source|
+            serialize_block(source, participant_role: participant_role, user: user, depth: depth + 1, view_context: :admin)
           end
         end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,10 @@ Rails.application.routes.draw do
           post :submit_buzzer_response
           delete :clear_buzzer_responses
 
+          post 'sources', action: :attach_source
+          delete 'sources/:source_block_id', action: :detach_source
+          patch 'sources', action: :reorder_sources
+
           post 'family_feud/auto_categorize', action: :auto_categorize
           post 'family_feud/add_bucket', action: :add_bucket
           patch 'family_feud/buckets/:bucket_id', action: :rename_bucket

--- a/db/migrate/20260526000001_add_source_to_block_link_relationship.rb
+++ b/db/migrate/20260526000001_add_source_to_block_link_relationship.rb
@@ -1,0 +1,29 @@
+class AddSourceToBlockLinkRelationship < ActiveRecord::Migration[7.2]
+  def up
+    execute <<~SQL
+      ALTER TYPE block_link_relationship ADD VALUE IF NOT EXISTS 'source';
+    SQL
+
+    if index_exists?(:experience_block_links, :child_block_id, name: :idx_eb_links_unique_child)
+      remove_index :experience_block_links, name: :idx_eb_links_unique_child
+    end
+  end
+
+  def down
+    add_index :experience_block_links, :child_block_id,
+      unique: true, name: :idx_eb_links_unique_child
+
+    execute <<~SQL
+      ALTER TYPE block_link_relationship RENAME TO block_link_relationship_old;
+      CREATE TYPE block_link_relationship AS ENUM ('depends_on');
+      ALTER TABLE experience_block_links
+        ALTER COLUMN relationship DROP DEFAULT;
+      ALTER TABLE experience_block_links
+        ALTER COLUMN relationship TYPE block_link_relationship
+        USING relationship::text::block_link_relationship;
+      ALTER TABLE experience_block_links
+        ALTER COLUMN relationship SET DEFAULT 'depends_on'::block_link_relationship;
+      DROP TYPE block_link_relationship_old;
+    SQL
+  end
+end

--- a/db/migrate/20260526000002_add_position_to_experience_block_links.rb
+++ b/db/migrate/20260526000002_add_position_to_experience_block_links.rb
@@ -1,0 +1,7 @@
+class AddPositionToExperienceBlockLinks < ActiveRecord::Migration[7.2]
+  def change
+    add_column :experience_block_links, :position, :integer, null: false, default: 0
+    add_index :experience_block_links, [:parent_block_id, :relationship, :position],
+      name: :idx_eb_links_parent_rel_pos
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_20_000001) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_26_000002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
-  create_enum "block_link_relationship", ["depends_on"]
+  create_enum "block_link_relationship", ["depends_on", "source"]
   create_enum "block_variable_datatype", ["string", "number", "text"]
   create_enum "experience_block_statuses", ["hidden", "open", "closed"]
   create_enum "experience_participant_roles", ["audience", "player", "moderator", "host"]
@@ -92,9 +92,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_20_000001) do
     t.jsonb "meta", default: {}, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["child_block_id"], name: "idx_eb_links_unique_child", unique: true
+    t.integer "position", default: 0, null: false
     t.index ["child_block_id"], name: "index_experience_block_links_on_child_block_id"
     t.index ["parent_block_id", "child_block_id"], name: "idx_eb_links_parent_child", unique: true
+    t.index ["parent_block_id", "relationship", "position"], name: "idx_eb_links_parent_rel_pos"
     t.index ["parent_block_id"], name: "index_experience_block_links_on_parent_block_id"
   end
 

--- a/spec/controllers/api/experience_blocks_controller_spec.rb
+++ b/spec/controllers/api/experience_blocks_controller_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe Api::ExperienceBlocksController, type: :controller do
       end
 
       before do
-        child = block.child_blocks.first
+        child = block.sources.first
         create(:experience_question_submission, experience_block: child, user: player.user)
       end
 
@@ -259,7 +259,7 @@ RSpec.describe Api::ExperienceBlocksController, type: :controller do
 
     context "propagating question edits to family feud child blocks" do
       let(:block) { create(:experience_block, :family_feud, experience: experience) }
-      let(:child) { block.child_blocks.first }
+      let(:child) { block.sources.first }
       let(:update_params) do
         {
           payload: { "title" => "New Title" },

--- a/spec/factories/experience_blocks_factory.rb
+++ b/spec/factories/experience_blocks_factory.rb
@@ -41,27 +41,27 @@ FactoryBot.define do
           evaluator.question_count.times.map { |i| { question: "Question #{i + 1}" } }
 
         questions_to_create.each_with_index do |question_spec, index|
-          child_block = create(
+          source_block = create(
             :experience_block,
             experience: block.experience,
             kind: ExperienceBlock::QUESTION,
             status: block.status,
-            payload: { 
+            payload: {
               question: question_spec[:question] || question_spec["question"],
               formKey: "answer_#{index}",
               inputType: "text"
             },
             visible_to_roles: block.visible_to_roles,
             target_user_ids: [],
-            parent_block_id: block.id,
-            position: index,
+            position: block.position + 1 + index,
             show_in_lobby: true
           )
 
           ExperienceBlockLink.create!(
             parent_block: block,
-            child_block: child_block,
-            relationship: :depends_on
+            child_block: source_block,
+            relationship: :source,
+            position: index
           )
         end
       end

--- a/spec/services/experiences/orchestrator_spec.rb
+++ b/spec/services/experiences/orchestrator_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe Experiences::Orchestrator do
       described_class.new(actor: user, experience: experience).open_block!(block.id)
     end
 
-    context "when opening a family feud block with child question blocks" do
+    context "when opening a family feud block" do
       let!(:block) do
         create(
           :experience_block,
@@ -247,12 +247,13 @@ RSpec.describe Experiences::Orchestrator do
         )
       end
 
-      it "opens the parent block and all child question blocks" do
+      it "opens the consumer block without touching source question blocks" do
+        sources_before = block.sources.map(&:status)
         subject
 
         expect(block.reload.status).to eq("open")
-        expect(block.child_blocks.count).to eq(2)
-        expect(block.child_blocks.map(&:status)).to all(eq("open"))
+        expect(block.sources.count).to eq(2)
+        expect(block.sources.map(&:status)).to eq(sources_before)
       end
     end
   end
@@ -264,7 +265,7 @@ RSpec.describe Experiences::Orchestrator do
       described_class.new(actor: user, experience: experience).close_block!(block.id)
     end
 
-    context "when closing a parent block with children" do
+    context "when closing a family feud block" do
       let!(:block) do
         create(
           :experience_block,
@@ -275,12 +276,13 @@ RSpec.describe Experiences::Orchestrator do
         )
       end
 
-      it "closes the parent block and all child blocks" do
+      it "closes the consumer block without touching source question blocks" do
+        sources_before = block.sources.map(&:status)
         subject
 
         expect(block.reload.status).to eq("closed")
-        expect(block.child_blocks.count).to eq(2)
-        expect(block.child_blocks.map(&:status)).to all(eq("closed"))
+        expect(block.sources.count).to eq(2)
+        expect(block.sources.map(&:status)).to eq(sources_before)
       end
     end
   end
@@ -292,7 +294,7 @@ RSpec.describe Experiences::Orchestrator do
       described_class.new(actor: user, experience: experience).hide_block!(block.id)
     end
 
-    context "when hiding a parent block with children" do
+    context "when hiding a family feud block" do
       let!(:block) do
         create(
           :experience_block,
@@ -303,12 +305,13 @@ RSpec.describe Experiences::Orchestrator do
         )
       end
 
-      it "hides the parent block and all child blocks" do
+      it "hides the consumer block without touching source question blocks" do
+        sources_before = block.sources.map(&:status)
         subject
 
         expect(block.reload.status).to eq("hidden")
-        expect(block.child_blocks.count).to eq(2)
-        expect(block.child_blocks.map(&:status)).to all(eq("hidden"))
+        expect(block.sources.count).to eq(2)
+        expect(block.sources.map(&:status)).to eq(sources_before)
       end
     end
   end
@@ -549,7 +552,7 @@ RSpec.describe Experiences::Orchestrator do
       let(:new_payload) { { "title" => "Updated" } }
 
       before do
-        child = block.child_blocks.first
+        child = block.sources.first
         create(:experience_question_submission, experience_block: child, user: user)
       end
 
@@ -563,7 +566,7 @@ RSpec.describe Experiences::Orchestrator do
       let(:block) do
         create(:experience_block, :family_feud, experience: experience, status: ExperienceBlock::HIDDEN)
       end
-      let(:child) { block.child_blocks.first }
+      let(:child) { block.sources.first }
       let(:new_payload) { { "title" => "New Title" } }
       let(:questions) { [{ id: child.id, question: "Updated question" }] }
 


### PR DESCRIPTION
## Status: Draft, parked

This branch is a fully-working implementation of a Source/Consumer block model. It's pushed as a draft for context, not for merging. The simpler parent/child + flatten approach lives in **#173 (block-lifecycle-decouple)** — that's the one to review for the immediate need.

I'm posting this branch as reference in case the parent/child approach turns out to be limiting later, or to inform whatever direction GuessWho's overhaul takes.

## Context (for @jared)

You mentioned that the original codebase had a graph-style model (variables + bindings) that you intentionally simplified down to parent/child because the upkeep wasn't paying off. When I came in not knowing that history, my first instinct was to build a Source/Consumer model — essentially the same direction you'd already moved away from.

After you flagged this, we changed course: I parked this branch and took your suggested path — try parent/child + ordering first, and only revisit the heavier model if friction shows up. That work is in #173.

The original requirements from the user were:
1. Broadcast FamilyFeud questions earlier in the experience (independent of when FamilyFeud itself runs)
2. Allow GuessWho to consume the same questions/answers

Requirement 1 is met by the parent/child + lifecycle-decouple approach in #173. Requirement 2 is already satisfied today through GuessWho's existing `slides[].block_id` payload references and `ParticipantSubmissions.for_user`, which query all blocks regardless of nesting.

## What this branch contains

If we ever need cross-consumer reuse of source blocks (one Poll feeding both a FamilyFeud and a GuessWho simultaneously, surfaced in the UI), this branch has a working implementation:

**Schema**
- Adds `source` to the `block_link_relationship` enum on `ExperienceBlockLink`
- Drops the global unique constraint on `child_block_id` so a block can be linked from multiple consumers
- Adds `position` for ordering within a consumer

**Backend**
- New `sources`/`consumers` associations on `ExperienceBlock` (scoped to the `source` relationship; existing `children`/`parents` stay scoped to `depends_on`)
- `Orchestrator#attach_source!`, `#detach_source!`, `#reorder_sources!` endpoints under `/blocks/:id/sources`
- `start_family_feud_playing!` reads from `block.sources` rather than `block.child_blocks`

**Frontend**
- `Core/SourcesPanel` — pure presentational component with attach/detach/reorder, plus Storybook stories
- `useBlockSources` hook
- Wired into EditBlock for FamilyFeud — host can attach Question/Poll blocks as sources

**Tests**
- 344 specs pass on this branch (the snapshot when I pushed); tsc + storybook clean

## When this might be worth revisiting

- GuessWho overhaul lands and needs explicit "use these specific questions as sources" semantics
- A new block kind needs many-to-many fan-in (multiple consumers reading from the same source)
- Visual UI for "which blocks does this consumer depend on" becomes a user-facing requirement

For now, the simpler change in #173 is the recommended path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)