### PR TITLE
Add case-insensitive uniqueness validation to segment name

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -111,6 +111,11 @@ class Api::BaseController < ApplicationController
         message: "Edit not allowed",
         error: e.message,
       }, status: :unprocessable_entity
+    rescue ActiveRecord::RecordInvalid => e
+      render json: {
+        success: false,
+        error: e.record.errors.full_messages.first,
+      }, status: :unprocessable_entity
     end
   end
 end

--- a/app/frontend/Pages/Manage/ParticipantsTab/SegmentManager/SegmentManager.tsx
+++ b/app/frontend/Pages/Manage/ParticipantsTab/SegmentManager/SegmentManager.tsx
@@ -23,7 +23,7 @@ export default function SegmentManager({ segments, defaultSegmentId }: SegmentMa
   const [editColor, setEditColor] = useState('');
 
   const { createSegment, isLoading: isCreating, error: createError } = useCreateSegment();
-  const { updateSegment, isLoading: isUpdating } = useUpdateSegment();
+  const { updateSegment, isLoading: isUpdating, error: updateError } = useUpdateSegment();
   const { deleteSegment, isLoading: isDeleting } = useDeleteSegment();
 
   const handleCreate = async () => {
@@ -159,6 +159,7 @@ export default function SegmentManager({ segments, defaultSegmentId }: SegmentMa
       )}
 
       {createError && <div className={styles.error}>{createError}</div>}
+      {updateError && <div className={styles.error}>{updateError}</div>}
     </div>
   );
 }

--- a/app/models/experience_segment.rb
+++ b/app/models/experience_segment.rb
@@ -8,7 +8,7 @@ class ExperienceSegment < ApplicationRecord
   has_many :experience_blocks, through: :experience_block_segments
 
   validates :name, presence: true, length: { maximum: 50 },
-    uniqueness: { scope: :experience_id }
+    uniqueness: { scope: :experience_id, case_sensitive: false }
   validates :color, presence: true
   validates :position, presence: true,
     numericality: { only_integer: true, greater_than_or_equal_to: 0 },

--- a/db/migrate/20260528000001_make_segment_name_unique_case_insensitive.rb
+++ b/db/migrate/20260528000001_make_segment_name_unique_case_insensitive.rb
@@ -1,0 +1,9 @@
+class MakeSegmentNameUniqueCaseInsensitive < ActiveRecord::Migration[7.2]
+  def up
+    change_column :experience_segments, :name, :citext, null: false
+  end
+
+  def down
+    change_column :experience_segments, :name, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_27_000001) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_28_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -229,7 +229,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_27_000001) do
 
   create_table "experience_segments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "experience_id", null: false
-    t.string "name", null: false
+    t.citext "name", null: false
     t.string "color", default: "#6B7280", null: false
     t.integer "position", default: 0, null: false
     t.datetime "created_at", null: false

--- a/spec/models/experience_segment_spec.rb
+++ b/spec/models/experience_segment_spec.rb
@@ -30,6 +30,18 @@ RSpec.describe ExperienceSegment do
       expect(duplicate).not_to be_valid
     end
 
+    it "enforces unique name case-insensitively within experience" do
+      experience.experience_segments.create!(name: "Team A", color: "#FF0000", position: 0)
+      duplicate = experience.experience_segments.build(name: "team a", color: "#0000FF", position: 1)
+      expect(duplicate).not_to be_valid
+    end
+
+    it "enforces unique name case-insensitively for mixed case within experience" do
+      experience.experience_segments.create!(name: "Team A", color: "#FF0000", position: 0)
+      duplicate = experience.experience_segments.build(name: "TEAM A", color: "#0000FF", position: 1)
+      expect(duplicate).not_to be_valid
+    end
+
     it "allows the same name in different experiences" do
       other_experience = create(:experience)
       experience.experience_segments.create!(name: "Team A", color: "#FF0000", position: 0)


### PR DESCRIPTION
Changes the experience_segments.name column to citext so the existing unique index enforces case-insensitive uniqueness at the DB level. Adds case_sensitive: false to the model validation, rescues ActiveRecord::RecordInvalid in the base controller to surface validation errors as JSON, and displays update errors in the SegmentManager UI.