### PR TITLE
Playbill running order + CCSTE event seed

### DIFF
--- a/.storybook/fixtures.ts
+++ b/.storybook/fixtures.ts
@@ -4,6 +4,7 @@ import {
   Experience,
   ExperienceParticipant,
   ParticipantSummary,
+  PlaybillRunningOrderEntry,
   PlaybillSection,
 } from '../app/frontend/types';
 
@@ -165,6 +166,37 @@ export const mockPlaybill: PlaybillSection[] = [
 
 export const mockBlocks: Block[] = [mockPollBlock, mockQuestionBlock, mockAnnouncementBlock];
 
+export const mockPlaybillRunningOrder: PlaybillRunningOrderEntry[] = [
+  {
+    id: 'block1',
+    kind: BlockKind.POLL,
+    position: 0,
+    playbill_mysterious: false,
+    title: "What's your favorite city?",
+  },
+  {
+    id: 'block2',
+    kind: BlockKind.QUESTION,
+    position: 1,
+    playbill_mysterious: false,
+    title: 'What brought you here tonight?',
+  },
+  {
+    id: 'block-mystery',
+    kind: BlockKind.FAMILY_FEUD,
+    position: 2,
+    playbill_mysterious: true,
+    title: null,
+  },
+  {
+    id: 'block3',
+    kind: BlockKind.ANNOUNCEMENT,
+    position: 3,
+    playbill_mysterious: false,
+    title: 'Welcome to the show!',
+  },
+];
+
 function makeExperience(overrides: Partial<Experience> = {}): Experience {
   return {
     id: 'exp1',
@@ -180,6 +212,7 @@ function makeExperience(overrides: Partial<Experience> = {}): Experience {
     blocks: mockBlocks,
     playbill_enabled: true,
     playbill: mockPlaybill,
+    playbill_running_order: mockPlaybillRunningOrder,
     segments: [
       { id: 'seg1', name: 'Red Team', color: '#ff4911', position: 0 },
       { id: 'seg2', name: 'Blue Team', color: '#3300ff', position: 1 },

--- a/app/controllers/api/experience_blocks_controller.rb
+++ b/app/controllers/api/experience_blocks_controller.rb
@@ -41,7 +41,9 @@ class Api::ExperienceBlocksController < Api::BaseController
           visible_to_roles: create_params[:visible_to_roles] || [],
           target_user_ids: create_params[:target_user_ids] || [],
           status: create_params[:status] || :hidden,
-          questions: create_params[:questions] || []
+          questions: create_params[:questions] || [],
+          add_to_playbill: create_params[:add_to_playbill] || false,
+          playbill_mysterious: create_params[:playbill_mysterious] || false
         )
       else
         orchestrator.add_block!(
@@ -51,7 +53,9 @@ class Api::ExperienceBlocksController < Api::BaseController
           target_user_ids: create_params[:target_user_ids] || [],
           status: create_params[:status] || :hidden,
           open_immediately: create_params[:open_immediately] || false,
-          show_in_lobby: create_params[:show_in_lobby] || false
+          show_in_lobby: create_params[:show_in_lobby] || false,
+          add_to_playbill: create_params[:add_to_playbill] || false,
+          playbill_mysterious: create_params[:playbill_mysterious] || false
         )
       end
 
@@ -801,6 +805,8 @@ class Api::ExperienceBlocksController < Api::BaseController
       :status,
       :open_immediately,
       :show_in_lobby,
+      :add_to_playbill,
+      :playbill_mysterious,
       visible_to_roles: [],
       visible_to_segment_ids: [],
       target_user_ids: []

--- a/app/frontend/Hooks/useCreateExperienceBlock.ts
+++ b/app/frontend/Hooks/useCreateExperienceBlock.ts
@@ -17,6 +17,8 @@ export interface CreateExperienceBlockParams {
   visible_to_segment_ids?: string[];
   status?: BlockStatus;
   open_immediately?: boolean;
+  add_to_playbill?: boolean;
+  playbill_mysterious?: boolean;
   variables?: Array<{
     key: string;
     label: string;
@@ -44,6 +46,8 @@ export function useCreateExperienceBlock() {
       visible_to_segment_ids = [],
       status = 'hidden',
       open_immediately = false,
+      add_to_playbill = false,
+      playbill_mysterious = false,
       variables,
       questions,
     }: CreateExperienceBlockParams): Promise<CreateExperienceApiResponse | null> => {
@@ -71,6 +75,8 @@ export function useCreateExperienceBlock() {
         visible_to_segment_ids,
         status,
         open_immediately,
+        add_to_playbill,
+        playbill_mysterious,
         ...(variables && { variables }),
         ...(questions && questions.length > 0 && { questions }),
       };

--- a/app/frontend/Pages/Manage/CreateBlock/CreateBlock.module.scss
+++ b/app/frontend/Pages/Manage/CreateBlock/CreateBlock.module.scss
@@ -122,3 +122,28 @@
   color: var(--hot-white);
   width: 100%;
 }
+
+.playbillToggles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid hsl(var(--border));
+  border-radius: 6px;
+}
+
+.playbillRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  font-size: 14px;
+  color: var(--hot-white);
+}
+
+.playbillHint {
+  font-size: 0.8rem;
+  color: hsl(var(--muted-foreground));
+}

--- a/app/frontend/Pages/Manage/CreateBlock/CreateBlock.tsx
+++ b/app/frontend/Pages/Manage/CreateBlock/CreateBlock.tsx
@@ -1,5 +1,5 @@
 import { useExperience } from '@cctv/contexts/ExperienceContext';
-import { DialogDescription, DialogTitle, SegmentMultiSelect } from '@cctv/core';
+import { DialogDescription, DialogTitle, SegmentMultiSelect, Switch } from '@cctv/core';
 import { Button } from '@cctv/core/Button/Button';
 import { Dropdown } from '@cctv/core/Dropdown/Dropdown';
 import { BLOCK_KIND_LABELS, BlockKind, ParticipantSummary } from '@cctv/types';
@@ -61,6 +61,7 @@ function CreateBlockForm({ onClose }: CreateBlockFormProps) {
 
       <BlockEditor />
       <SegmentSelector />
+      <PlaybillToggles />
 
       <div className={styles.actions}>
         <Button variant="secondary" onClick={onClose}>
@@ -116,6 +117,37 @@ function BlockEditor() {
       const exhaustiveCheck: never = blockData;
       return <div className={styles.details}>Unknown block type: {exhaustiveCheck}</div>;
   }
+}
+
+function PlaybillToggles() {
+  const { addToPlaybill, setAddToPlaybill, playbillMysterious, setPlaybillMysterious } =
+    useCreateBlockContext();
+
+  return (
+    <div className={styles.playbillToggles}>
+      <label className={styles.playbillRow}>
+        <span>
+          Add to playbill
+          <div className={styles.playbillHint}>
+            Show this block in the playbill&rsquo;s running order.
+          </div>
+        </span>
+        <Switch checked={addToPlaybill} onCheckedChange={setAddToPlaybill} />
+      </label>
+
+      {addToPlaybill && (
+        <label className={styles.playbillRow}>
+          <span>
+            Display block mysteriously
+            <div className={styles.playbillHint}>
+              Hide the block&rsquo;s identity &mdash; list it as &ldquo;A Surprise Segment&rdquo;.
+            </div>
+          </span>
+          <Switch checked={playbillMysterious} onCheckedChange={setPlaybillMysterious} />
+        </label>
+      )}
+    </div>
+  );
 }
 
 function SegmentSelector() {

--- a/app/frontend/Pages/Manage/CreateBlock/CreateBlockContext.tsx
+++ b/app/frontend/Pages/Manage/CreateBlock/CreateBlockContext.tsx
@@ -153,6 +153,8 @@ export function CreateBlockProvider({
 
   const [visibleSegments, setVisibleSegments] = useState<string[]>(initialVisibleSegments);
   const [viewAdditionalDetails, setViewAdditionalDetails] = useState<boolean>(false);
+  const [addToPlaybill, setAddToPlaybill] = useState<boolean>(true);
+  const [playbillMysterious, setPlaybillMysterious] = useState<boolean>(false);
 
   const {
     createExperienceBlock,
@@ -392,6 +394,8 @@ export function CreateBlockProvider({
         target_user_ids: string[];
         status: BlockStatus;
         open_immediately: boolean;
+        add_to_playbill: boolean;
+        playbill_mysterious: boolean;
         questions?: Array<{ payload: Record<string, string> }>;
       } = {
         kind: blockData.kind,
@@ -400,6 +404,8 @@ export function CreateBlockProvider({
         target_user_ids: [],
         status: status,
         open_immediately: status === 'open',
+        add_to_playbill: addToPlaybill,
+        playbill_mysterious: addToPlaybill && playbillMysterious,
       };
 
       if (
@@ -421,6 +427,8 @@ export function CreateBlockProvider({
       setBlockData(getDefaultFormData(blockData.kind));
       setVisibleSegments(initialVisibleSegments);
       setViewAdditionalDetails(false);
+      setAddToPlaybill(true);
+      setPlaybillMysterious(false);
     },
     [
       blockData,
@@ -433,6 +441,8 @@ export function CreateBlockProvider({
       getDefaultFormData,
       experience,
       initialVisibleSegments,
+      addToPlaybill,
+      playbillMysterious,
     ],
   );
 
@@ -449,6 +459,15 @@ export function CreateBlockProvider({
     defaultSegmentName,
     viewAdditionalDetails,
     setViewAdditionalDetails,
+    addToPlaybill,
+    setAddToPlaybill: (value: boolean) => {
+      setAddToPlaybill(value);
+      if (!value) {
+        setPlaybillMysterious(false);
+      }
+    },
+    playbillMysterious,
+    setPlaybillMysterious,
   };
 
   return <CreateBlockContext.Provider value={contextValue}>{children}</CreateBlockContext.Provider>;

--- a/app/frontend/Pages/Playbill/Playbill.module.scss
+++ b/app/frontend/Pages/Playbill/Playbill.module.scss
@@ -91,37 +91,9 @@
 
 .tabs {
   display: flex;
-  gap: 0.25rem;
+  gap: var(--space-xs);
   justify-content: center;
   margin-bottom: var(--space-md);
-  border-bottom: 1px solid hsl(var(--border));
-}
-
-.tab {
-  background: transparent;
-  border: none;
-  color: var(--hot-white);
-  opacity: 0.6;
-  padding: 0.5rem 1rem;
-  font-size: 0.95rem;
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  cursor: pointer;
-  border-bottom: 2px solid transparent;
-  margin-bottom: -1px;
-  transition:
-    opacity 0.15s ease,
-    border-color 0.15s ease;
-}
-
-.tab:hover {
-  opacity: 0.9;
-}
-
-.tabActive {
-  opacity: 1;
-  border-bottom-color: var(--phosphor);
 }
 
 .runningOrder {

--- a/app/frontend/Pages/Playbill/Playbill.module.scss
+++ b/app/frontend/Pages/Playbill/Playbill.module.scss
@@ -89,6 +89,91 @@
   text-align: left;
 }
 
+.tabs {
+  display: flex;
+  gap: 0.25rem;
+  justify-content: center;
+  margin-bottom: var(--space-md);
+  border-bottom: 1px solid hsl(var(--border));
+}
+
+.tab {
+  background: transparent;
+  border: none;
+  color: var(--hot-white);
+  opacity: 0.6;
+  padding: 0.5rem 1rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition:
+    opacity 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.tab:hover {
+  opacity: 0.9;
+}
+
+.tabActive {
+  opacity: 1;
+  border-bottom-color: var(--phosphor);
+}
+
+.runningOrder {
+  list-style: none;
+  padding: 0;
+  margin: var(--space-sm) 0 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.runningOrderItem {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-sm);
+  padding: var(--space-sm);
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.5rem;
+  text-align: left;
+}
+
+.runningOrderIndex {
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--phosphor);
+  color: var(--black);
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.runningOrderText {
+  flex: 1;
+  min-width: 0;
+}
+
+.runningOrderTitle {
+  margin: 0 0 0.25rem 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.runningOrderDescription {
+  margin: 0;
+  opacity: 0.7;
+  font-size: 0.9rem;
+}
+
 @media (max-width: 768px) {
   .fab {
     bottom: calc(var(--bottom-nav-h) + env(safe-area-inset-bottom) + var(--space-sm));

--- a/app/frontend/Pages/Playbill/Playbill.module.scss
+++ b/app/frontend/Pages/Playbill/Playbill.module.scss
@@ -107,12 +107,36 @@
 
 .runningOrderItem {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: var(--space-sm);
   padding: var(--space-sm);
   border: 1px solid hsl(var(--border));
   border-radius: 0.5rem;
   text-align: left;
+}
+
+.runningOrderItemMysterious .runningOrderText {
+  display: flex;
+  align-items: center;
+}
+
+.mysteryMark {
+  flex-shrink: 0;
+  margin-left: auto;
+  width: 4rem;
+  height: 4rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--phosphor);
+  color: var(--black);
+  font-size: 2.25rem;
+  font-weight: 800;
+  line-height: 1;
+  box-shadow:
+    0 0 0 4px hsl(var(--background)),
+    0 0 0 6px var(--phosphor);
 }
 
 .runningOrderIndex {

--- a/app/frontend/Pages/Playbill/Playbill.stories.tsx
+++ b/app/frontend/Pages/Playbill/Playbill.stories.tsx
@@ -41,3 +41,26 @@ export const Disabled: Story = {
     ),
   ],
 };
+
+export const RunningOrderPopulated: Story = {
+  decorators: [
+    (Story) => (
+      <ExperienceSeeder experience={lobbyExperience} participant={undefined}>
+        <Story />
+      </ExperienceSeeder>
+    ),
+  ],
+};
+
+export const RunningOrderEmpty: Story = {
+  decorators: [
+    (Story) => (
+      <ExperienceSeeder
+        experience={{ ...lobbyExperience, playbill_running_order: [] }}
+        participant={undefined}
+      >
+        <Story />
+      </ExperienceSeeder>
+    ),
+  ],
+};

--- a/app/frontend/Pages/Playbill/Playbill.tsx
+++ b/app/frontend/Pages/Playbill/Playbill.tsx
@@ -158,19 +158,26 @@ function RunningOrderTab() {
 }
 
 function RunningOrderItem({ entry, index }: { entry: PlaybillRunningOrderEntry; index: number }) {
-  const title = entry.playbill_mysterious
-    ? 'A Surprise Segment'
-    : entry.title || BLOCK_KIND_LABELS[entry.kind];
-  const description = entry.playbill_mysterious
-    ? 'Identity revealed live during the show.'
-    : BLOCK_KIND_DESCRIPTIONS[entry.kind];
+  if (entry.playbill_mysterious) {
+    return (
+      <li className={`${styles.runningOrderItem} ${styles.runningOrderItemMysterious}`}>
+        <span className={styles.runningOrderIndex}>{index + 1}</span>
+        <div className={styles.runningOrderText}>
+          <h3 className={styles.runningOrderTitle}>A Surprise Segment</h3>
+        </div>
+        <div className={styles.mysteryMark} aria-hidden="true">
+          ?
+        </div>
+      </li>
+    );
+  }
 
   return (
     <li className={styles.runningOrderItem}>
       <span className={styles.runningOrderIndex}>{index + 1}</span>
       <div className={styles.runningOrderText}>
-        <h3 className={styles.runningOrderTitle}>{title}</h3>
-        <p className={styles.runningOrderDescription}>{description}</p>
+        <h3 className={styles.runningOrderTitle}>{entry.title || BLOCK_KIND_LABELS[entry.kind]}</h3>
+        <p className={styles.runningOrderDescription}>{BLOCK_KIND_DESCRIPTIONS[entry.kind]}</p>
       </div>
     </li>
   );

--- a/app/frontend/Pages/Playbill/Playbill.tsx
+++ b/app/frontend/Pages/Playbill/Playbill.tsx
@@ -6,7 +6,7 @@ import { ChevronLeft } from 'lucide-react';
 
 import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { Button } from '@cctv/core';
-import { Block, BlockKind } from '@cctv/types';
+import { BLOCK_KIND_LABELS, BlockKind, PlaybillRunningOrderEntry } from '@cctv/types';
 
 import styles from './Playbill.module.scss';
 
@@ -24,38 +24,6 @@ const BLOCK_KIND_DESCRIPTIONS: Record<BlockKind, string> = {
   [BlockKind.MINIGAME_BALLOON_PUMP]: 'Balloon-pump minigame',
   [BlockKind.THE_SCENE]: 'Improv suggestion + voting',
 };
-
-function getBlockTitle(block: Block): string {
-  switch (block.kind) {
-    case BlockKind.POLL:
-      return block.payload?.question?.trim() || 'Poll';
-    case BlockKind.QUESTION:
-      return block.payload?.question?.trim() || 'Question';
-    case BlockKind.ANNOUNCEMENT: {
-      const msg = block.payload?.message?.trim();
-      if (!msg) return 'Announcement';
-      return msg.length > 60 ? `${msg.slice(0, 60)}…` : msg;
-    }
-    case BlockKind.FAMILY_FEUD:
-      return block.payload?.title?.trim() || 'Family Feud';
-    case BlockKind.PHOTO_UPLOAD:
-      return block.payload?.prompt?.trim() || 'Photo Upload';
-    case BlockKind.BUZZER:
-      return block.payload?.label?.trim() || block.payload?.prompt?.trim() || 'Buzzer';
-    case BlockKind.GUESS_WHO:
-      return 'Guess Who';
-    case BlockKind.MINIGAME_ARITHMETIC:
-      return 'Arithmetic Minigame';
-    case BlockKind.MINIGAME_BALLOON_PUMP:
-      return 'Balloon Pump Minigame';
-    case BlockKind.THE_SCENE:
-      return 'The Scene';
-    default: {
-      const _exhaust: never = block;
-      return (_exhaust as Block).kind;
-    }
-  }
-}
 
 export default function Playbill() {
   const { experience, code, isLoading, error } = useExperience();
@@ -101,24 +69,22 @@ export default function Playbill() {
       </Link>
 
       <div className={styles.tabs} role="tablist">
-        <button
-          type="button"
+        <Button
           role="tab"
           aria-selected={activeTab === 'performers'}
-          className={`${styles.tab} ${activeTab === 'performers' ? styles.tabActive : ''}`}
+          variant={activeTab === 'performers' ? 'primary' : 'ghost'}
           onClick={() => setActiveTab('performers')}
         >
           Performers
-        </button>
-        <button
-          type="button"
+        </Button>
+        <Button
           role="tab"
           aria-selected={activeTab === 'running_order'}
-          className={`${styles.tab} ${activeTab === 'running_order' ? styles.tabActive : ''}`}
+          variant={activeTab === 'running_order' ? 'primary' : 'ghost'}
           onClick={() => setActiveTab('running_order')}
         >
           Running Order
-        </button>
+        </Button>
       </div>
 
       {activeTab === 'performers' && <PerformersTab />}
@@ -172,13 +138,9 @@ function PerformersTab() {
 
 function RunningOrderTab() {
   const { experience } = useExperience();
+  const entries = experience?.playbill_running_order || [];
 
-  const blocks = (experience?.blocks || [])
-    .filter((block) => block.add_to_playbill && !block.parent_block_id)
-    .slice()
-    .sort((a, b) => a.position - b.position);
-
-  if (blocks.length === 0) {
+  if (entries.length === 0) {
     return (
       <div className={styles.sections}>
         <p className={styles.subtitle}>No blocks have been added to the running order yet.</p>
@@ -188,23 +150,28 @@ function RunningOrderTab() {
 
   return (
     <ol className={styles.runningOrder}>
-      {blocks.map((block, index) => {
-        const mysterious = block.playbill_mysterious;
-        const title = mysterious ? 'A Surprise Segment' : getBlockTitle(block);
-        const description = mysterious
-          ? 'Identity revealed live during the show.'
-          : BLOCK_KIND_DESCRIPTIONS[block.kind];
-
-        return (
-          <li key={block.id} className={styles.runningOrderItem}>
-            <span className={styles.runningOrderIndex}>{index + 1}</span>
-            <div className={styles.runningOrderText}>
-              <h3 className={styles.runningOrderTitle}>{title}</h3>
-              <p className={styles.runningOrderDescription}>{description}</p>
-            </div>
-          </li>
-        );
-      })}
+      {entries.map((entry, index) => (
+        <RunningOrderItem key={entry.id} entry={entry} index={index} />
+      ))}
     </ol>
+  );
+}
+
+function RunningOrderItem({ entry, index }: { entry: PlaybillRunningOrderEntry; index: number }) {
+  const title = entry.playbill_mysterious
+    ? 'A Surprise Segment'
+    : entry.title || BLOCK_KIND_LABELS[entry.kind];
+  const description = entry.playbill_mysterious
+    ? 'Identity revealed live during the show.'
+    : BLOCK_KIND_DESCRIPTIONS[entry.kind];
+
+  return (
+    <li className={styles.runningOrderItem}>
+      <span className={styles.runningOrderIndex}>{index + 1}</span>
+      <div className={styles.runningOrderText}>
+        <h3 className={styles.runningOrderTitle}>{title}</h3>
+        <p className={styles.runningOrderDescription}>{description}</p>
+      </div>
+    </li>
   );
 }

--- a/app/frontend/Pages/Playbill/Playbill.tsx
+++ b/app/frontend/Pages/Playbill/Playbill.tsx
@@ -1,14 +1,65 @@
+import { useState } from 'react';
+
 import { Link } from 'react-router-dom';
 
 import { ChevronLeft } from 'lucide-react';
 
 import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { Button } from '@cctv/core';
+import { Block, BlockKind } from '@cctv/types';
 
 import styles from './Playbill.module.scss';
 
+type TabKey = 'performers' | 'running_order';
+
+const BLOCK_KIND_DESCRIPTIONS: Record<BlockKind, string> = {
+  [BlockKind.POLL]: 'Audience-wide poll',
+  [BlockKind.QUESTION]: 'Open-response question',
+  [BlockKind.ANNOUNCEMENT]: 'Announcement from the host',
+  [BlockKind.FAMILY_FEUD]: 'Family-Feud-style game',
+  [BlockKind.PHOTO_UPLOAD]: 'Photo submission prompt',
+  [BlockKind.BUZZER]: 'First-to-buzz challenge',
+  [BlockKind.GUESS_WHO]: 'Guess-who reveal',
+  [BlockKind.MINIGAME_ARITHMETIC]: 'Speed-math minigame',
+  [BlockKind.MINIGAME_BALLOON_PUMP]: 'Balloon-pump minigame',
+  [BlockKind.THE_SCENE]: 'Improv suggestion + voting',
+};
+
+function getBlockTitle(block: Block): string {
+  switch (block.kind) {
+    case BlockKind.POLL:
+      return block.payload?.question?.trim() || 'Poll';
+    case BlockKind.QUESTION:
+      return block.payload?.question?.trim() || 'Question';
+    case BlockKind.ANNOUNCEMENT: {
+      const msg = block.payload?.message?.trim();
+      if (!msg) return 'Announcement';
+      return msg.length > 60 ? `${msg.slice(0, 60)}…` : msg;
+    }
+    case BlockKind.FAMILY_FEUD:
+      return block.payload?.title?.trim() || 'Family Feud';
+    case BlockKind.PHOTO_UPLOAD:
+      return block.payload?.prompt?.trim() || 'Photo Upload';
+    case BlockKind.BUZZER:
+      return block.payload?.label?.trim() || block.payload?.prompt?.trim() || 'Buzzer';
+    case BlockKind.GUESS_WHO:
+      return 'Guess Who';
+    case BlockKind.MINIGAME_ARITHMETIC:
+      return 'Arithmetic Minigame';
+    case BlockKind.MINIGAME_BALLOON_PUMP:
+      return 'Balloon Pump Minigame';
+    case BlockKind.THE_SCENE:
+      return 'The Scene';
+    default: {
+      const _exhaust: never = block;
+      return (_exhaust as Block).kind;
+    }
+  }
+}
+
 export default function Playbill() {
   const { experience, code, isLoading, error } = useExperience();
+  const [activeTab, setActiveTab] = useState<TabKey>('performers');
 
   if (isLoading) {
     return (
@@ -40,8 +91,6 @@ export default function Playbill() {
     );
   }
 
-  const sections = experience?.playbill || [];
-
   return (
     <section className={styles.root}>
       <h1 className={styles.title}>{experience?.name || code}</h1>
@@ -51,39 +100,111 @@ export default function Playbill() {
         <ChevronLeft size={22} />
       </Link>
 
-      {sections.length === 0 ? (
-        <div className={styles.sections}>
-          <p className={styles.subtitle}>No playbill content yet.</p>
-        </div>
-      ) : (
-        <div className={styles.sections}>
-          {sections.map((section, index) => (
-            <div
-              key={section.id}
-              className={styles.section}
-              style={section.image_url ? undefined : { gridTemplateColumns: '1fr' }}
-            >
-              {section.image_url && (
-                <div className={styles.imageWrap}>
-                  <img
-                    className={styles.image}
-                    src={section.image_url}
-                    alt={section.title || `Playbill section ${index + 1}`}
-                    loading="lazy"
-                    decoding="async"
-                    width={section.image_width}
-                    height={section.image_height}
-                  />
-                </div>
-              )}
-              <div className={styles.textWrap}>
-                <h3 className={styles.itemTitle}>{section.title}</h3>
-                <p className={styles.itemBody}>{section.body}</p>
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
+      <div className={styles.tabs} role="tablist">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === 'performers'}
+          className={`${styles.tab} ${activeTab === 'performers' ? styles.tabActive : ''}`}
+          onClick={() => setActiveTab('performers')}
+        >
+          Performers
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === 'running_order'}
+          className={`${styles.tab} ${activeTab === 'running_order' ? styles.tabActive : ''}`}
+          onClick={() => setActiveTab('running_order')}
+        >
+          Running Order
+        </button>
+      </div>
+
+      {activeTab === 'performers' && <PerformersTab />}
+      {activeTab === 'running_order' && <RunningOrderTab />}
     </section>
+  );
+}
+
+function PerformersTab() {
+  const { experience } = useExperience();
+  const sections = experience?.playbill || [];
+
+  if (sections.length === 0) {
+    return (
+      <div className={styles.sections}>
+        <p className={styles.subtitle}>No performers listed yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.sections}>
+      {sections.map((section, index) => (
+        <div
+          key={section.id}
+          className={styles.section}
+          style={section.image_url ? undefined : { gridTemplateColumns: '1fr' }}
+        >
+          {section.image_url && (
+            <div className={styles.imageWrap}>
+              <img
+                className={styles.image}
+                src={section.image_url}
+                alt={section.title || `Performer ${index + 1}`}
+                loading="lazy"
+                decoding="async"
+                width={section.image_width}
+                height={section.image_height}
+              />
+            </div>
+          )}
+          <div className={styles.textWrap}>
+            <h3 className={styles.itemTitle}>{section.title}</h3>
+            <p className={styles.itemBody}>{section.body}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function RunningOrderTab() {
+  const { experience } = useExperience();
+
+  const blocks = (experience?.blocks || [])
+    .filter((block) => block.add_to_playbill && !block.parent_block_id)
+    .slice()
+    .sort((a, b) => a.position - b.position);
+
+  if (blocks.length === 0) {
+    return (
+      <div className={styles.sections}>
+        <p className={styles.subtitle}>No blocks have been added to the running order yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <ol className={styles.runningOrder}>
+      {blocks.map((block, index) => {
+        const mysterious = block.playbill_mysterious;
+        const title = mysterious ? 'A Surprise Segment' : getBlockTitle(block);
+        const description = mysterious
+          ? 'Identity revealed live during the show.'
+          : BLOCK_KIND_DESCRIPTIONS[block.kind];
+
+        return (
+          <li key={block.id} className={styles.runningOrderItem}>
+            <span className={styles.runningOrderIndex}>{index + 1}</span>
+            <div className={styles.runningOrderText}>
+              <h3 className={styles.runningOrderTitle}>{title}</h3>
+              <p className={styles.runningOrderDescription}>{description}</p>
+            </div>
+          </li>
+        );
+      })}
+    </ol>
   );
 }

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -370,6 +370,8 @@ interface BaseBlock {
   visible_to_segments?: string[];
   target_user_ids?: string[];
   show_in_lobby?: boolean;
+  add_to_playbill?: boolean;
+  playbill_mysterious?: boolean;
   sounds?: Partial<Record<string, SoundKey>>;
   created_at?: string;
   updated_at?: string;
@@ -556,6 +558,8 @@ export interface CreateBlockPayload {
   visible_to_segment_ids?: string[];
   status?: BlockStatus;
   open_immediately?: boolean;
+  add_to_playbill?: boolean;
+  playbill_mysterious?: boolean;
   questions?: Array<{
     payload: Record<string, string>;
   }>;
@@ -1041,6 +1045,11 @@ export interface CreateBlockContextValue {
   defaultSegmentName: string | null;
   viewAdditionalDetails: boolean;
   setViewAdditionalDetails: (view: boolean) => void;
+
+  addToPlaybill: boolean;
+  setAddToPlaybill: (value: boolean) => void;
+  playbillMysterious: boolean;
+  setPlaybillMysterious: (value: boolean) => void;
 }
 
 // Props interface for block components

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -492,6 +492,14 @@ export type Block =
   | MinigameBalloonPumpBlock
   | TheSceneBlock;
 
+export interface PlaybillRunningOrderEntry {
+  id: string;
+  kind: BlockKind;
+  position: number;
+  playbill_mysterious: boolean;
+  title: string | null;
+}
+
 export interface Experience {
   id: string;
   name: string;
@@ -506,6 +514,7 @@ export interface Experience {
   blocks: Block[];
   playbill_enabled?: boolean;
   playbill?: PlaybillSection[];
+  playbill_running_order?: PlaybillRunningOrderEntry[];
   segments?: ExperienceSegment[];
   default_segment_id?: string | null;
   created_at: string;

--- a/app/services/experiences/orchestrator.rb
+++ b/app/services/experiences/orchestrator.rb
@@ -19,7 +19,9 @@ module Experiences
       target_user_ids: [],
       status: :hidden,
       open_immediately: false,
-      show_in_lobby: false
+      show_in_lobby: false,
+      add_to_playbill: false,
+      playbill_mysterious: false
     )
       transaction do
         max_position = experience.experience_blocks.maximum(:position) || -1
@@ -32,7 +34,9 @@ module Experiences
           payload: prepared_payload,
           visible_to_roles: visible_to_roles,
           target_user_ids: target_user_ids,
-          position: max_position + 1
+          position: max_position + 1,
+          add_to_playbill: add_to_playbill,
+          playbill_mysterious: add_to_playbill && playbill_mysterious
         )
         block.update!(status: :open) if open_immediately
 
@@ -881,7 +885,9 @@ module Experiences
       visible_to_roles: [],
       target_user_ids: [],
       status: :hidden,
-      questions: []
+      questions: [],
+      add_to_playbill: false,
+      playbill_mysterious: false
     )
       transaction do
         max_position = experience.experience_blocks.maximum(:position) || -1
@@ -893,7 +899,9 @@ module Experiences
           sounds: default_sounds_for(kind),
           visible_to_roles: visible_to_roles,
           target_user_ids: target_user_ids,
-          position: max_position + 1
+          position: max_position + 1,
+          add_to_playbill: add_to_playbill,
+          playbill_mysterious: add_to_playbill && playbill_mysterious
         )
 
         if kind == ExperienceBlock::FAMILY_FEUD && questions.present?

--- a/app/services/experiences/visibility.rb
+++ b/app/services/experiences/visibility.rb
@@ -220,13 +220,15 @@ module Experiences
 
     def serialize_block(block, participant_role:, participant: nil, depth: 0, view_context: :admin)
       {
-        id:              block.id,
-        kind:            block.kind,
-        status:          block.status,
-        parent_block_id: block.parent_block_id,
-        payload:         shape_payload(block, participant_role, participant, view_context),
-        sounds:          block.sounds,
-        position:        block.position
+        id:                  block.id,
+        kind:                block.kind,
+        status:              block.status,
+        parent_block_id:     block.parent_block_id,
+        payload:             shape_payload(block, participant_role, participant, view_context),
+        sounds:              block.sounds,
+        position:            block.position,
+        add_to_playbill:     block.add_to_playbill,
+        playbill_mysterious: block.playbill_mysterious
       }
         .merge(responses: serialize_response_data(block, participant_role, participant))
         .merge(visibility_metadata(block, participant_role, participant))

--- a/app/services/experiences/visibility.rb
+++ b/app/services/experiences/visibility.rb
@@ -615,9 +615,10 @@ module Experiences
         created_at:       @experience.created_at,
         updated_at:       @experience.updated_at,
         blocks:           blocks,
-        playbill_enabled:   @experience.playbill_enabled,
-        playbill:           serialize_playbill,
-        segments:           serialize_segments,
+        playbill_enabled:        @experience.playbill_enabled,
+        playbill:                serialize_playbill,
+        playbill_running_order:  serialize_playbill_running_order,
+        segments:                serialize_segments,
         default_segment_id: @experience.default_segment_id,
         hosts:            serialize_participants(participants.select { |p| p.role == "host" }),
         participants:     serialize_participants(participants)
@@ -648,6 +649,43 @@ module Experiences
     def serialize_segments
       @experience.experience_segments.order(position: :asc).map do |s|
         { id: s.id, name: s.name, color: s.color, position: s.position }
+      end
+    end
+
+    def serialize_playbill_running_order
+      @experience.experience_blocks
+        .where(parent_block_id: nil, add_to_playbill: true)
+        .order(position: :asc)
+        .map do |block|
+          {
+            id:                  block.id,
+            kind:                block.kind,
+            position:            block.position,
+            playbill_mysterious: block.playbill_mysterious,
+            title:               block.playbill_mysterious ? nil : derive_playbill_title(block)
+          }
+        end
+    end
+
+    def derive_playbill_title(block)
+      payload = block.payload || {}
+
+      case block.kind
+      when ExperienceBlock::POLL, ExperienceBlock::QUESTION
+        payload["question"].to_s.strip.presence
+      when ExperienceBlock::ANNOUNCEMENT
+        msg = payload["message"].to_s.strip
+        if msg.empty?
+          nil
+        else
+          msg.length > 60 ? "#{msg[0, 60]}…" : msg
+        end
+      when ExperienceBlock::FAMILY_FEUD
+        payload["title"].to_s.strip.presence
+      when ExperienceBlock::PHOTO_UPLOAD
+        payload["prompt"].to_s.strip.presence
+      when ExperienceBlock::BUZZER
+        payload["label"].to_s.strip.presence || payload["prompt"].to_s.strip.presence
       end
     end
 

--- a/db/migrate/20260528000002_add_playbill_fields_to_experience_blocks.rb
+++ b/db/migrate/20260528000002_add_playbill_fields_to_experience_blocks.rb
@@ -1,0 +1,6 @@
+class AddPlaybillFieldsToExperienceBlocks < ActiveRecord::Migration[7.2]
+  def change
+    add_column :experience_blocks, :add_to_playbill, :boolean, default: false, null: false
+    add_column :experience_blocks, :playbill_mysterious, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_28_000001) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_28_000002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -121,6 +121,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_28_000001) do
     t.integer "position", default: 0, null: false
     t.boolean "show_in_lobby", default: false, null: false
     t.jsonb "sounds", default: {}, null: false
+    t.boolean "add_to_playbill", default: false, null: false
+    t.boolean "playbill_mysterious", default: false, null: false
     t.index ["experience_id", "position"], name: "index_experience_blocks_on_experience_id_and_position"
     t.index ["experience_id", "status"], name: "index_experience_blocks_on_experience_id_and_status"
     t.index ["experience_id"], name: "index_experience_blocks_on_experience_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,10 +7,22 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
-[
+superadmins = [
   ["jared.shay@gmail.com", "Jared"],
   ["dconnenc@gmail.com", "Dillon"],
   ["cam9548@gmail.com", "Cam"]
-].each do |email, name|
+].map do |email, name|
   User.find_or_create_by!(name: name, email: email, role: "superadmin")
+end
+
+Event.find_or_create_by!(slug: "chicago-comedy-social-technical-expo-2026") do |event|
+  event.title         = "Chicago Comedy Social & Technical Expo"
+  event.description   = "A celebration of Chicago's comedy community at The Den Theatre."
+  event.starts_at     = Time.zone.local(2026, 6, 11, 19, 0)
+  event.ends_at       = Time.zone.local(2026, 6, 11, 23, 0)
+  event.venue_name    = "The Den Theatre"
+  event.venue_address = "1331 N Milwaukee Ave, Chicago, IL 60622"
+  event.ticket_url    = "https://thedentheatre.com/performances/2026/6/11/chicago-comedy-social-technical-expo-the-den-theatre-comedy-club-chicago"
+  event.published     = true
+  event.creator       = superadmins.first
 end


### PR DESCRIPTION
## Summary
- Seeds the Chicago Comedy Social & Technical Expo event (June 11, 2026, The Den Theatre) so the existing `Event` model surfaces real content on the calendar.
- Adds `add_to_playbill` + `playbill_mysterious` columns to `experience_blocks`, threaded through the orchestrator, controller, and `Visibility#serialize_block`.
- Block creation form always shows an "Add to playbill" toggle (default **on**); flipping it on reveals a "Display block mysteriously" toggle.
- Rebuilds the Playbill page as a tabbed view: **Performers** (existing playbill JSONB sections) and **Running Order** (parent blocks ordered by `position`, filtered to `add_to_playbill = true`, rendered with derived title + kind-based description). Mysterious blocks render as "A Surprise Segment".

## Test plan
- [x] `bin/rails db:migrate && bin/rails db:seed` — CCSTE event appears on `/calendar` for June 2026
- [x] Open the block-creation drawer on `/manage`: "Add to playbill" defaults on, "Display mysteriously" only shows when on
- [x] Create a block with playbill on (not mysterious): appears in `/playbill` Running Order with title + description
- [x] Create a mysterious block: appears as "A Surprise Segment"
- [x] Reorder blocks via existing reorder endpoint: Running Order reflects the new sequence
- [x] Family Feud child question blocks are filtered out of Running Order

🤖 Generated with [Claude Code](https://claude.com/claude-code)