### PR TITLE
Rework The Scene with roles, performers, buzzer + winner reveal

### DIFF
--- a/app/controllers/api/experience_blocks_controller.rb
+++ b/app/controllers/api/experience_blocks_controller.rb
@@ -9,7 +9,7 @@ class Api::ExperienceBlocksController < Api::BaseController
     dispatch_guess_who_poll conclude_guess_who_poll reveal_guess_who
     start_minigame_arithmetic end_minigame_arithmetic
     start_minigame_balloon_pump end_minigame_balloon_pump
-    advance_the_scene_phase start_next_the_scene
+    start_the_scene end_the_scene force_next_the_scene update_the_scene_performers
     clear_the_scene_top clear_the_scene_suggestion clear_the_scene_all
   ].freeze
 
@@ -17,7 +17,7 @@ class Api::ExperienceBlocksController < Api::BaseController
     submit_poll_response submit_question_response
     submit_photo_upload_response submit_buzzer_response
     submit_minigame_arithmetic_response submit_minigame_balloon_pump_update
-    submit_the_scene_suggestion submit_the_scene_vote
+    submit_the_scene_suggestion submit_the_scene_vote press_the_scene_buzzer
   ].freeze
 
   before_action :authenticate_and_set_user_and_experience
@@ -768,12 +768,12 @@ class Api::ExperienceBlocksController < Api::BaseController
     end
   end
 
-  # POST /api/experiences/:experience_id/blocks/:id/the_scene/phase
-  def advance_the_scene_phase
+  # POST /api/experiences/:experience_id/blocks/:id/the_scene/start
+  def start_the_scene
     with_experience_orchestration do
       block = Experiences::Orchestrator.new(
         experience: @experience, actor: @user
-      ).advance_the_scene_phase!(block: @block, phase: params[:phase])
+      ).start_the_scene!(block: @block)
 
       Experiences::Broadcaster.new(@experience).broadcast_experience_update
 
@@ -781,16 +781,58 @@ class Api::ExperienceBlocksController < Api::BaseController
     end
   end
 
-  # POST /api/experiences/:experience_id/blocks/:id/the_scene/next
-  def start_next_the_scene
+  # POST /api/experiences/:experience_id/blocks/:id/the_scene/end
+  def end_the_scene
     with_experience_orchestration do
       block = Experiences::Orchestrator.new(
         experience: @experience, actor: @user
-      ).start_next_scene!(block: @block)
+      ).end_the_scene!(block: @block)
 
       Experiences::Broadcaster.new(@experience).broadcast_experience_update
 
       render json: { success: true, data: block }, status: 200
+    end
+  end
+
+  # POST /api/experiences/:experience_id/blocks/:id/the_scene/force_next_scene
+  def force_next_the_scene
+    with_experience_orchestration do
+      block = Experiences::Orchestrator.new(
+        experience: @experience, actor: @user
+      ).force_next_scene!(block: @block)
+
+      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      render json: { success: true, data: block }, status: 200
+    end
+  end
+
+  # PATCH /api/experiences/:experience_id/blocks/:id/the_scene/performers
+  def update_the_scene_performers
+    with_experience_orchestration do
+      block = Experiences::Orchestrator.new(
+        experience: @experience, actor: @user
+      ).update_the_scene_performers!(
+        block: @block,
+        performer_participant_ids: Array(params[:performer_participant_ids])
+      )
+
+      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      render json: { success: true, data: block }, status: 200
+    end
+  end
+
+  # POST /api/experiences/:experience_id/blocks/:id/the_scene/buzzer
+  def press_the_scene_buzzer
+    with_experience_orchestration do
+      Experiences::Orchestrator.new(
+        experience: @experience, actor: @user
+      ).press_the_scene_buzzer!(block: @block)
+
+      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      render json: { success: true }, status: 200
     end
   end
 

--- a/app/frontend/Core/GlassCaseButton/GlassCaseButton.module.scss
+++ b/app/frontend/Core/GlassCaseButton/GlassCaseButton.module.scss
@@ -1,0 +1,72 @@
+.root {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+  cursor: pointer;
+  border-radius: 12px;
+  outline: none;
+  transition: transform 0.15s ease;
+
+  &:focus-visible {
+    box-shadow: 0 0 0 2px var(--phosphor);
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+}
+
+.canvasMount {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+
+  canvas {
+    display: block;
+  }
+}
+
+.label {
+  position: absolute;
+  bottom: 12px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  letter-spacing: 0.18em;
+  color: var(--phosphor);
+  text-shadow: 0 0 8px var(--phosphor-glow-strong);
+  pointer-events: none;
+}
+
+.locked {
+  cursor: not-allowed;
+
+  .label {
+    color: var(--dim);
+    text-shadow: none;
+  }
+}
+
+.armed {
+  .label {
+    color: var(--red);
+    text-shadow: 0 0 12px rgba(255, 73, 17, 0.6);
+    animation: pulseLabel 0.9s ease-in-out infinite alternate;
+  }
+}
+
+@keyframes pulseLabel {
+  from {
+    opacity: 0.6;
+  }
+  to {
+    opacity: 1;
+  }
+}

--- a/app/frontend/Core/GlassCaseButton/GlassCaseButton.stories.tsx
+++ b/app/frontend/Core/GlassCaseButton/GlassCaseButton.stories.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { GlassCaseButton } from './GlassCaseButton';
+
+const meta: Meta<typeof GlassCaseButton> = {
+  title: 'Core/GlassCaseButton',
+  component: GlassCaseButton,
+  tags: ['autodocs'],
+};
+export default meta;
+
+type Story = StoryObj<typeof GlassCaseButton>;
+
+export const Locked: Story = {
+  args: {
+    locked: true,
+    lockedLabel: 'WAITING',
+    onPress: () => undefined,
+  },
+};
+
+export const Armed: Story = {
+  args: {
+    locked: false,
+    label: 'BREAK GLASS',
+    onPress: () => alert('Buzzer pressed!'),
+    onBreak: () => undefined,
+  },
+};
+
+export const Interactive: Story = {
+  render: function Interactive() {
+    const [pressedAt, setPressedAt] = useState<string | null>(null);
+    const [brokeAt, setBrokeAt] = useState<string | null>(null);
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', padding: '1rem' }}>
+        <GlassCaseButton
+          locked={false}
+          onBreak={() => setBrokeAt(new Date().toLocaleTimeString())}
+          onPress={() => setPressedAt(new Date().toLocaleTimeString())}
+        />
+        <div style={{ fontFamily: 'var(--font-body)', color: 'var(--hot-white)' }}>
+          <div>Glass broken at: {brokeAt ?? '—'}</div>
+          <div>Buzzer pressed at: {pressedAt ?? '—'}</div>
+        </div>
+      </div>
+    );
+  },
+};
+
+export const LargeSize: Story = {
+  args: {
+    locked: false,
+    size: 380,
+    onPress: () => undefined,
+  },
+};

--- a/app/frontend/Core/GlassCaseButton/GlassCaseButton.tsx
+++ b/app/frontend/Core/GlassCaseButton/GlassCaseButton.tsx
@@ -1,0 +1,339 @@
+import { PointerEvent, useCallback, useEffect, useRef, useState } from 'react';
+
+import * as THREE from 'three';
+import * as Tone from 'tone';
+
+import styles from './GlassCaseButton.module.scss';
+
+type GlassState = 'intact' | 'breaking' | 'broken';
+
+interface Props {
+  locked: boolean;
+  onBreak?: () => void;
+  onPress: () => void;
+  label?: string;
+  lockedLabel?: string;
+  size?: number;
+}
+
+const SHARD_COUNT = 36;
+
+function resolveCssVar(name: string, fallback: string): string {
+  const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  return v || fallback;
+}
+
+export function GlassCaseButton({
+  locked,
+  onBreak,
+  onPress,
+  label = 'BREAK GLASS',
+  lockedLabel = 'WAITING…',
+  size = 280,
+}: Props) {
+  const mountRef = useRef<HTMLDivElement | null>(null);
+  const stateRef = useRef<{
+    renderer?: THREE.WebGLRenderer;
+    scene?: THREE.Scene;
+    camera?: THREE.PerspectiveCamera;
+    dome?: THREE.Mesh;
+    button?: THREE.Mesh;
+    shards: THREE.Mesh[];
+    glassState: GlassState;
+    pressing: boolean;
+    pressT: number;
+    rafId?: number;
+    disposed: boolean;
+  }>({
+    shards: [],
+    glassState: 'intact',
+    pressing: false,
+    pressT: 0,
+    disposed: false,
+  });
+
+  const [glassState, setGlassState] = useState<GlassState>('intact');
+  const [pressing, setPressing] = useState(false);
+
+  useEffect(() => {
+    if (locked) {
+      setGlassState('intact');
+      stateRef.current.glassState = 'intact';
+      stateRef.current.shards.forEach((s) => {
+        s.position.set(0, 0, 0);
+        s.visible = true;
+      });
+      const dome = stateRef.current.dome;
+      if (dome) dome.visible = true;
+    }
+  }, [locked]);
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return;
+
+    const phosphor = resolveCssVar('--phosphor', '#c8f060');
+    const card = resolveCssVar('--card', '#1c1c1c');
+
+    const scene = new THREE.Scene();
+    scene.background = null;
+
+    const camera = new THREE.PerspectiveCamera(38, 1, 0.1, 100);
+    camera.position.set(0, 0.4, 5);
+    camera.lookAt(0, 0, 0);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.setSize(size, size);
+    mount.appendChild(renderer.domElement);
+
+    const ambient = new THREE.AmbientLight(0xffffff, 0.45);
+    scene.add(ambient);
+
+    const key = new THREE.DirectionalLight(0xffffff, 0.9);
+    key.position.set(2, 4, 3);
+    scene.add(key);
+
+    const rim = new THREE.PointLight(new THREE.Color(phosphor), 1.4, 12);
+    rim.position.set(-1.5, 1.5, 1.8);
+    scene.add(rim);
+
+    const base = new THREE.Mesh(
+      new THREE.CylinderGeometry(1.6, 1.7, 0.35, 64),
+      new THREE.MeshStandardMaterial({
+        color: new THREE.Color(card),
+        roughness: 0.6,
+        metalness: 0.2,
+      }),
+    );
+    base.position.y = -0.95;
+    scene.add(base);
+
+    const button = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.9, 0.95, 0.45, 48),
+      new THREE.MeshStandardMaterial({
+        color: new THREE.Color('#ff2a35'),
+        emissive: new THREE.Color('#5a0008'),
+        emissiveIntensity: 0.45,
+        roughness: 0.35,
+        metalness: 0.15,
+      }),
+    );
+    button.position.y = -0.55;
+    scene.add(button);
+
+    const dome = new THREE.Mesh(
+      new THREE.SphereGeometry(1.25, 40, 32, 0, Math.PI * 2, 0, Math.PI / 2),
+      new THREE.MeshPhysicalMaterial({
+        color: new THREE.Color('#a8e0ff'),
+        transparent: true,
+        opacity: 0.28,
+        roughness: 0.05,
+        metalness: 0,
+        transmission: 0.9,
+        thickness: 0.25,
+        side: THREE.DoubleSide,
+      }),
+    );
+    dome.position.y = -0.7;
+    scene.add(dome);
+
+    const shards: THREE.Mesh[] = [];
+    for (let i = 0; i < SHARD_COUNT; i++) {
+      const shard = new THREE.Mesh(
+        new THREE.ConeGeometry(0.08 + Math.random() * 0.06, 0.18 + Math.random() * 0.12, 4),
+        new THREE.MeshPhysicalMaterial({
+          color: new THREE.Color('#cdf0ff'),
+          transparent: true,
+          opacity: 0.8,
+          roughness: 0.1,
+          metalness: 0.1,
+        }),
+      );
+      shard.visible = false;
+      scene.add(shard);
+      shards.push(shard);
+    }
+
+    const st = stateRef.current;
+    st.renderer = renderer;
+    st.scene = scene;
+    st.camera = camera;
+    st.dome = dome;
+    st.button = button;
+    st.shards = shards;
+
+    let last = performance.now();
+    const tick = () => {
+      if (st.disposed) return;
+      const now = performance.now();
+      const dt = (now - last) / 1000;
+      last = now;
+
+      base.rotation.y += dt * 0.18;
+      button.rotation.y -= dt * 0.18;
+      dome.rotation.y += dt * 0.12;
+
+      if (st.glassState === 'breaking') {
+        let stillFlying = false;
+        st.shards.forEach((shard) => {
+          if (!shard.visible) return;
+          const v = (shard.userData.velocity as THREE.Vector3) || new THREE.Vector3();
+          shard.position.addScaledVector(v, dt);
+          v.y -= 4.5 * dt;
+          shard.rotation.x += (shard.userData.spin?.x ?? 1) * dt * 4;
+          shard.rotation.y += (shard.userData.spin?.y ?? 1) * dt * 4;
+          const mat = shard.material as THREE.MeshPhysicalMaterial;
+          mat.opacity = Math.max(0, mat.opacity - dt * 0.7);
+          if (mat.opacity > 0.02 && shard.position.y > -3) stillFlying = true;
+          else shard.visible = false;
+        });
+        if (!stillFlying) {
+          st.glassState = 'broken';
+          setGlassState('broken');
+        }
+      }
+
+      if (st.pressing) {
+        st.pressT = Math.min(1, st.pressT + dt * 6);
+        button.position.y = -0.55 - 0.22 * Math.sin(st.pressT * Math.PI);
+        const mat = button.material as THREE.MeshStandardMaterial;
+        mat.emissiveIntensity = 0.45 + 0.9 * Math.sin(st.pressT * Math.PI);
+        if (st.pressT >= 1) {
+          st.pressing = false;
+          st.pressT = 0;
+          button.position.y = -0.55;
+          mat.emissiveIntensity = 0.45;
+          setPressing(false);
+        }
+      }
+
+      renderer.render(scene, camera);
+      st.rafId = requestAnimationFrame(tick);
+    };
+    st.rafId = requestAnimationFrame(tick);
+
+    return () => {
+      st.disposed = true;
+      if (st.rafId) cancelAnimationFrame(st.rafId);
+      renderer.dispose();
+      scene.traverse((obj) => {
+        const mesh = obj as THREE.Mesh;
+        if (mesh.geometry) mesh.geometry.dispose();
+        if (mesh.material) {
+          const mat = mesh.material as THREE.Material | THREE.Material[];
+          if (Array.isArray(mat)) mat.forEach((m) => m.dispose());
+          else mat.dispose();
+        }
+      });
+      if (renderer.domElement.parentElement === mount) {
+        mount.removeChild(renderer.domElement);
+      }
+    };
+  }, [size]);
+
+  // Dim materials when locked.
+  useEffect(() => {
+    const button = stateRef.current.button;
+    if (!button) return;
+    const mat = button.material as THREE.MeshStandardMaterial;
+    mat.emissiveIntensity = locked ? 0.1 : 0.45;
+    mat.color = new THREE.Color(locked ? '#7a2228' : '#ff2a35');
+  }, [locked, glassState]);
+
+  const shatter = useCallback(async () => {
+    if (stateRef.current.glassState !== 'intact') return;
+    if (stateRef.current.disposed) return;
+
+    await Tone.start();
+
+    const dome = stateRef.current.dome;
+    if (dome) dome.visible = false;
+
+    stateRef.current.shards.forEach((shard) => {
+      shard.visible = true;
+      const angle = Math.random() * Math.PI * 2;
+      const radius = 1.1;
+      shard.position.set(Math.cos(angle) * 0.4, -0.4 + Math.random() * 1.0, Math.sin(angle) * 0.4);
+      const speed = 2.0 + Math.random() * 2.2;
+      shard.userData.velocity = new THREE.Vector3(
+        Math.cos(angle) * speed * radius,
+        2.5 + Math.random() * 1.5,
+        Math.sin(angle) * speed * radius,
+      );
+      shard.userData.spin = { x: Math.random() * 6, y: Math.random() * 6 };
+      const mat = shard.material as THREE.MeshPhysicalMaterial;
+      mat.opacity = 0.85;
+    });
+
+    stateRef.current.glassState = 'breaking';
+    setGlassState('breaking');
+
+    const noise = new Tone.NoiseSynth({
+      noise: { type: 'white' },
+      envelope: { attack: 0.001, decay: 0.6, sustain: 0, release: 0.05 },
+    }).toDestination();
+    noise.volume.value = -10;
+    noise.triggerAttackRelease('0.5');
+    setTimeout(() => noise.dispose(), 800);
+
+    onBreak?.();
+  }, [onBreak]);
+
+  const press = useCallback(async () => {
+    if (stateRef.current.glassState !== 'broken') return;
+    if (stateRef.current.pressing) return;
+
+    await Tone.start();
+    const thud = new Tone.MembraneSynth({
+      pitchDecay: 0.05,
+      octaves: 4,
+      envelope: { attack: 0.001, decay: 0.4, sustain: 0, release: 0.1 },
+    }).toDestination();
+    thud.volume.value = -6;
+    thud.triggerAttackRelease('C2', '8n');
+    setTimeout(() => thud.dispose(), 600);
+
+    stateRef.current.pressing = true;
+    setPressing(true);
+    onPress();
+  }, [onPress]);
+
+  const handlePointerDown = useCallback(
+    (e: PointerEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      if (locked) return;
+      if (stateRef.current.glassState === 'intact') {
+        void shatter();
+      } else if (stateRef.current.glassState === 'broken') {
+        void press();
+      }
+    },
+    [locked, shatter, press],
+  );
+
+  const activeLabel = (() => {
+    if (locked) return lockedLabel;
+    if (glassState === 'intact') return label;
+    if (glassState === 'breaking') return '';
+    if (pressing) return 'PRESSED';
+    return 'PRESS';
+  })();
+
+  return (
+    <div
+      className={`${styles.root} ${locked ? styles.locked : ''} ${glassState === 'broken' ? styles.armed : ''}`}
+      style={{ width: size, height: size }}
+      onPointerDown={handlePointerDown}
+      role="button"
+      tabIndex={0}
+      aria-label={activeLabel}
+      aria-disabled={locked}
+    >
+      <div ref={mountRef} className={styles.canvasMount} />
+      <span className={styles.label}>{activeLabel}</span>
+    </div>
+  );
+}
+
+export default GlassCaseButton;

--- a/app/frontend/Core/PerformerStoriesBar/PerformerStoriesBar.module.scss
+++ b/app/frontend/Core/PerformerStoriesBar/PerformerStoriesBar.module.scss
@@ -1,0 +1,78 @@
+.root {
+  width: 100%;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--phosphor-glow);
+  background: linear-gradient(180deg, rgba(13, 13, 15, 0.6), rgba(13, 13, 15, 0));
+}
+
+.scroller {
+  display: flex;
+  gap: 0.85rem;
+  padding: 0 1rem;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.item {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.3rem;
+  text-decoration: none;
+  color: var(--hot-white);
+  min-width: 64px;
+}
+
+.ringWrap {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background: conic-gradient(from 180deg, var(--phosphor), var(--amber), var(--phosphor));
+  padding: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  overflow: hidden;
+  background: var(--deep);
+  border: 2px solid var(--black);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+}
+
+.initial {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  color: var(--phosphor);
+  letter-spacing: 0.04em;
+}
+
+.name {
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  text-align: center;
+  max-width: 72px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  letter-spacing: 0.04em;
+}

--- a/app/frontend/Core/PerformerStoriesBar/PerformerStoriesBar.module.scss
+++ b/app/frontend/Core/PerformerStoriesBar/PerformerStoriesBar.module.scss
@@ -27,6 +27,11 @@
   text-decoration: none;
   color: var(--hot-white);
   min-width: 64px;
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  cursor: pointer;
 }
 
 .ringWrap {

--- a/app/frontend/Core/PerformerStoriesBar/PerformerStoriesBar.stories.tsx
+++ b/app/frontend/Core/PerformerStoriesBar/PerformerStoriesBar.stories.tsx
@@ -85,3 +85,10 @@ export const Mixed: Story = {
 export const Empty: Story = {
   args: { performers: [] },
 };
+
+export const Selectable: Story = {
+  args: {
+    performers: withPhotos,
+    onSelect: (performer) => alert(`Selected ${performer.name}`),
+  },
+};

--- a/app/frontend/Core/PerformerStoriesBar/PerformerStoriesBar.stories.tsx
+++ b/app/frontend/Core/PerformerStoriesBar/PerformerStoriesBar.stories.tsx
@@ -1,0 +1,87 @@
+import { MemoryRouter } from 'react-router-dom';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { TheScenePerformer } from '@cctv/types';
+
+import { PerformerStoriesBar } from './PerformerStoriesBar';
+
+const meta: Meta<typeof PerformerStoriesBar> = {
+  title: 'Core/PerformerStoriesBar',
+  component: PerformerStoriesBar,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <div style={{ background: 'var(--deep)', padding: '1rem' }}>
+          <Story />
+        </div>
+      </MemoryRouter>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof PerformerStoriesBar>;
+
+const withPhotos: TheScenePerformer[] = [
+  {
+    participant_id: '1',
+    user_id: 'u1',
+    name: 'Maya Carter',
+    slug: 'maya-carter',
+    photo_url: 'https://i.pravatar.cc/120?img=1',
+    has_performer_profile: true,
+  },
+  {
+    participant_id: '2',
+    user_id: 'u2',
+    name: 'Jordan Ali',
+    slug: 'jordan-ali',
+    photo_url: 'https://i.pravatar.cc/120?img=12',
+    has_performer_profile: true,
+  },
+  {
+    participant_id: '3',
+    user_id: 'u3',
+    name: 'Sam Pierce',
+    slug: 'sam-pierce',
+    photo_url: 'https://i.pravatar.cc/120?img=33',
+    has_performer_profile: true,
+  },
+];
+
+const withoutPhotos: TheScenePerformer[] = [
+  {
+    participant_id: '4',
+    user_id: 'u4',
+    name: 'Anna Vega',
+    slug: null,
+    photo_url: null,
+    has_performer_profile: false,
+  },
+  {
+    participant_id: '5',
+    user_id: 'u5',
+    name: 'Bobby T',
+    slug: null,
+    photo_url: null,
+    has_performer_profile: false,
+  },
+];
+
+export const WithPhotos: Story = {
+  args: { performers: withPhotos },
+};
+
+export const WithInitialsFallback: Story = {
+  args: { performers: withoutPhotos },
+};
+
+export const Mixed: Story = {
+  args: { performers: [...withPhotos, ...withoutPhotos] },
+};
+
+export const Empty: Story = {
+  args: { performers: [] },
+};

--- a/app/frontend/Core/PerformerStoriesBar/PerformerStoriesBar.tsx
+++ b/app/frontend/Core/PerformerStoriesBar/PerformerStoriesBar.tsx
@@ -7,9 +7,10 @@ import styles from './PerformerStoriesBar.module.scss';
 interface Props {
   performers: TheScenePerformer[];
   className?: string;
+  onSelect?: (performer: TheScenePerformer) => void;
 }
 
-export function PerformerStoriesBar({ performers, className }: Props) {
+export function PerformerStoriesBar({ performers, className, onSelect }: Props) {
   if (!performers || performers.length === 0) return null;
 
   return (
@@ -31,6 +32,19 @@ export function PerformerStoriesBar({ performers, className }: Props) {
               <span className={styles.name}>{performer.name}</span>
             </>
           );
+
+          if (onSelect) {
+            return (
+              <button
+                key={performer.participant_id}
+                type="button"
+                className={styles.item}
+                onClick={() => onSelect(performer)}
+              >
+                {content}
+              </button>
+            );
+          }
 
           return performer.slug ? (
             <Link

--- a/app/frontend/Core/PerformerStoriesBar/PerformerStoriesBar.tsx
+++ b/app/frontend/Core/PerformerStoriesBar/PerformerStoriesBar.tsx
@@ -1,0 +1,54 @@
+import { Link } from 'react-router-dom';
+
+import { TheScenePerformer } from '@cctv/types';
+
+import styles from './PerformerStoriesBar.module.scss';
+
+interface Props {
+  performers: TheScenePerformer[];
+  className?: string;
+}
+
+export function PerformerStoriesBar({ performers, className }: Props) {
+  if (!performers || performers.length === 0) return null;
+
+  return (
+    <div className={`${styles.root} ${className ?? ''}`}>
+      <div className={styles.scroller}>
+        {performers.map((performer) => {
+          const initial = (performer.name?.charAt(0) ?? '?').toUpperCase();
+          const content = (
+            <>
+              <div className={styles.ringWrap}>
+                <div className={styles.avatar}>
+                  {performer.photo_url ? (
+                    <img src={performer.photo_url} alt={performer.name} />
+                  ) : (
+                    <span className={styles.initial}>{initial}</span>
+                  )}
+                </div>
+              </div>
+              <span className={styles.name}>{performer.name}</span>
+            </>
+          );
+
+          return performer.slug ? (
+            <Link
+              key={performer.participant_id}
+              to={`/performers/${performer.slug}`}
+              className={styles.item}
+            >
+              {content}
+            </Link>
+          ) : (
+            <div key={performer.participant_id} className={styles.item}>
+              {content}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default PerformerStoriesBar;

--- a/app/frontend/Experiences/TheScene/BuzzerPanel.module.scss
+++ b/app/frontend/Experiences/TheScene/BuzzerPanel.module.scss
@@ -1,0 +1,25 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.5rem 1rem;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: 1.6rem;
+  color: var(--phosphor);
+  text-shadow: 0 0 12px var(--phosphor-glow-strong);
+  letter-spacing: 0.08em;
+  margin: 0;
+}
+
+.subtitle {
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  color: var(--hot-white);
+  opacity: 0.85;
+  text-align: center;
+  margin: 0 0 0.5rem;
+}

--- a/app/frontend/Experiences/TheScene/BuzzerPanel.stories.tsx
+++ b/app/frontend/Experiences/TheScene/BuzzerPanel.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { BuzzerPanel } from './BuzzerPanel';
+
+const meta: Meta<typeof BuzzerPanel> = {
+  title: 'Experiences/TheScene/BuzzerPanel',
+  component: BuzzerPanel,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div style={{ background: 'var(--deep)', padding: '1rem', minHeight: 480 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof BuzzerPanel>;
+
+export const LockedWaiting: Story = {
+  args: { blockId: 'demo', activeSuggestionCount: 0 },
+};
+
+export const LockedOneSuggestion: Story = {
+  args: { blockId: 'demo', activeSuggestionCount: 1 },
+};
+
+export const Armed: Story = {
+  args: { blockId: 'demo', activeSuggestionCount: 3 },
+};

--- a/app/frontend/Experiences/TheScene/BuzzerPanel.tsx
+++ b/app/frontend/Experiences/TheScene/BuzzerPanel.tsx
@@ -1,0 +1,37 @@
+import { GlassCaseButton } from '@cctv/core/GlassCaseButton/GlassCaseButton';
+import { useTheScene } from '@cctv/hooks/useTheScene';
+
+import styles from './BuzzerPanel.module.scss';
+
+interface Props {
+  blockId: string;
+  activeSuggestionCount: number;
+}
+
+export function BuzzerPanel({ blockId, activeSuggestionCount }: Props) {
+  const { pressBuzzer } = useTheScene();
+  const locked = activeSuggestionCount < 2;
+
+  return (
+    <div className={styles.root}>
+      <p className={styles.title}>You hold the buzzer</p>
+      <p className={styles.subtitle}>
+        {locked
+          ? `Waiting on ${2 - activeSuggestionCount} more suggestion${
+              2 - activeSuggestionCount === 1 ? '' : 's'
+            }…`
+          : 'Break the glass when the scene needs to end.'}
+      </p>
+      <GlassCaseButton
+        locked={locked}
+        label="BREAK GLASS"
+        lockedLabel="LOCKED"
+        onPress={() => {
+          void pressBuzzer(blockId);
+        }}
+      />
+    </div>
+  );
+}
+
+export default BuzzerPanel;

--- a/app/frontend/Experiences/TheScene/TheScene.module.scss
+++ b/app/frontend/Experiences/TheScene/TheScene.module.scss
@@ -216,6 +216,27 @@
   box-shadow: 0 0 18px var(--phosphor-glow);
 }
 
+.leaderboardWinner {
+  animation: winnerPulse 1.2s ease-in-out infinite alternate;
+  transform-origin: center;
+  z-index: 2;
+}
+
+@keyframes winnerPulse {
+  from {
+    transform: scale(1);
+    box-shadow: 0 0 18px var(--phosphor-glow);
+    border-color: var(--phosphor);
+  }
+  to {
+    transform: scale(1.04);
+    box-shadow:
+      0 0 36px var(--phosphor-glow-strong),
+      0 0 80px var(--phosphor-glow-medium);
+    border-color: var(--amber);
+  }
+}
+
 .leaderboardRank {
   font-family: var(--font-display);
   font-size: 2rem;
@@ -284,4 +305,51 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.performersConfig {
+  border: 1px dashed var(--phosphor-glow-medium);
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  font-family: var(--font-body);
+
+  summary {
+    cursor: pointer;
+    font-family: var(--font-display);
+    letter-spacing: 0.08em;
+    color: var(--phosphor);
+  }
+}
+
+.performerList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 0.5rem;
+  max-height: 16rem;
+  overflow-y: auto;
+}
+
+.performerRow {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  padding: 0.2rem 0.3rem;
+  cursor: pointer;
+
+  input[type='checkbox'] {
+    accent-color: var(--phosphor);
+  }
+}
+
+.performerBadge {
+  font-family: var(--font-display);
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  color: var(--black);
+  background: var(--phosphor);
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  margin-left: auto;
 }

--- a/app/frontend/Experiences/TheScene/TheScene.stories.tsx
+++ b/app/frontend/Experiences/TheScene/TheScene.stories.tsx
@@ -1,0 +1,196 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { BlockKind, TheSceneBlock, TheScenePerformer, TheSceneSuggestion } from '@cctv/types';
+
+import { ExperienceSeeder } from '../../../../.storybook/ExperienceSeeder';
+import { lobbyExperience } from '../../../../.storybook/fixtures';
+import TheScene from './TheScene';
+
+const performers: TheScenePerformer[] = [
+  {
+    participant_id: 'p1',
+    user_id: 'u1',
+    name: 'Maya Carter',
+    slug: 'maya-carter',
+    photo_url: 'https://i.pravatar.cc/120?img=1',
+    has_performer_profile: true,
+  },
+  {
+    participant_id: 'p2',
+    user_id: 'u2',
+    name: 'Jordan Ali',
+    slug: 'jordan-ali',
+    photo_url: 'https://i.pravatar.cc/120?img=12',
+    has_performer_profile: true,
+  },
+];
+
+const sampleSuggestions: TheSceneSuggestion[] = [
+  { id: 's1', text: 'A wedding on the moon', participant_id: 'p3', vote_count: 5, rank: 1 },
+  {
+    id: 's2',
+    text: 'Dentist appointment gone wrong',
+    participant_id: 'p4',
+    vote_count: 3,
+    rank: 2,
+  },
+  { id: 's3', text: 'Two raccoons in a trenchcoat', participant_id: 'p5', vote_count: 2, rank: 3 },
+  { id: 's4', text: 'First day at a haunted DMV', participant_id: 'p6', vote_count: 1, rank: 4 },
+];
+
+function build(overrides: Partial<TheSceneBlock['payload']> = {}): TheSceneBlock {
+  return {
+    id: 'scene-1',
+    kind: BlockKind.THE_SCENE,
+    status: 'open',
+    position: 0,
+    payload: {
+      phase: 'collecting',
+      scene_started_at: new Date().toISOString(),
+      winner_revealed_at: null,
+      leaderboard_size: 5,
+      prompt_input_count: 3,
+      performer_participant_ids: performers.map((p) => p.participant_id),
+      prompt_participant_ids: [],
+      buzzer_participant_id: null,
+      leaderboard: sampleSuggestions,
+      performers,
+      is_prompt_recipient: false,
+      is_buzzer_holder: false,
+      is_performer: false,
+      ...overrides,
+    },
+  };
+}
+
+const meta: Meta<typeof TheScene> = {
+  title: 'Experiences/TheScene',
+  component: TheScene,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <ExperienceSeeder experience={lobbyExperience}>
+        <Story />
+      </ExperienceSeeder>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof TheScene>;
+
+export const ParticipantIdle: Story = {
+  args: {
+    block: build({ phase: 'idle', leaderboard: [] }),
+    viewContext: 'participant',
+  },
+};
+
+export const ParticipantPromptInput: Story = {
+  args: {
+    block: build({ is_prompt_recipient: true, leaderboard: [] }),
+    viewContext: 'participant',
+  },
+};
+
+export const ParticipantWaitingForOthers: Story = {
+  args: {
+    block: build({ leaderboard: [sampleSuggestions[0]] }),
+    viewContext: 'participant',
+  },
+};
+
+export const ParticipantVoting: Story = {
+  args: {
+    block: build({ leaderboard: sampleSuggestions }),
+    viewContext: 'participant',
+  },
+};
+
+export const ParticipantBuzzerHolderLocked: Story = {
+  args: {
+    block: build({ is_buzzer_holder: true, leaderboard: [] }),
+    viewContext: 'participant',
+  },
+};
+
+export const ParticipantBuzzerHolderArmed: Story = {
+  args: {
+    block: build({ is_buzzer_holder: true, leaderboard: sampleSuggestions }),
+    viewContext: 'participant',
+  },
+};
+
+export const ParticipantAsPerformer: Story = {
+  args: {
+    block: build({ is_performer: true }),
+    viewContext: 'participant',
+  },
+};
+
+export const ParticipantWinnerReveal: Story = {
+  args: {
+    block: build({
+      phase: 'winner_reveal',
+      leaderboard: sampleSuggestions,
+      winner_revealed_at: new Date().toISOString(),
+    }),
+    viewContext: 'participant',
+  },
+};
+
+export const MonitorIdle: Story = {
+  args: {
+    block: build({ phase: 'idle', leaderboard: [] }),
+    viewContext: 'monitor',
+  },
+};
+
+export const MonitorCollecting: Story = {
+  args: {
+    block: build({ leaderboard: sampleSuggestions }),
+    viewContext: 'monitor',
+  },
+};
+
+export const MonitorWinnerReveal: Story = {
+  args: {
+    block: build({
+      phase: 'winner_reveal',
+      leaderboard: sampleSuggestions,
+      winner_revealed_at: new Date().toISOString(),
+    }),
+    viewContext: 'monitor',
+  },
+};
+
+export const ManageIdle: Story = {
+  args: {
+    block: build({ phase: 'idle', leaderboard: [], all_suggestions: [] }),
+    viewContext: 'manage',
+  },
+};
+
+export const ManageCollecting: Story = {
+  args: {
+    block: build({
+      leaderboard: sampleSuggestions,
+      all_suggestions: sampleSuggestions,
+      prompt_participant_ids: ['p3', 'p4', 'p5'],
+      buzzer_participant_id: 'p6',
+    }),
+    viewContext: 'manage',
+  },
+};
+
+export const ManageWinnerReveal: Story = {
+  args: {
+    block: build({
+      phase: 'winner_reveal',
+      leaderboard: sampleSuggestions,
+      all_suggestions: sampleSuggestions,
+      winner_revealed_at: new Date().toISOString(),
+    }),
+    viewContext: 'manage',
+  },
+};

--- a/app/frontend/Experiences/TheScene/TheScene.tsx
+++ b/app/frontend/Experiences/TheScene/TheScene.tsx
@@ -1,9 +1,13 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 
+import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { useExperienceState } from '@cctv/contexts/ExperienceStateContext';
 import { Button } from '@cctv/core/Button/Button';
+import { PerformerStoriesBar } from '@cctv/core/PerformerStoriesBar/PerformerStoriesBar';
 import { useTheScene } from '@cctv/hooks/useTheScene';
-import { TheSceneBlock, TheSceneSuggestion } from '@cctv/types';
+import { ExperienceParticipant, TheSceneBlock } from '@cctv/types';
+
+import { BuzzerPanel } from './BuzzerPanel';
 
 import styles from './TheScene.module.scss';
 
@@ -28,120 +32,236 @@ export default function TheScene({ block, viewContext = 'participant' }: Props) 
 function ParticipantView({ block }: { block: TheSceneBlock }) {
   const { submitSuggestion, submitVote, isSubmitting } = useTheScene();
   const { submissionState } = useExperienceState();
-  const { phase } = block.payload;
+  const { phase, leaderboard, performers, is_prompt_recipient, is_buzzer_holder, is_performer } =
+    block.payload;
+
+  const activeSuggestionCount = leaderboard.length;
+  const votingOpen = phase === 'collecting' && activeSuggestionCount >= 2;
   const blockState = submissionState[block.id];
   const own_suggestion = blockState?.own_suggestion ?? null;
   const own_vote_suggestion_id = blockState?.own_vote_suggestion_id ?? null;
-  const votable_suggestions = useMemo(
-    () =>
-      phase === 'voting' && own_suggestion
-        ? block.payload.leaderboard.filter((s) => s.id !== own_suggestion.id)
-        : [],
-    [phase, own_suggestion, block.payload.leaderboard],
-  );
-  const [text, setText] = useState('');
+  const [editing, setEditing] = useState(false);
+  const [text, setText] = useState(own_suggestion?.text ?? '');
 
-  // Reset local input whenever the user has no active own suggestion (i.e. between scenes / after clear).
   useEffect(() => {
-    if (!own_suggestion) setText('');
+    if (!own_suggestion) {
+      setText('');
+      setEditing(false);
+    }
   }, [own_suggestion]);
+
+  const votableSuggestions = useMemo(
+    () =>
+      votingOpen && own_suggestion
+        ? leaderboard.filter((s) => s.id !== own_suggestion.id)
+        : votingOpen
+          ? leaderboard
+          : [],
+    [votingOpen, own_suggestion, leaderboard],
+  );
+
+  const stories = <PerformerStoriesBar performers={performers} />;
 
   if (phase === 'idle') {
     return (
-      <div className={styles.root}>
+      <Shell stories={stories}>
         <p className={styles.heading}>Waiting for the next scene…</p>
-      </div>
+      </Shell>
     );
   }
 
   if (phase === 'ended') {
     return (
-      <div className={styles.root}>
+      <Shell stories={stories}>
         <p className={styles.heading}>Scene ended</p>
         <p className={styles.subheading}>See the monitor for the winning suggestion.</p>
-      </div>
+      </Shell>
     );
   }
 
-  // No suggestion yet → input.
-  if (!own_suggestion) {
-    const remaining = MAX_SUGGESTION_LENGTH - text.length;
-    const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
-      e.preventDefault();
-      const trimmed = text.trim();
-      if (!trimmed) return;
-      const result = await submitSuggestion(block.id, trimmed);
-      if (result?.success) setText('');
-    };
-
+  if (phase === 'winner_reveal') {
     return (
-      <div className={styles.root}>
-        <p className={styles.heading}>Drop a suggestion</p>
-        <p className={styles.subheading}>One per scene. Make it weird, make it specific.</p>
-        <form className={styles.suggestionForm} onSubmit={handleSubmit}>
-          <input
-            className={styles.input}
-            type="text"
-            maxLength={MAX_SUGGESTION_LENGTH}
-            placeholder="A wedding on the moon…"
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-            disabled={isSubmitting}
-            autoFocus
-          />
-          <span className={styles.charCount}>{remaining} characters left</span>
-          <Button type="submit" loading={isSubmitting} loadingText="Submitting...">
-            Submit suggestion
+      <Shell stories={stories}>
+        <p className={styles.heading}>Scene ended!</p>
+        <p className={styles.subheading}>Watch the monitor for the winning prompt.</p>
+      </Shell>
+    );
+  }
+
+  if (is_performer) {
+    return (
+      <Shell stories={stories}>
+        <p className={styles.heading}>You're on stage</p>
+        <p className={styles.subheading}>Sit back — the audience is picking your scene.</p>
+      </Shell>
+    );
+  }
+
+  if (is_buzzer_holder) {
+    return (
+      <Shell stories={stories}>
+        <BuzzerPanel blockId={block.id} activeSuggestionCount={activeSuggestionCount} />
+      </Shell>
+    );
+  }
+
+  // Prompt recipient flows.
+  if (is_prompt_recipient) {
+    // Show input when no submission yet OR when explicitly editing.
+    if (!own_suggestion || editing) {
+      const remaining = MAX_SUGGESTION_LENGTH - text.length;
+      const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        const trimmed = text.trim();
+        if (!trimmed) return;
+        const result = await submitSuggestion(block.id, trimmed);
+        if (result?.success) {
+          setEditing(false);
+        }
+      };
+
+      return (
+        <Shell stories={stories}>
+          <p className={styles.heading}>{editing ? 'Edit your suggestion' : 'Drop a suggestion'}</p>
+          <p className={styles.subheading}>
+            {editing
+              ? 'Your votes will stick to your suggestion.'
+              : 'Make it weird, make it specific.'}
+          </p>
+          <form className={styles.suggestionForm} onSubmit={handleSubmit}>
+            <input
+              className={styles.input}
+              type="text"
+              maxLength={MAX_SUGGESTION_LENGTH}
+              placeholder="A wedding on the moon…"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              disabled={isSubmitting}
+              autoFocus
+            />
+            <span className={styles.charCount}>{remaining} characters left</span>
+            <Button type="submit" loading={isSubmitting} loadingText="Submitting...">
+              {editing ? 'Save' : 'Submit suggestion'}
+            </Button>
+            {editing && (
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => {
+                  setText(own_suggestion?.text ?? '');
+                  setEditing(false);
+                }}
+              >
+                Cancel
+              </Button>
+            )}
+          </form>
+        </Shell>
+      );
+    }
+
+    // Submitted — show voting (or waiting) with edit affordance.
+    return (
+      <Shell stories={stories}>
+        <div className={styles.manageRow}>
+          <Button
+            variant="ghost"
+            onClick={() => {
+              setText(own_suggestion.text);
+              setEditing(true);
+            }}
+          >
+            ← Edit suggestion
           </Button>
-        </form>
-      </div>
-    );
-  }
-
-  // Submitted but voting isn't open yet → patience screen.
-  if (phase === 'collecting') {
-    return (
-      <div className={styles.root}>
-        <p className={styles.patienceTitle}>You're in!</p>
-        <div className={styles.ownSuggestion}>"{own_suggestion.text}"</div>
-        <div className={styles.patience}>
-          <span>Waiting for the voting to open</span>
-          <span>
-            <span className={styles.dotPulse} />
-            <span className={styles.dotPulse} />
-            <span className={styles.dotPulse} />
-          </span>
         </div>
+        <p className={styles.heading}>{votingOpen ? 'Vote' : "You're in!"}</p>
+        <div className={styles.ownSuggestion}>Your suggestion: "{own_suggestion.text}"</div>
+        <VotingBody
+          blockId={block.id}
+          votingOpen={votingOpen}
+          activeSuggestionCount={activeSuggestionCount}
+          choices={votableSuggestions}
+          ownVoteSuggestionId={own_vote_suggestion_id}
+          onVote={(id) => void submitVote(block.id, id)}
+        />
+      </Shell>
+    );
+  }
+
+  // Non-prompt-recipient (and non-buzzer, non-performer): observer / voter.
+  return (
+    <Shell stories={stories}>
+      <p className={styles.heading}>{votingOpen ? 'Vote' : 'Waiting on suggestions'}</p>
+      <VotingBody
+        blockId={block.id}
+        votingOpen={votingOpen}
+        activeSuggestionCount={activeSuggestionCount}
+        choices={votableSuggestions}
+        ownVoteSuggestionId={own_vote_suggestion_id}
+        onVote={(id) => void submitVote(block.id, id)}
+      />
+    </Shell>
+  );
+}
+
+function Shell({ stories, children }: { stories: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <div>
+      {stories}
+      <div className={styles.root}>{children}</div>
+    </div>
+  );
+}
+
+function VotingBody({
+  votingOpen,
+  activeSuggestionCount,
+  choices,
+  ownVoteSuggestionId,
+  onVote,
+}: {
+  blockId: string;
+  votingOpen: boolean;
+  activeSuggestionCount: number;
+  choices: TheSceneBlock['payload']['leaderboard'];
+  ownVoteSuggestionId: string | null;
+  onVote: (id: string) => void;
+}) {
+  if (!votingOpen) {
+    return (
+      <div className={styles.patience}>
+        <span>
+          Need {Math.max(0, 2 - activeSuggestionCount)} more suggestion
+          {Math.max(0, 2 - activeSuggestionCount) === 1 ? '' : 's'} before voting opens
+        </span>
+        <span>
+          <span className={styles.dotPulse} />
+          <span className={styles.dotPulse} />
+          <span className={styles.dotPulse} />
+        </span>
       </div>
     );
   }
 
-  // phase === 'voting' and we have own_suggestion → render voting list (excludes own).
-  const choices = votable_suggestions ?? [];
   return (
-    <div className={styles.root}>
-      <p className={styles.heading}>Vote</p>
-      <p className={styles.subheading}>Tap to vote. Tap a different one to change your mind.</p>
-      <div className={styles.ownSuggestion}>Your suggestion: "{own_suggestion.text}"</div>
-      <div className={styles.votingList}>
-        {choices.length === 0 && (
-          <p className={styles.subheading}>No other suggestions yet — hang tight.</p>
-        )}
-        {choices.map((s) => {
-          const active = own_vote_suggestion_id === s.id;
-          return (
-            <button
-              key={s.id}
-              type="button"
-              className={`${styles.voteRow} ${active ? styles.voteRowActive : ''}`}
-              onClick={() => submitVote(block.id, s.id)}
-            >
-              <span>{s.text}</span>
-              <span className={styles.voteCount}>{s.vote_count}</span>
-            </button>
-          );
-        })}
-      </div>
+    <div className={styles.votingList}>
+      {choices.length === 0 && (
+        <p className={styles.subheading}>No other suggestions yet — hang tight.</p>
+      )}
+      {choices.map((s) => {
+        const active = ownVoteSuggestionId === s.id;
+        return (
+          <button
+            key={s.id}
+            type="button"
+            className={`${styles.voteRow} ${active ? styles.voteRowActive : ''}`}
+            onClick={() => onVote(s.id)}
+          >
+            <span>{s.text}</span>
+            <span className={styles.voteCount}>{s.vote_count}</span>
+          </button>
+        );
+      })}
     </div>
   );
 }
@@ -149,8 +269,9 @@ function ParticipantView({ block }: { block: TheSceneBlock }) {
 const ROW_HEIGHT_PX = 76;
 
 function MonitorView({ block }: { block: TheSceneBlock }) {
-  const { phase, leaderboard, leaderboard_size } = block.payload;
+  const { phase, leaderboard, leaderboard_size, winner_revealed_at } = block.payload;
   const top = leaderboard.slice(0, leaderboard_size);
+  const revealing = phase === 'winner_reveal';
 
   if (phase === 'idle') {
     return (
@@ -163,47 +284,117 @@ function MonitorView({ block }: { block: TheSceneBlock }) {
 
   return (
     <div className={styles.monitorRoot}>
-      <p className={styles.monitorTitle}>{phase === 'ended' ? 'Scene ended' : 'The Scene'}</p>
+      <p className={styles.monitorTitle}>
+        {phase === 'ended' ? 'Scene ended' : revealing ? 'And the winner is…' : 'The Scene'}
+      </p>
       <p className={styles.monitorPhase}>
-        {phase === 'collecting' && 'Collecting suggestions'}
-        {phase === 'voting' && 'Voting'}
+        {phase === 'collecting' && 'Live'}
+        {revealing && 'Winner reveal'}
         {phase === 'ended' && 'Final results'}
       </p>
-      <Leaderboard suggestions={top} />
+      <Leaderboard suggestions={top} reveal={revealing} revealKey={winner_revealed_at} />
     </div>
   );
 }
 
-function Leaderboard({ suggestions }: { suggestions: TheSceneSuggestion[] }) {
-  // Maintain stable index-positions per suggestion id so rows can transition
-  // between rank slots smoothly even when their list index changes.
+function Leaderboard({
+  suggestions,
+  reveal,
+  revealKey,
+}: {
+  suggestions: TheSceneBlock['payload']['leaderboard'];
+  reveal: boolean;
+  revealKey: string | null;
+}) {
   const containerHeight = Math.max(suggestions.length * ROW_HEIGHT_PX, ROW_HEIGHT_PX);
 
   return (
     <div className={styles.monitorLeaderboard} style={{ height: containerHeight }}>
-      {suggestions.map((s, index) => (
-        <div
-          key={s.id}
-          className={styles.leaderboardRow}
-          data-rank={s.rank}
-          style={{ top: `${index * ROW_HEIGHT_PX}px` }}
-        >
-          <span className={styles.leaderboardRank}>#{s.rank}</span>
-          <span className={styles.leaderboardText}>{s.text}</span>
-          <span className={styles.leaderboardVotes}>{s.vote_count}</span>
-        </div>
-      ))}
+      {suggestions.map((s, index) => {
+        const isWinner = reveal && s.rank === 1;
+        return (
+          <div
+            key={s.id}
+            className={`${styles.leaderboardRow} ${isWinner ? styles.leaderboardWinner : ''}`}
+            data-rank={s.rank}
+            data-reveal-key={isWinner ? (revealKey ?? '') : undefined}
+            style={{ top: `${index * ROW_HEIGHT_PX}px` }}
+          >
+            <span className={styles.leaderboardRank}>#{s.rank}</span>
+            <span className={styles.leaderboardText}>{s.text}</span>
+            <span className={styles.leaderboardVotes}>{s.vote_count}</span>
+          </div>
+        );
+      })}
     </div>
   );
 }
 
 function ManageView({ block }: { block: TheSceneBlock }) {
-  const { advancePhase, nextScene, clearTop, clearAll, clearSuggestion } = useTheScene();
-  const { phase, all_suggestions = [] } = block.payload;
+  const { experience } = useExperience();
+  const {
+    startScene,
+    endScene,
+    forceNextScene,
+    updatePerformers,
+    clearTop,
+    clearAll,
+    clearSuggestion,
+  } = useTheScene();
+
+  const {
+    phase,
+    prompt_participant_ids = [],
+    buzzer_participant_id,
+    performer_participant_ids = [],
+    performers: performerSummaries = [],
+    all_suggestions = [],
+  } = block.payload;
+
+  const participants = useMemo(() => {
+    if (!experience) return [] as ExperienceParticipant[];
+    return [...(experience.hosts || []), ...(experience.participants || [])];
+  }, [experience]);
+
+  const participantById = useMemo(() => {
+    const map = new Map<string, ExperienceParticipant>();
+    participants.forEach((p) => map.set(p.id, p));
+    return map;
+  }, [participants]);
+
+  const performerProfileUserIds = useMemo(
+    () => new Set(performerSummaries.filter((p) => p.has_performer_profile).map((p) => p.user_id)),
+    [performerSummaries],
+  );
+
+  const sortedParticipants = useMemo(() => {
+    const eligible = participants.filter((p) => p.role !== 'host' && p.role !== 'moderator');
+    return eligible.slice().sort((a, b) => {
+      const aHas = performerProfileUserIds.has(a.user_id) ? 0 : 1;
+      const bHas = performerProfileUserIds.has(b.user_id) ? 0 : 1;
+      if (aHas !== bHas) return aHas - bHas;
+      return a.name.localeCompare(b.name);
+    });
+  }, [participants, performerProfileUserIds]);
+
   const totalVotes = useMemo(
     () => all_suggestions.reduce((sum, s) => sum + s.vote_count, 0),
     [all_suggestions],
   );
+
+  const togglePerformer = (participantId: string) => {
+    const next = performer_participant_ids.includes(participantId)
+      ? performer_participant_ids.filter((id) => id !== participantId)
+      : [...performer_participant_ids, participantId];
+    void updatePerformers(block.id, next);
+  };
+
+  const promptNames = prompt_participant_ids
+    .map((id) => participantById.get(id)?.name ?? id.slice(0, 6))
+    .join(', ');
+  const buzzerName = buzzer_participant_id
+    ? (participantById.get(buzzer_participant_id)?.name ?? buzzer_participant_id.slice(0, 6))
+    : '—';
 
   return (
     <div className={styles.manageRoot}>
@@ -212,24 +403,30 @@ function ManageView({ block }: { block: TheSceneBlock }) {
         scene: {totalVotes}
       </p>
 
+      <p className={styles.manageStat}>
+        Prompt recipients: <strong>{promptNames || '—'}</strong> • Buzzer:{' '}
+        <strong>{buzzerName}</strong>
+      </p>
+
       <div className={styles.manageRow}>
-        {phase === 'idle' && (
-          <Button onClick={() => advancePhase(block.id, 'collecting')}>Open scene</Button>
-        )}
+        {phase === 'idle' && <Button onClick={() => startScene(block.id)}>Start scene</Button>}
         {phase === 'collecting' && (
           <>
-            <Button onClick={() => advancePhase(block.id, 'voting')}>Open voting</Button>
-            <Button variant="secondary" onClick={() => advancePhase(block.id, 'ended')}>
-              End scene
+            <Button onClick={() => forceNextScene(block.id)}>Force next scene</Button>
+            <Button variant="secondary" onClick={() => endScene(block.id)}>
+              End block
             </Button>
           </>
         )}
-        {phase === 'voting' && (
-          <Button variant="secondary" onClick={() => advancePhase(block.id, 'ended')}>
-            End scene
-          </Button>
+        {phase === 'winner_reveal' && (
+          <>
+            <Button onClick={() => forceNextScene(block.id)}>Skip wait → next scene</Button>
+            <Button variant="secondary" onClick={() => endScene(block.id)}>
+              End block
+            </Button>
+          </>
         )}
-        {phase === 'ended' && <Button onClick={() => nextScene(block.id)}>Next scene</Button>}
+        {phase === 'ended' && <Button onClick={() => startScene(block.id)}>Restart scene</Button>}
       </div>
 
       <div className={styles.manageRow}>
@@ -248,6 +445,26 @@ function ManageView({ block }: { block: TheSceneBlock }) {
           Clear all
         </Button>
       </div>
+
+      <details className={styles.performersConfig}>
+        <summary>Performers ({performer_participant_ids.length})</summary>
+        <div className={styles.performerList}>
+          {sortedParticipants.map((p) => {
+            const selected = performer_participant_ids.includes(p.id);
+            const hasProfile = performerProfileUserIds.has(p.user_id);
+            return (
+              <label key={p.id} className={styles.performerRow}>
+                <input type="checkbox" checked={selected} onChange={() => togglePerformer(p.id)} />
+                <span>{p.name}</span>
+                {hasProfile && <span className={styles.performerBadge}>Performer</span>}
+              </label>
+            );
+          })}
+          {sortedParticipants.length === 0 && (
+            <p className={styles.subheading}>No eligible participants.</p>
+          )}
+        </div>
+      </details>
 
       {all_suggestions.length > 0 && (
         <div className={styles.manageList}>

--- a/app/frontend/Experiences/TheScene/TheScene.tsx
+++ b/app/frontend/Experiences/TheScene/TheScene.tsx
@@ -120,20 +120,34 @@ function ParticipantView({ block }: { block: TheSceneBlock }) {
         }
       };
 
+      const insertPerformerName = (name: string) => {
+        setText((current) => {
+          const separator = current && !/\s$/.test(current) ? ' ' : '';
+          return `${current}${separator}${name}`.slice(0, MAX_SUGGESTION_LENGTH);
+        });
+      };
+
+      const inputStories = (
+        <PerformerStoriesBar
+          performers={performers}
+          onSelect={(p) => insertPerformerName(p.name)}
+        />
+      );
+
       return (
-        <Shell stories={stories}>
+        <Shell stories={inputStories}>
           <p className={styles.heading}>{editing ? 'Edit your suggestion' : 'Drop a suggestion'}</p>
           <p className={styles.subheading}>
             {editing
               ? 'Your votes will stick to your suggestion.'
-              : 'Make it weird, make it specific.'}
+              : "The ideal suggestion, continues the narrative. For example: Jordan's character is now a doctor on a first date."}
           </p>
           <form className={styles.suggestionForm} onSubmit={handleSubmit}>
             <input
               className={styles.input}
               type="text"
               maxLength={MAX_SUGGESTION_LENGTH}
-              placeholder="A wedding on the moon…"
+              placeholder="Taylor eats a bowl of hair…"
               value={text}
               onChange={(e) => setText(e.target.value)}
               disabled={isSubmitting}

--- a/app/frontend/Hooks/useTheScene.ts
+++ b/app/frontend/Hooks/useTheScene.ts
@@ -3,7 +3,6 @@ import { useCallback, useState } from 'react';
 import { useAdminAuth } from '@cctv/contexts/AdminAuthContext';
 import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { useExperienceState } from '@cctv/contexts/ExperienceStateContext';
-import { TheScenePhase } from '@cctv/types';
 
 interface ActionResult {
   success: boolean;
@@ -17,25 +16,24 @@ export function useTheScene() {
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const buildAdminUrl = useCallback(
+  const buildUrl = useCallback(
     (blockId: string, path: string) =>
       `/api/experiences/${encodeURIComponent(code ?? '')}/blocks/${encodeURIComponent(blockId)}/the_scene/${path}`,
     [code],
   );
 
-  const buildParticipantUrl = useCallback(
-    (blockId: string, path: string) =>
-      `/api/experiences/${encodeURIComponent(code ?? '')}/blocks/${encodeURIComponent(blockId)}/the_scene/${path}`,
-    [code],
-  );
-
-  const adminPost = useCallback(
-    async (blockId: string, path: string, body?: object): Promise<ActionResult> => {
+  const adminRequest = useCallback(
+    async (
+      method: 'POST' | 'PATCH',
+      blockId: string,
+      path: string,
+      body?: object,
+    ): Promise<ActionResult> => {
       if (!code) return { success: false, error: 'Missing experience code' };
       setError(null);
       try {
-        const res = await adminFetch(buildAdminUrl(blockId, path), {
-          method: 'POST',
+        const res = await adminFetch(buildUrl(blockId, path), {
+          method,
           ...(body !== undefined && { body: JSON.stringify(body) }),
         });
         const data = await res.json();
@@ -54,21 +52,40 @@ export function useTheScene() {
         return { success: false, error: msg };
       }
     },
-    [code, adminFetch, buildAdminUrl],
+    [code, adminFetch, buildUrl],
   );
 
-  const advancePhase = useCallback(
-    (blockId: string, phase: TheScenePhase) => adminPost(blockId, 'phase', { phase }),
-    [adminPost],
+  const startScene = useCallback(
+    (blockId: string) => adminRequest('POST', blockId, 'start'),
+    [adminRequest],
   );
-
-  const nextScene = useCallback((blockId: string) => adminPost(blockId, 'next'), [adminPost]);
-  const clearTop = useCallback((blockId: string) => adminPost(blockId, 'clear_top'), [adminPost]);
-  const clearAll = useCallback((blockId: string) => adminPost(blockId, 'clear_all'), [adminPost]);
+  const endScene = useCallback(
+    (blockId: string) => adminRequest('POST', blockId, 'end'),
+    [adminRequest],
+  );
+  const forceNextScene = useCallback(
+    (blockId: string) => adminRequest('POST', blockId, 'force_next_scene'),
+    [adminRequest],
+  );
+  const updatePerformers = useCallback(
+    (blockId: string, performerParticipantIds: string[]) =>
+      adminRequest('PATCH', blockId, 'performers', {
+        performer_participant_ids: performerParticipantIds,
+      }),
+    [adminRequest],
+  );
+  const clearTop = useCallback(
+    (blockId: string) => adminRequest('POST', blockId, 'clear_top'),
+    [adminRequest],
+  );
+  const clearAll = useCallback(
+    (blockId: string) => adminRequest('POST', blockId, 'clear_all'),
+    [adminRequest],
+  );
   const clearSuggestion = useCallback(
     (blockId: string, suggestionId: string) =>
-      adminPost(blockId, `clear/${encodeURIComponent(suggestionId)}`),
-    [adminPost],
+      adminRequest('POST', blockId, `clear/${encodeURIComponent(suggestionId)}`),
+    [adminRequest],
   );
 
   const submitSuggestion = useCallback(
@@ -77,7 +94,7 @@ export function useTheScene() {
       setIsSubmitting(true);
       setError(null);
       try {
-        const res = await experienceFetch(buildParticipantUrl(blockId, 'suggestions'), {
+        const res = await experienceFetch(buildUrl(blockId, 'suggestions'), {
           method: 'POST',
           body: JSON.stringify({ text }),
         });
@@ -108,7 +125,7 @@ export function useTheScene() {
         setIsSubmitting(false);
       }
     },
-    [code, experienceFetch, buildParticipantUrl, setSubmissionState],
+    [code, experienceFetch, buildUrl, setSubmissionState],
   );
 
   const submitVote = useCallback(
@@ -116,7 +133,7 @@ export function useTheScene() {
       if (!code) return { success: false, error: 'Missing experience code' };
       setError(null);
       try {
-        const res = await experienceFetch(buildParticipantUrl(blockId, 'votes'), {
+        const res = await experienceFetch(buildUrl(blockId, 'votes'), {
           method: 'POST',
           body: JSON.stringify({ suggestion_id: suggestionId }),
         });
@@ -142,17 +159,45 @@ export function useTheScene() {
         return { success: false, error: msg };
       }
     },
-    [code, experienceFetch, buildParticipantUrl, setSubmissionState],
+    [code, experienceFetch, buildUrl, setSubmissionState],
+  );
+
+  const pressBuzzer = useCallback(
+    async (blockId: string): Promise<ActionResult> => {
+      if (!code) return { success: false, error: 'Missing experience code' };
+      setError(null);
+      try {
+        const res = await experienceFetch(buildUrl(blockId, 'buzzer'), { method: 'POST' });
+        const data = await res.json();
+        if (!res.ok || !data?.success) {
+          const msg = data?.error || 'Failed to press buzzer';
+          setError(msg);
+          return { success: false, error: msg };
+        }
+        return { success: true };
+      } catch (e: unknown) {
+        const msg =
+          e instanceof Error && e.message === 'Authentication expired'
+            ? 'Authentication expired'
+            : 'Connection error. Please try again.';
+        setError(msg);
+        return { success: false, error: msg };
+      }
+    },
+    [code, experienceFetch, buildUrl],
   );
 
   return {
-    advancePhase,
-    nextScene,
+    startScene,
+    endScene,
+    forceNextScene,
+    updatePerformers,
     clearTop,
     clearAll,
     clearSuggestion,
     submitSuggestion,
     submitVote,
+    pressBuzzer,
     isSubmitting,
     error,
   };

--- a/app/frontend/Pages/Manage/CreateBlock/CreateTheScene/CreateTheScene.module.scss
+++ b/app/frontend/Pages/Manage/CreateBlock/CreateTheScene/CreateTheScene.module.scss
@@ -1,0 +1,58 @@
+.help {
+  font-size: 0.85rem;
+  opacity: 0.8;
+  font-family: var(--font-body);
+  margin: 0.25rem 0;
+}
+
+.performersField {
+  border: 1px solid var(--phosphor-glow-medium);
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  font-family: var(--font-body);
+
+  legend {
+    font-family: var(--font-display);
+    letter-spacing: 0.1em;
+    color: var(--phosphor);
+    padding: 0 0.5rem;
+  }
+}
+
+.performerList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  max-height: 18rem;
+  overflow-y: auto;
+  margin-top: 0.5rem;
+}
+
+.performerRow {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  padding: 0.25rem 0.4rem;
+  cursor: pointer;
+  border-radius: 0.25rem;
+
+  input[type='checkbox'] {
+    accent-color: var(--phosphor);
+  }
+
+  &:hover {
+    background: color-mix(in srgb, var(--phosphor) 6%, transparent);
+  }
+}
+
+.performerBadge {
+  font-family: var(--font-display);
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  color: var(--black);
+  background: var(--phosphor);
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  margin-left: auto;
+}

--- a/app/frontend/Pages/Manage/CreateBlock/CreateTheScene/CreateTheScene.tsx
+++ b/app/frontend/Pages/Manage/CreateBlock/CreateTheScene/CreateTheScene.tsx
@@ -1,4 +1,7 @@
+import { useMemo } from 'react';
+
 import { TextInput } from '@cctv/core/TextInput/TextInput';
+import { usePerformers } from '@cctv/hooks/usePerformers';
 import {
   BlockComponentProps,
   BlockKind,
@@ -10,14 +13,20 @@ import {
 } from '@cctv/types';
 
 import sharedStyles from '../CreateBlock.module.scss';
+import styles from './CreateTheScene.module.scss';
 
 export const getDefaultTheSceneState = (): TheSceneData => ({
   leaderboard_size: 5,
+  prompt_input_count: 3,
+  performer_participant_ids: [],
 });
 
 export const validateTheScene = (data: TheSceneData): string | null => {
   if (!Number.isInteger(data.leaderboard_size) || data.leaderboard_size <= 0) {
     return 'Leaderboard size must be a positive whole number';
+  }
+  if (!Number.isInteger(data.prompt_input_count) || data.prompt_input_count <= 0) {
+    return 'Prompt input count must be a positive whole number';
   }
   return null;
 };
@@ -25,6 +34,8 @@ export const validateTheScene = (data: TheSceneData): string | null => {
 export const buildTheScenePayload = (data: TheSceneData): TheSceneApiPayload => ({
   type: BlockKind.THE_SCENE,
   leaderboard_size: data.leaderboard_size,
+  prompt_input_count: data.prompt_input_count,
+  performer_participant_ids: data.performer_participant_ids,
 });
 
 export const canTheSceneOpenImmediately = (
@@ -40,9 +51,38 @@ export const processTheSceneBeforeSubmit = (
 
 export const theScenePayloadToFormData = (payload: TheScenePayload): TheSceneData => ({
   leaderboard_size: payload.leaderboard_size,
+  prompt_input_count: payload.prompt_input_count ?? 3,
+  performer_participant_ids: payload.performer_participant_ids ?? [],
 });
 
-export default function CreateTheScene({ data, onChange }: BlockComponentProps<TheSceneData>) {
+export default function CreateTheScene({
+  data,
+  onChange,
+  participants = [],
+}: BlockComponentProps<TheSceneData>) {
+  const { performers } = usePerformers();
+
+  const performerUserIds = useMemo(
+    () => new Set(performers.map((p) => p.user_id).filter(Boolean) as string[]),
+    [performers],
+  );
+
+  const sortedParticipants = useMemo(() => {
+    const eligible = participants.filter((p) => p.role !== 'host' && p.role !== 'moderator');
+    return eligible.slice().sort((a, b) => {
+      const aHas = performerUserIds.has(a.user_id) ? 0 : 1;
+      const bHas = performerUserIds.has(b.user_id) ? 0 : 1;
+      if (aHas !== bHas) return aHas - bHas;
+      return a.name.localeCompare(b.name);
+    });
+  }, [participants, performerUserIds]);
+
+  const togglePerformer = (id: string) => {
+    const ids = data.performer_participant_ids ?? [];
+    const next = ids.includes(id) ? ids.filter((x) => x !== id) : [...ids, id];
+    onChange?.({ performer_participant_ids: next });
+  };
+
   return (
     <div className={sharedStyles.container}>
       <TextInput
@@ -55,11 +95,48 @@ export default function CreateTheScene({ data, onChange }: BlockComponentProps<T
           onChange?.({ leaderboard_size: Number.isNaN(value) ? 0 : value });
         }}
       />
-      <p style={{ fontSize: '0.85rem', opacity: 0.8 }}>
-        How many top suggestions show on the monitor leaderboard. The audience can vote on any
-        active suggestion — the leaderboard just controls how many ranks render publicly.
+      <p className={styles.help}>How many top suggestions show on the monitor leaderboard.</p>
+
+      <TextInput
+        label="Prompt recipients per scene"
+        type="number"
+        min={1}
+        value={data.prompt_input_count || ''}
+        onChange={(e) => {
+          const value = parseInt(e.target.value, 10);
+          onChange?.({ prompt_input_count: Number.isNaN(value) ? 0 : value });
+        }}
+      />
+      <p className={styles.help}>
+        Random audience members who receive the suggestion input each scene. One additional
+        participant gets the buzzer.
       </p>
-      <p style={{ fontSize: '0.85rem', opacity: 0.8 }}>
+
+      <fieldset className={styles.performersField}>
+        <legend>Performers ({(data.performer_participant_ids ?? []).length})</legend>
+        <p className={styles.help}>
+          Performers won't be dispatched suggestion inputs or the buzzer. Members with a Performer
+          profile are listed first.
+        </p>
+        <div className={styles.performerList}>
+          {sortedParticipants.map((p) => {
+            const selected = (data.performer_participant_ids ?? []).includes(p.id);
+            const hasProfile = performerUserIds.has(p.user_id);
+            return (
+              <label key={p.id} className={styles.performerRow}>
+                <input type="checkbox" checked={selected} onChange={() => togglePerformer(p.id)} />
+                <span>{p.name}</span>
+                {hasProfile && <span className={styles.performerBadge}>Performer</span>}
+              </label>
+            );
+          })}
+          {sortedParticipants.length === 0 && (
+            <p className={styles.help}>Invite participants first to assign performers.</p>
+          )}
+        </div>
+      </fieldset>
+
+      <p className={styles.help}>
         A segment is required — set it under "Additional Details". Suggestions persist across scenes
         unless cleared. Votes reset each scene.
       </p>

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -218,7 +218,7 @@ export interface MinigameBalloonPumpLiveResult {
   fill_amount: number;
 }
 
-export type TheScenePhase = 'idle' | 'collecting' | 'voting' | 'ended';
+export type TheScenePhase = 'idle' | 'collecting' | 'winner_reveal' | 'ended';
 
 export interface TheSceneSuggestion {
   id: string;
@@ -228,11 +228,29 @@ export interface TheSceneSuggestion {
   rank: number;
 }
 
+export interface TheScenePerformer {
+  participant_id: string;
+  user_id: string;
+  name: string;
+  slug: string | null;
+  photo_url: string | null;
+  has_performer_profile: boolean;
+}
+
 export interface TheScenePayload {
   phase: TheScenePhase;
   scene_started_at: string | null;
+  winner_revealed_at: string | null;
   leaderboard_size: number;
+  prompt_input_count: number;
+  performer_participant_ids: string[];
+  prompt_participant_ids: string[];
+  buzzer_participant_id: string | null;
   leaderboard: TheSceneSuggestion[];
+  performers: TheScenePerformer[];
+  is_prompt_recipient: boolean;
+  is_buzzer_holder: boolean;
+  is_performer: boolean;
   all_suggestions?: TheSceneSuggestion[];
 }
 
@@ -311,6 +329,8 @@ export interface MinigameArithmeticApiPayload {
 export interface TheSceneApiPayload {
   type: 'the_scene';
   leaderboard_size: number;
+  prompt_input_count: number;
+  performer_participant_ids: string[];
 }
 
 export interface MinigameBalloonPumpApiPayload {
@@ -900,6 +920,7 @@ export function isDrawingUpdateMessage(msg: ExperienceChannelMessage): msg is Dr
 
 export interface Performer {
   id: string;
+  user_id?: string;
   name: string;
   bio: string | null;
   slug: string;
@@ -1012,6 +1033,8 @@ export interface MinigameBalloonPumpData {
 
 export interface TheSceneData {
   leaderboard_size: number;
+  prompt_input_count: number;
+  performer_participant_ids: string[];
 }
 
 // Union type for all block component data

--- a/app/jobs/the_scene_advance_after_reveal_job.rb
+++ b/app/jobs/the_scene_advance_after_reveal_job.rb
@@ -1,0 +1,21 @@
+class TheSceneAdvanceAfterRevealJob < ApplicationJob
+  queue_as :default
+
+  discard_on ActiveRecord::RecordNotFound
+
+  def perform(block_id, expected_scene_started_at)
+    block = ExperienceBlock.find(block_id)
+    return unless block.kind == ExperienceBlock::THE_SCENE
+
+    payload = block.payload || {}
+    return unless payload["phase"] == "winner_reveal"
+    return unless payload["scene_started_at"] == expected_scene_started_at
+
+    experience = block.experience
+
+    Experiences::Orchestrator.new(experience: experience, actor: experience.creator)
+      .start_next_scene!(block: block)
+
+    Experiences::Broadcaster.new(experience).broadcast_experience_update
+  end
+end

--- a/app/policies/experience_block_policy.rb
+++ b/app/policies/experience_block_policy.rb
@@ -31,6 +31,10 @@ class ExperienceBlockPolicy < ApplicationPolicy
     user_allowed_to_interact_with_block?
   end
 
+  def press_the_scene_buzzer?
+    user_allowed_to_interact_with_block?
+  end
+
   private
 
   def user_allowed_to_interact_with_block?

--- a/app/serializers/performer_serializer.rb
+++ b/app/serializers/performer_serializer.rb
@@ -28,6 +28,7 @@ class PerformerSerializer
   def self.serialize_summary(performer, current_user: nil)
     {
       id: performer.id,
+      user_id: performer.user_id,
       name: performer.name,
       bio: performer.bio,
       slug: performer.slug,

--- a/app/services/experiences/orchestrator.rb
+++ b/app/services/experiences/orchestrator.rb
@@ -1250,10 +1250,6 @@ module Experiences
       # Reserve a buzzer first when possible so the scene can always be ended.
       buzzer_id  = eligible.shift if eligible.length > 1
       prompt_ids = eligible.first(prompt_count)
-      # If only one eligible, give them the prompt and leave buzzer empty.
-      if buzzer_id.nil? && eligible.length == 1 && prompt_count.positive?
-        prompt_ids = [eligible.first]
-      end
 
       payload["prompt_participant_ids"] = prompt_ids
       payload["buzzer_participant_id"]  = buzzer_id

--- a/app/services/experiences/orchestrator.rb
+++ b/app/services/experiences/orchestrator.rb
@@ -84,9 +84,19 @@ module Experiences
         leaderboard_size = payload["leaderboard_size"].to_i
         raise ArgumentError, "leaderboard_size must be positive" unless leaderboard_size.positive?
 
-        payload["leaderboard_size"] = leaderboard_size
-        payload["phase"]            = "idle"
-        payload["scene_started_at"] = nil
+        prompt_input_count = payload["prompt_input_count"].present? ? payload["prompt_input_count"].to_i : 3
+        raise ArgumentError, "prompt_input_count must be positive" unless prompt_input_count.positive?
+
+        performer_ids = Array(payload["performer_participant_ids"]).map(&:to_s).uniq
+
+        payload["leaderboard_size"]          = leaderboard_size
+        payload["prompt_input_count"]        = prompt_input_count
+        payload["performer_participant_ids"] = performer_ids
+        payload["prompt_participant_ids"]    = []
+        payload["buzzer_participant_id"]     = nil
+        payload["phase"]                     = "idle"
+        payload["scene_started_at"]          = nil
+        payload["winner_revealed_at"]        = nil
       when ExperienceBlock::GUESS_WHO
         payload["eligibility_threshold"] ||= 0.10
         payload["monitor_view"]            = "idle"
@@ -951,50 +961,107 @@ module Experiences
 
     # The Scene -------------------------------------------------------------
 
-    SCENE_PHASES = %w[idle collecting voting ended].freeze
+    SCENE_PHASES = %w[idle collecting winner_reveal ended].freeze
+    WINNER_REVEAL_DELAY_SECONDS = 15
 
-    def advance_the_scene_phase!(block:, phase:)
-      raise ArgumentError, "Unknown phase: #{phase}" unless SCENE_PHASES.include?(phase.to_s)
-      raise ArgumentError, "Block is not a Scene" unless block.kind == ExperienceBlock::THE_SCENE
+    def start_the_scene!(block:)
+      guard_the_scene!(block)
 
       transaction do
-        payload = block.payload || {}
-        payload["phase"] = phase.to_s
+        payload = block.payload.deep_dup || {}
+        payload["phase"] = "collecting"
+        payload["scene_started_at"] = next_scene_stamp(payload["scene_started_at"])
+        payload["winner_revealed_at"] = nil
+        assign_scene_roles!(payload)
+        block.update!(payload: payload, status: :open)
+      end
 
-        # First time we leave idle, stamp scene_started_at so votes scope cleanly.
-        if payload["phase"] != "idle" && payload["scene_started_at"].blank?
-          payload["scene_started_at"] = Time.current.iso8601(6)
+      block
+    end
+
+    def press_the_scene_buzzer!(block:)
+      guard_the_scene!(block)
+
+      payload = block.payload || {}
+      raise Experiences::InvalidTransitionError, "Buzzer is not active" unless payload["phase"] == "collecting"
+
+      participant = current_participant
+      raise Experiences::ForbiddenError, "Only the buzzer holder can press the buzzer" unless payload["buzzer_participant_id"] == participant.id
+
+      active_count = block.improv_suggestions.active.where(created_at: scene_window(payload)).count
+      raise Experiences::InvalidTransitionError, "Need at least 2 suggestions before ending the scene" if active_count < 2
+
+      scene_stamp = nil
+      transaction do
+        updated = block.payload.deep_dup
+        updated["phase"] = "winner_reveal"
+        updated["winner_revealed_at"] = Time.current.iso8601(6)
+        scene_stamp = updated["scene_started_at"]
+        block.update!(payload: updated, status: :open)
+      end
+
+      TheSceneAdvanceAfterRevealJob.set(wait: WINNER_REVEAL_DELAY_SECONDS.seconds)
+        .perform_later(block.id, scene_stamp)
+
+      block
+    end
+
+    def force_next_scene!(block:)
+      guard_the_scene!(block)
+      start_next_scene!(block: block)
+    end
+
+    def end_the_scene!(block:)
+      guard_the_scene!(block)
+
+      transaction do
+        payload = block.payload.deep_dup
+        payload["phase"] = "ended"
+        payload["prompt_participant_ids"] = []
+        payload["buzzer_participant_id"] = nil
+        block.update!(payload: payload, status: :closed)
+      end
+
+      block
+    end
+
+    def update_the_scene_performers!(block:, performer_participant_ids:)
+      guard_the_scene!(block)
+
+      ids = Array(performer_participant_ids).map(&:to_s).uniq
+      valid_ids = experience.experience_participants.where(id: ids).pluck(:id).map(&:to_s)
+
+      transaction do
+        payload = block.payload.deep_dup
+        payload["performer_participant_ids"] = valid_ids
+
+        if %w[collecting].include?(payload["phase"])
+          prompts = Array(payload["prompt_participant_ids"]).map(&:to_s) - valid_ids
+          buzzer  = payload["buzzer_participant_id"]
+          buzzer  = nil if valid_ids.include?(buzzer.to_s)
+          payload["prompt_participant_ids"] = prompts
+          payload["buzzer_participant_id"]  = buzzer
+
+          if prompts.empty? || buzzer.nil?
+            assign_scene_roles!(payload)
+          end
         end
 
-        new_status =
-          case payload["phase"]
-          when "idle"   then :hidden
-          when "ended"  then :closed
-          else               :open
-          end
-
-        block.update!(payload: payload, status: new_status)
+        block.update!(payload: payload)
       end
 
       block
     end
 
     def start_next_scene!(block:)
-      raise ArgumentError, "Block is not a Scene" unless block.kind == ExperienceBlock::THE_SCENE
+      guard_the_scene!(block)
 
       transaction do
-        payload = block.payload || {}
-        prior = payload["scene_started_at"]
-        candidate = Time.current.iso8601(6)
-
-        # Guarantee strict monotonic increase even if the host clicks
-        # twice in the same microsecond.
-        if prior.present? && candidate <= prior
-          candidate = (Time.iso8601(prior) + 0.001.seconds).iso8601(6)
-        end
-
-        payload["phase"]            = "collecting"
-        payload["scene_started_at"] = candidate
+        payload = block.payload.deep_dup || {}
+        payload["phase"]              = "collecting"
+        payload["scene_started_at"]   = next_scene_stamp(payload["scene_started_at"])
+        payload["winner_revealed_at"] = nil
+        assign_scene_roles!(payload)
         block.update!(payload: payload, status: :open)
       end
 
@@ -1002,38 +1069,54 @@ module Experiences
     end
 
     def submit_the_scene_suggestion!(block:, text:)
-      raise ArgumentError, "Block is not a Scene" unless block.kind == ExperienceBlock::THE_SCENE
+      guard_the_scene!(block)
 
       payload = block.payload || {}
-      raise Experiences::InvalidTransitionError, "Scene is not collecting suggestions" unless %w[collecting voting].include?(payload["phase"])
+      raise Experiences::InvalidTransitionError, "Scene is not collecting suggestions" unless payload["phase"] == "collecting"
+
+      participant = current_participant
+      eligible_ids = Array(payload["prompt_participant_ids"]).map(&:to_s)
+      raise Experiences::ForbiddenError, "You are not selected to submit a prompt this scene" unless eligible_ids.include?(participant.id)
 
       trimmed = text.to_s.strip
       raise ArgumentError, "Suggestion cannot be blank" if trimmed.empty?
       raise ArgumentError, "Suggestion is too long (#{ImprovSuggestion::MAX_LENGTH} max)" if trimmed.length > ImprovSuggestion::MAX_LENGTH
 
       transaction do
-        existing = block.improv_suggestions.active.find_by(experience_participant: current_participant)
-        raise Experiences::InvalidTransitionError, "You already submitted this scene" if existing
+        existing = block.improv_suggestions.active
+          .where(created_at: scene_window(payload))
+          .find_by(experience_participant: participant)
 
-        block.improv_suggestions.create!(experience_participant: current_participant, text: trimmed)
+        if existing
+          existing.update!(text: trimmed)
+          existing
+        else
+          block.improv_suggestions.create!(experience_participant: participant, text: trimmed)
+        end
       end
     end
 
     def submit_the_scene_vote!(block:, suggestion_id:)
-      raise ArgumentError, "Block is not a Scene" unless block.kind == ExperienceBlock::THE_SCENE
+      guard_the_scene!(block)
 
       payload = block.payload || {}
-      raise Experiences::InvalidTransitionError, "Voting is not open" unless payload["phase"] == "voting"
+      raise Experiences::InvalidTransitionError, "Voting is not open" unless payload["phase"] == "collecting"
+
+      participant = current_participant
+      raise Experiences::ForbiddenError, "Buzzer holder cannot vote" if payload["buzzer_participant_id"] == participant.id
 
       scene_started_at = payload["scene_started_at"]
       raise Experiences::InvalidTransitionError, "Scene has not started" if scene_started_at.blank?
 
+      active_count = block.improv_suggestions.active.where(created_at: scene_window(payload)).count
+      raise Experiences::InvalidTransitionError, "Voting opens once 2 suggestions are in" if active_count < 2
+
       suggestion = block.improv_suggestions.active.find(suggestion_id)
-      raise ArgumentError, "Cannot vote for your own suggestion" if suggestion.experience_participant_id == current_participant.id
+      raise ArgumentError, "Cannot vote for your own suggestion" if suggestion.experience_participant_id == participant.id
 
       transaction do
         vote = ImprovVote
-          .where(experience_block_id: block.id, experience_participant: current_participant, scene_started_at: scene_started_at)
+          .where(experience_block_id: block.id, experience_participant: participant, scene_started_at: scene_started_at)
           .first_or_initialize
 
         vote.improv_suggestion_id = suggestion.id
@@ -1134,6 +1217,47 @@ module Experiences
     end
 
     private
+
+    def guard_the_scene!(block)
+      raise ArgumentError, "Block is not a Scene" unless block.kind == ExperienceBlock::THE_SCENE
+    end
+
+    def next_scene_stamp(prior)
+      candidate = Time.current.iso8601(6)
+      return candidate if prior.blank?
+      return candidate if candidate > prior
+      (Time.iso8601(prior) + 0.001.seconds).iso8601(6)
+    end
+
+    def scene_window(payload)
+      start = payload["scene_started_at"]
+      return (Time.at(0)..) if start.blank?
+      Time.iso8601(start)..
+    end
+
+    def assign_scene_roles!(payload)
+      performers = Array(payload["performer_participant_ids"]).map(&:to_s).to_set
+      prompt_count = payload["prompt_input_count"].to_i
+      prompt_count = 3 if prompt_count <= 0
+
+      eligible = experience.experience_participants
+        .where.not(role: %w[host moderator])
+        .pluck(:id)
+        .map(&:to_s)
+        .reject { |id| performers.include?(id) }
+        .shuffle
+
+      # Reserve a buzzer first when possible so the scene can always be ended.
+      buzzer_id  = eligible.shift if eligible.length > 1
+      prompt_ids = eligible.first(prompt_count)
+      # If only one eligible, give them the prompt and leave buzzer empty.
+      if buzzer_id.nil? && eligible.length == 1 && prompt_count.positive?
+        prompt_ids = [eligible.first]
+      end
+
+      payload["prompt_participant_ids"] = prompt_ids
+      payload["buzzer_participant_id"]  = buzzer_id
+    end
 
     def default_sounds_for(kind)
       case kind.to_s

--- a/app/services/experiences/visibility.rb
+++ b/app/services/experiences/visibility.rb
@@ -255,7 +255,7 @@ module Experiences
 
     def shape_the_scene_payload(block, participant_role, participant, view_context)
       payload          = block.payload.deep_dup || {}
-      phase            = payload["phase"] || "idle"
+      phase            = legacy_the_scene_phase(payload["phase"])
       scene_started_at = payload["scene_started_at"]
       leaderboard_size = payload["leaderboard_size"].to_i
 
@@ -265,18 +265,70 @@ module Experiences
 
       tally = TheScene::Tally.full(block: block, scene_started_at: scene_started_at)
 
+      performer_ids = Array(payload["performer_participant_ids"]).map(&:to_s)
+      prompt_ids    = Array(payload["prompt_participant_ids"]).map(&:to_s)
+      buzzer_id     = payload["buzzer_participant_id"]
+
       shaped = {
-        "phase"            => phase,
-        "scene_started_at" => scene_started_at,
-        "leaderboard_size" => leaderboard_size,
-        "leaderboard"      => tally.first(leaderboard_size).map { |entry| serialize_tally_entry(entry) }
+        "phase"                     => phase,
+        "scene_started_at"          => scene_started_at,
+        "winner_revealed_at"        => payload["winner_revealed_at"],
+        "leaderboard_size"          => leaderboard_size,
+        "prompt_input_count"        => (payload["prompt_input_count"] || 3).to_i,
+        "performer_participant_ids" => performer_ids,
+        "prompt_participant_ids"    => privileged ? prompt_ids : [],
+        "buzzer_participant_id"     => privileged ? buzzer_id : nil,
+        "leaderboard"               => tally.first(leaderboard_size).map { |entry| serialize_tally_entry(entry) },
+        "performers"                => the_scene_performer_summaries(performer_ids)
       }
+
+      if participant && view_context == :participant
+        shaped["is_prompt_recipient"] = prompt_ids.include?(participant.id)
+        shaped["is_buzzer_holder"]    = buzzer_id.to_s == participant.id
+        shaped["is_performer"]        = performer_ids.include?(participant.id)
+      else
+        shaped["is_prompt_recipient"] = false
+        shaped["is_buzzer_holder"]    = false
+        shaped["is_performer"]        = false
+      end
 
       if privileged
         shaped["all_suggestions"] = tally.map { |entry| serialize_tally_entry(entry) }
       end
 
       shaped
+    end
+
+    def legacy_the_scene_phase(phase)
+      case phase.to_s
+      when "voting" then "collecting"
+      when "", nil  then "idle"
+      else phase.to_s
+      end
+    end
+
+    def the_scene_performer_summaries(performer_participant_ids)
+      return [] if performer_participant_ids.empty?
+
+      participants = @experience.experience_participants
+        .includes(:user)
+        .where(id: performer_participant_ids)
+        .to_a
+
+      user_ids = participants.map(&:user_id)
+      performers_by_user_id = Performer.where(user_id: user_ids).index_by(&:user_id)
+
+      participants.map do |p|
+        performer = performers_by_user_id[p.user_id]
+        {
+          "participant_id" => p.id,
+          "user_id"        => p.user_id,
+          "name"           => performer&.name.presence || p.name,
+          "slug"           => performer&.slug,
+          "photo_url"      => performer&.photo_url,
+          "has_performer_profile" => performer.present?
+        }
+      end
     end
 
     def serialize_tally_entry(entry)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,8 +109,11 @@ Rails.application.routes.draw do
           post 'minigame/balloon_pump/end', action: :end_minigame_balloon_pump
           post 'minigame/balloon_pump/pump', action: :submit_minigame_balloon_pump_update
 
-          post 'the_scene/phase', action: :advance_the_scene_phase
-          post 'the_scene/next', action: :start_next_the_scene
+          post 'the_scene/start', action: :start_the_scene
+          post 'the_scene/end', action: :end_the_scene
+          post 'the_scene/force_next_scene', action: :force_next_the_scene
+          patch 'the_scene/performers', action: :update_the_scene_performers
+          post 'the_scene/buzzer', action: :press_the_scene_buzzer
           post 'the_scene/clear_top', action: :clear_the_scene_top
           post 'the_scene/clear/:suggestion_id', action: :clear_the_scene_suggestion
           post 'the_scene/clear_all', action: :clear_the_scene_all

--- a/spec/jobs/the_scene_advance_after_reveal_job_spec.rb
+++ b/spec/jobs/the_scene_advance_after_reveal_job_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe TheSceneAdvanceAfterRevealJob do
+  let(:creator) { create(:user) }
+  let(:experience) { create(:experience, status: :live, creator: creator) }
+  let!(:host) { create(:experience_participant, :host, user: creator, experience: experience) }
+  let!(:player_a) { create(:experience_participant, :audience, experience: experience) }
+  let!(:player_b) { create(:experience_participant, :audience, experience: experience) }
+  let!(:player_c) { create(:experience_participant, :audience, experience: experience) }
+  let!(:player_d) { create(:experience_participant, :audience, experience: experience) }
+  let!(:player_e) { create(:experience_participant, :audience, experience: experience) }
+
+  let(:orchestrator) { Experiences::Orchestrator.new(experience: experience, actor: creator) }
+
+  let(:block) do
+    orchestrator.add_block!(
+      kind: ExperienceBlock::THE_SCENE,
+      payload: { "leaderboard_size" => 5, "prompt_input_count" => 2 }
+    )
+  end
+
+  def setup_winner_reveal
+    orchestrator.start_the_scene!(block: block)
+    prompts = block.reload.payload["prompt_participant_ids"]
+    r_a = experience.experience_participants.find(prompts[0])
+    r_b = experience.experience_participants.find(prompts[1])
+    Experiences::Orchestrator.new(experience: experience, actor: r_a.user).submit_the_scene_suggestion!(block: block, text: "a")
+    Experiences::Orchestrator.new(experience: experience, actor: r_b.user).submit_the_scene_suggestion!(block: block, text: "b")
+    buzzer = experience.experience_participants.find(block.reload.payload["buzzer_participant_id"])
+    Experiences::Orchestrator.new(experience: experience, actor: buzzer.user).press_the_scene_buzzer!(block: block)
+    block.reload
+  end
+
+  it "advances to the next scene and broadcasts when scene_started_at matches" do
+    setup_winner_reveal
+    scene_stamp = block.payload["scene_started_at"]
+
+    expect_any_instance_of(Experiences::Broadcaster).to receive(:broadcast_experience_update)
+    described_class.perform_now(block.id, scene_stamp)
+
+    payload = block.reload.payload
+    expect(payload["phase"]).to eq("collecting")
+    expect(payload["scene_started_at"]).not_to eq(scene_stamp)
+    expect(payload["winner_revealed_at"]).to be_nil
+  end
+
+  it "is a no-op when scene_started_at has already changed" do
+    setup_winner_reveal
+    stale_stamp = "1999-01-01T00:00:00.000000Z"
+
+    expect_any_instance_of(Experiences::Broadcaster).not_to receive(:broadcast_experience_update)
+    described_class.perform_now(block.id, stale_stamp)
+
+    expect(block.reload.payload["phase"]).to eq("winner_reveal")
+  end
+
+  it "is a no-op when phase has already left winner_reveal" do
+    setup_winner_reveal
+    scene_stamp = block.payload["scene_started_at"]
+
+    orchestrator.start_next_scene!(block: block)
+
+    expect_any_instance_of(Experiences::Broadcaster).not_to receive(:broadcast_experience_update)
+    described_class.perform_now(block.id, scene_stamp)
+  end
+
+  it "discards on missing block" do
+    expect {
+      described_class.perform_now("00000000-0000-0000-0000-000000000000", "x")
+    }.not_to raise_error
+  end
+end

--- a/spec/services/experiences/the_scene_orchestrator_spec.rb
+++ b/spec/services/experiences/the_scene_orchestrator_spec.rb
@@ -7,13 +7,19 @@ RSpec.describe Experiences::Orchestrator, "the scene" do
   let!(:player_a)  { create(:experience_participant, :audience, experience: experience) }
   let!(:player_b)  { create(:experience_participant, :audience, experience: experience) }
   let!(:player_c)  { create(:experience_participant, :audience, experience: experience) }
+  let!(:player_d)  { create(:experience_participant, :audience, experience: experience) }
+  let!(:player_e)  { create(:experience_participant, :audience, experience: experience) }
 
   subject(:orchestrator) { described_class.new(actor: host_user, experience: experience) }
 
   let(:block) do
     orchestrator.add_block!(
       kind: ExperienceBlock::THE_SCENE,
-      payload: { "leaderboard_size" => 5 }
+      payload: {
+        "leaderboard_size"          => 5,
+        "prompt_input_count"        => 3,
+        "performer_participant_ids" => []
+      }
     )
   end
 
@@ -21,11 +27,42 @@ RSpec.describe Experiences::Orchestrator, "the scene" do
     described_class.new(actor: participant.user, experience: experience)
   end
 
+  def prompt_holders(blk)
+    blk.reload.payload["prompt_participant_ids"].map(&:to_s)
+  end
+
+  def buzzer_holder(blk)
+    blk.reload.payload["buzzer_participant_id"]
+  end
+
   describe "#add_block!" do
-    it "creates a Scene block in idle phase with the configured leaderboard size" do
+    it "creates a Scene block in idle phase with configured fields" do
       expect(block.payload["phase"]).to eq("idle")
       expect(block.payload["leaderboard_size"]).to eq(5)
+      expect(block.payload["prompt_input_count"]).to eq(3)
+      expect(block.payload["performer_participant_ids"]).to eq([])
+      expect(block.payload["prompt_participant_ids"]).to eq([])
+      expect(block.payload["buzzer_participant_id"]).to be_nil
       expect(block.payload["scene_started_at"]).to be_nil
+    end
+
+    it "defaults prompt_input_count to 3 when omitted" do
+      blk = orchestrator.add_block!(
+        kind: ExperienceBlock::THE_SCENE,
+        payload: { "leaderboard_size" => 5 }
+      )
+      expect(blk.payload["prompt_input_count"]).to eq(3)
+    end
+
+    it "stores performer_participant_ids when provided" do
+      blk = orchestrator.add_block!(
+        kind: ExperienceBlock::THE_SCENE,
+        payload: {
+          "leaderboard_size" => 5,
+          "performer_participant_ids" => [player_a.id, player_b.id]
+        }
+      )
+      expect(blk.payload["performer_participant_ids"]).to contain_exactly(player_a.id, player_b.id)
     end
 
     it "raises when leaderboard_size is missing" do
@@ -35,184 +72,307 @@ RSpec.describe Experiences::Orchestrator, "the scene" do
     end
   end
 
-  describe "#advance_the_scene_phase!" do
-    it "transitions through phases and stamps scene_started_at" do
-      orchestrator.advance_the_scene_phase!(block: block, phase: "collecting")
-      block.reload
-      expect(block.payload["phase"]).to eq("collecting")
-      expect(block.payload["scene_started_at"]).to be_present
+  describe "#start_the_scene!" do
+    it "transitions to collecting and stamps scene_started_at" do
+      orchestrator.start_the_scene!(block: block)
+      payload = block.reload.payload
+      expect(payload["phase"]).to eq("collecting")
+      expect(payload["scene_started_at"]).to be_present
       expect(block.status).to eq("open")
     end
 
-    it "preserves scene_started_at across collecting → voting" do
-      orchestrator.advance_the_scene_phase!(block: block, phase: "collecting")
-      first_stamp = block.reload.payload["scene_started_at"]
+    it "randomly assigns prompt holders and a buzzer holder from non-performer audience" do
+      orchestrator.start_the_scene!(block: block)
 
-      orchestrator.advance_the_scene_phase!(block: block, phase: "voting")
-      expect(block.reload.payload["scene_started_at"]).to eq(first_stamp)
+      prompts = prompt_holders(block)
+      buzzer  = buzzer_holder(block)
+      eligible = [player_a, player_b, player_c, player_d, player_e].map(&:id)
+
+      expect(prompts.size).to eq(3)
+      expect(prompts).to all(be_in(eligible))
+      expect(buzzer).to be_in(eligible)
+      expect(prompts).not_to include(buzzer)
+      expect(prompts).not_to include(host.id)
     end
 
-    it "rejects unknown phases" do
-      expect {
-        orchestrator.advance_the_scene_phase!(block: block, phase: "garbage")
-      }.to raise_error(ArgumentError)
+    it "excludes performers from prompt and buzzer assignment" do
+      orchestrator.update_the_scene_performers!(
+        block: block,
+        performer_participant_ids: [player_a.id, player_b.id]
+      )
+      orchestrator.start_the_scene!(block: block)
+
+      excluded = [player_a.id, player_b.id, host.id]
+      expect(prompt_holders(block)).not_to include(*excluded)
+      expect(buzzer_holder(block)).not_to be_in(excluded)
+    end
+
+    it "picks what's available when prompt_input_count exceeds eligible pool" do
+      orchestrator.update_the_scene_performers!(
+        block: block,
+        performer_participant_ids: [player_a.id, player_b.id, player_c.id]
+      )
+      orchestrator.start_the_scene!(block: block)
+
+      prompts = prompt_holders(block)
+      buzzer  = buzzer_holder(block)
+
+      # 2 eligible, prompt_input_count=3: 1 buzzer reserved, 1 prompt.
+      expect(prompts.size).to eq(1)
+      expect(buzzer).not_to be_nil
+      expect(prompts).not_to include(buzzer)
     end
   end
 
   describe "#submit_the_scene_suggestion!" do
-    before { orchestrator.advance_the_scene_phase!(block: block, phase: "collecting") }
+    before do
+      orchestrator.start_the_scene!(block: block)
+    end
 
-    it "creates an active suggestion for the participant" do
-      suggestion = player_orchestrator(player_a).submit_the_scene_suggestion!(
+    it "accepts a suggestion from a prompt recipient" do
+      recipient = experience.experience_participants.find(prompt_holders(block).first)
+      suggestion = player_orchestrator(recipient).submit_the_scene_suggestion!(
         block: block, text: "  a wedding  "
       )
       expect(suggestion.text).to eq("a wedding")
       expect(suggestion.cleared_at).to be_nil
     end
 
-    it "rejects blank suggestions" do
+    it "rejects suggestions from non-recipients" do
+      non_recipient_id = experience.experience_participants.where.not(role: "host").pluck(:id).map(&:to_s) - prompt_holders(block) - [buzzer_holder(block)]
+      skip "no non-recipient available" if non_recipient_id.empty?
+      non_recipient = experience.experience_participants.find(non_recipient_id.first)
+
       expect {
-        player_orchestrator(player_a).submit_the_scene_suggestion!(block: block, text: "   ")
+        player_orchestrator(non_recipient).submit_the_scene_suggestion!(block: block, text: "no")
+      }.to raise_error(Experiences::ForbiddenError)
+    end
+
+    it "rejects suggestions from the buzzer holder" do
+      buzzer = experience.experience_participants.find(buzzer_holder(block))
+      expect {
+        player_orchestrator(buzzer).submit_the_scene_suggestion!(block: block, text: "nope")
+      }.to raise_error(Experiences::ForbiddenError)
+    end
+
+    it "edits the existing suggestion in place, preserving id and votes" do
+      recipient_id = prompt_holders(block).first
+      recipient = experience.experience_participants.find(recipient_id)
+      first = player_orchestrator(recipient).submit_the_scene_suggestion!(block: block, text: "first")
+      second = player_orchestrator(recipient).submit_the_scene_suggestion!(block: block, text: "second")
+
+      expect(second.id).to eq(first.id)
+      expect(second.text).to eq("second")
+    end
+
+    it "rejects blank suggestions" do
+      recipient = experience.experience_participants.find(prompt_holders(block).first)
+      expect {
+        player_orchestrator(recipient).submit_the_scene_suggestion!(block: block, text: "   ")
       }.to raise_error(ArgumentError)
     end
 
-    it "rejects a second suggestion in the same scene" do
-      player_orchestrator(player_a).submit_the_scene_suggestion!(block: block, text: "first")
-
+    it "rejects suggestions in non-collecting phases" do
+      orchestrator.end_the_scene!(block: block)
+      recipient = experience.experience_participants.find_by(role: "audience")
       expect {
-        player_orchestrator(player_a).submit_the_scene_suggestion!(block: block, text: "second")
-      }.to raise_error(Experiences::InvalidTransitionError)
-    end
-
-    it "allows resubmission after admin clears the prior one" do
-      first = player_orchestrator(player_a).submit_the_scene_suggestion!(block: block, text: "first")
-      orchestrator.clear_the_scene_suggestion!(block: block, suggestion_id: first.id)
-
-      second = player_orchestrator(player_a).submit_the_scene_suggestion!(block: block, text: "second")
-      expect(second.text).to eq("second")
-      expect(second.id).not_to eq(first.id)
-    end
-
-    it "rejects when phase is idle or ended" do
-      orchestrator.advance_the_scene_phase!(block: block, phase: "ended")
-      expect {
-        player_orchestrator(player_a).submit_the_scene_suggestion!(block: block, text: "no")
+        player_orchestrator(recipient).submit_the_scene_suggestion!(block: block, text: "x")
       }.to raise_error(Experiences::InvalidTransitionError)
     end
   end
 
   describe "#submit_the_scene_vote!" do
-    let(:suggestion_a) { player_orchestrator(player_a).submit_the_scene_suggestion!(block: block, text: "a wedding") }
-    let(:suggestion_b) { player_orchestrator(player_b).submit_the_scene_suggestion!(block: block, text: "a circus") }
-
     before do
-      orchestrator.advance_the_scene_phase!(block: block, phase: "collecting")
-      suggestion_a
-      suggestion_b
-      orchestrator.advance_the_scene_phase!(block: block, phase: "voting")
+      orchestrator.start_the_scene!(block: block)
+      prompts = prompt_holders(block)
+      @recipient_a = experience.experience_participants.find(prompts[0])
+      @recipient_b = experience.experience_participants.find(prompts[1])
+      @suggestion_a = player_orchestrator(@recipient_a).submit_the_scene_suggestion!(block: block, text: "a wedding")
+      @suggestion_b = player_orchestrator(@recipient_b).submit_the_scene_suggestion!(block: block, text: "a circus")
     end
 
-    it "records a vote" do
-      vote = player_orchestrator(player_c).submit_the_scene_vote!(
-        block: block, suggestion_id: suggestion_a.id
-      )
-      expect(vote.improv_suggestion_id).to eq(suggestion_a.id)
+    it "records a vote from any audience participant once 2+ suggestions exist" do
+      voter = audience_voter
+      vote = player_orchestrator(voter).submit_the_scene_vote!(block: block, suggestion_id: @suggestion_a.id)
+      expect(vote.improv_suggestion_id).to eq(@suggestion_a.id)
     end
 
-    it "allows changing a vote" do
-      player_orchestrator(player_c).submit_the_scene_vote!(block: block, suggestion_id: suggestion_a.id)
-      player_orchestrator(player_c).submit_the_scene_vote!(block: block, suggestion_id: suggestion_b.id)
+    it "allows changing a vote until the buzzer is pressed" do
+      voter = audience_voter
+      player_orchestrator(voter).submit_the_scene_vote!(block: block, suggestion_id: @suggestion_a.id)
+      player_orchestrator(voter).submit_the_scene_vote!(block: block, suggestion_id: @suggestion_b.id)
 
-      votes = ImprovVote.where(experience_block_id: block.id, experience_participant: player_c).to_a
+      votes = ImprovVote.where(experience_block_id: block.id, experience_participant: voter).to_a
       expect(votes.size).to eq(1)
-      expect(votes.first.improv_suggestion_id).to eq(suggestion_b.id)
+      expect(votes.first.improv_suggestion_id).to eq(@suggestion_b.id)
+    end
+
+    it "rejects votes from the buzzer holder" do
+      buzzer = experience.experience_participants.find(buzzer_holder(block))
+      expect {
+        player_orchestrator(buzzer).submit_the_scene_vote!(block: block, suggestion_id: @suggestion_a.id)
+      }.to raise_error(Experiences::ForbiddenError)
     end
 
     it "rejects voting for own suggestion" do
       expect {
-        player_orchestrator(player_a).submit_the_scene_vote!(block: block, suggestion_id: suggestion_a.id)
+        player_orchestrator(@recipient_a).submit_the_scene_vote!(block: block, suggestion_id: @suggestion_a.id)
       }.to raise_error(ArgumentError)
     end
 
-    it "rejects voting outside the voting phase" do
-      orchestrator.advance_the_scene_phase!(block: block, phase: "ended")
+    it "rejects voting outside collecting phase" do
+      orchestrator.end_the_scene!(block: block)
+      voter = audience_voter
       expect {
-        player_orchestrator(player_c).submit_the_scene_vote!(block: block, suggestion_id: suggestion_a.id)
+        player_orchestrator(voter).submit_the_scene_vote!(block: block, suggestion_id: @suggestion_a.id)
+      }.to raise_error(Experiences::InvalidTransitionError)
+    end
+
+    def audience_voter
+      candidates = experience.experience_participants.where(role: "audience")
+        .where.not(id: [@recipient_a.id, @recipient_b.id, buzzer_holder(block)])
+      candidates.first
+    end
+  end
+
+  describe "#press_the_scene_buzzer!" do
+    before do
+      orchestrator.start_the_scene!(block: block)
+      prompts = prompt_holders(block)
+      @recipient_a = experience.experience_participants.find(prompts[0])
+      @recipient_b = experience.experience_participants.find(prompts[1])
+      @suggestion_a = player_orchestrator(@recipient_a).submit_the_scene_suggestion!(block: block, text: "a wedding")
+      @suggestion_b = player_orchestrator(@recipient_b).submit_the_scene_suggestion!(block: block, text: "a circus")
+    end
+
+    it "transitions to winner_reveal and enqueues the advance job" do
+      buzzer = experience.experience_participants.find(buzzer_holder(block))
+      expect {
+        player_orchestrator(buzzer).press_the_scene_buzzer!(block: block)
+      }.to have_enqueued_job(TheSceneAdvanceAfterRevealJob)
+
+      payload = block.reload.payload
+      expect(payload["phase"]).to eq("winner_reveal")
+      expect(payload["winner_revealed_at"]).to be_present
+    end
+
+    it "rejects presses from non-buzzer-holders" do
+      non_buzzer = experience.experience_participants
+        .where(role: "audience")
+        .where.not(id: buzzer_holder(block))
+        .first
+      expect {
+        player_orchestrator(non_buzzer).press_the_scene_buzzer!(block: block)
+      }.to raise_error(Experiences::ForbiddenError)
+    end
+
+    it "rejects when fewer than 2 suggestions exist" do
+      orchestrator.clear_the_scene_suggestion!(block: block, suggestion_id: @suggestion_b.id)
+      buzzer = experience.experience_participants.find(buzzer_holder(block))
+      expect {
+        player_orchestrator(buzzer).press_the_scene_buzzer!(block: block)
+      }.to raise_error(Experiences::InvalidTransitionError)
+    end
+
+    it "rejects when not in collecting phase" do
+      orchestrator.end_the_scene!(block: block)
+      expect {
+        player_orchestrator(player_a).press_the_scene_buzzer!(block: block)
       }.to raise_error(Experiences::InvalidTransitionError)
     end
   end
 
-  describe "#start_next_scene!" do
-    let(:suggestion_a) { player_orchestrator(player_a).submit_the_scene_suggestion!(block: block, text: "a wedding") }
-    let(:suggestion_b) { player_orchestrator(player_b).submit_the_scene_suggestion!(block: block, text: "a circus") }
-
+  describe "#start_next_scene! / #force_next_scene!" do
     before do
-      orchestrator.advance_the_scene_phase!(block: block, phase: "collecting")
-      suggestion_a
-      suggestion_b
-      orchestrator.advance_the_scene_phase!(block: block, phase: "voting")
-      player_orchestrator(player_c).submit_the_scene_vote!(block: block, suggestion_id: suggestion_a.id)
+      orchestrator.start_the_scene!(block: block)
     end
 
-    it "preserves active suggestions across scenes (rolls forward)" do
-      orchestrator.start_next_scene!(block: block)
-      active_ids = block.improv_suggestions.active.pluck(:id)
-      expect(active_ids).to contain_exactly(suggestion_a.id, suggestion_b.id)
-    end
-
-    it "scopes votes to the new scene_started_at, leaving prior votes inert" do
+    it "re-randomizes prompt and buzzer assignments and bumps scene_started_at" do
       first_stamp = block.reload.payload["scene_started_at"]
+      first_prompts = prompt_holders(block)
+      first_buzzer = buzzer_holder(block)
 
       orchestrator.start_next_scene!(block: block)
       second_stamp = block.reload.payload["scene_started_at"]
-      expect(second_stamp).not_to eq(first_stamp)
 
-      tally = TheScene::Tally.full(block: block.reload, scene_started_at: second_stamp)
-      expect(tally.map(&:vote_count).sum).to eq(0)
+      expect(second_stamp).not_to eq(first_stamp)
+      expect(second_stamp > first_stamp).to be(true)
+
+      new_prompts = prompt_holders(block)
+      new_buzzer  = buzzer_holder(block)
+      expect(new_prompts).not_to include(new_buzzer)
+      expect((first_prompts + [first_buzzer]).any? { |id| ![*new_prompts, new_buzzer].include?(id) }).to be_truthy
     end
 
-    it "lets a participant submit a fresh suggestion in the next scene" do
-      orchestrator.start_next_scene!(block: block)
+    it "force_next_scene! delegates to start_next_scene!" do
+      first_stamp = block.reload.payload["scene_started_at"]
+      orchestrator.force_next_scene!(block: block)
+      expect(block.reload.payload["scene_started_at"]).not_to eq(first_stamp)
+      expect(block.reload.payload["phase"]).to eq("collecting")
+    end
+  end
 
-      expect {
-        player_orchestrator(player_a).submit_the_scene_suggestion!(block: block, text: "another")
-      }.to raise_error(Experiences::InvalidTransitionError),
-        "active suggestion from prior scene should still block resubmission"
+  describe "#update_the_scene_performers!" do
+    it "stores valid performer participant ids" do
+      orchestrator.update_the_scene_performers!(
+        block: block,
+        performer_participant_ids: [player_a.id, player_b.id]
+      )
+      expect(block.reload.payload["performer_participant_ids"]).to contain_exactly(player_a.id, player_b.id)
+    end
 
-      orchestrator.clear_the_scene_suggestion!(block: block, suggestion_id: suggestion_a.id)
-      fresh = player_orchestrator(player_a).submit_the_scene_suggestion!(block: block, text: "another")
-      expect(fresh).to be_persisted
+    it "reassigns prompts/buzzer when an active assignee becomes a performer" do
+      orchestrator.start_the_scene!(block: block)
+      assignee_id = prompt_holders(block).first
+
+      orchestrator.update_the_scene_performers!(
+        block: block,
+        performer_participant_ids: [assignee_id]
+      )
+
+      expect(prompt_holders(block)).not_to include(assignee_id)
+      expect(buzzer_holder(block)).not_to eq(assignee_id)
+    end
+
+    it "ignores unknown participant ids" do
+      orchestrator.update_the_scene_performers!(
+        block: block,
+        performer_participant_ids: ["00000000-0000-0000-0000-000000000000"]
+      )
+      expect(block.reload.payload["performer_participant_ids"]).to eq([])
     end
   end
 
   describe "clear actions" do
-    let(:suggestion_a) { player_orchestrator(player_a).submit_the_scene_suggestion!(block: block, text: "a wedding") }
-    let(:suggestion_b) { player_orchestrator(player_b).submit_the_scene_suggestion!(block: block, text: "a circus") }
-
     before do
-      orchestrator.advance_the_scene_phase!(block: block, phase: "collecting")
-      suggestion_a
-      suggestion_b
-      orchestrator.advance_the_scene_phase!(block: block, phase: "voting")
-      player_orchestrator(player_c).submit_the_scene_vote!(block: block, suggestion_id: suggestion_a.id)
+      orchestrator.start_the_scene!(block: block)
+      prompts = prompt_holders(block)
+      @recipient_a = experience.experience_participants.find(prompts[0])
+      @recipient_b = experience.experience_participants.find(prompts[1])
+      @suggestion_a = player_orchestrator(@recipient_a).submit_the_scene_suggestion!(block: block, text: "a wedding")
+      @suggestion_b = player_orchestrator(@recipient_b).submit_the_scene_suggestion!(block: block, text: "a circus")
+      voter = experience.experience_participants.where(role: "audience")
+        .where.not(id: [@recipient_a.id, @recipient_b.id, buzzer_holder(block)])
+        .first
+      player_orchestrator(voter).submit_the_scene_vote!(block: block, suggestion_id: @suggestion_a.id)
     end
 
     it "clear_top removes the highest-voted suggestion" do
       orchestrator.clear_the_scene_top!(block: block)
-      expect(suggestion_a.reload.cleared_at).to be_present
-      expect(suggestion_b.reload.cleared_at).to be_nil
+      expect(@suggestion_a.reload.cleared_at).to be_present
+      expect(@suggestion_b.reload.cleared_at).to be_nil
     end
 
     it "clear_specific removes the named suggestion" do
-      orchestrator.clear_the_scene_suggestion!(block: block, suggestion_id: suggestion_b.id)
-      expect(suggestion_b.reload.cleared_at).to be_present
-      expect(suggestion_a.reload.cleared_at).to be_nil
+      orchestrator.clear_the_scene_suggestion!(block: block, suggestion_id: @suggestion_b.id)
+      expect(@suggestion_b.reload.cleared_at).to be_present
+      expect(@suggestion_a.reload.cleared_at).to be_nil
     end
 
     it "clear_all removes every active suggestion" do
       orchestrator.clear_the_scene_all!(block: block)
-      expect(suggestion_a.reload.cleared_at).to be_present
-      expect(suggestion_b.reload.cleared_at).to be_present
+      expect(@suggestion_a.reload.cleared_at).to be_present
+      expect(@suggestion_b.reload.cleared_at).to be_present
     end
   end
 end


### PR DESCRIPTION
## Summary

Rework of "The Scene" block to support a structured improv flow:

- **Phase model** collapses to `idle | collecting | winner_reveal | ended`. Voting unlocks during `collecting` once 2+ suggestions exist (no separate voting phase).
- **Per-scene roles**: N random prompt recipients (default 3, configurable at block creation) + one buzzer holder. Buzzer holder cannot vote or submit. Suggestions edit-in-place so votes stay attached.
- **Performers**: assignable participants who never receive prompt input or buzzer. Configurable at create time and editable mid-experience from the manage view. Participants with a linked `Performer` profile are sorted to the top and badged in the multi-select.
- **Buzzer**: reusable `GlassCaseButton` (Three.js + Tone.js) — glass case unlocks once 2+ suggestions exist; tap shatters glass, second tap fires the buzzer. Server transitions to `winner_reveal`, monitor animates rank-1 row, and `TheSceneAdvanceAfterRevealJob` auto-starts the next scene after 15s (idempotent on `scene_started_at` + phase). Host can force-skip the wait.
- **Performer stories bar**: new `PerformerStoriesBar` Core component renders Instagram-style avatars across the top of participant views (suggestion input, voting, buzzer).

## Test plan

- [x] Backend specs: `bundle exec rspec spec/services/experiences/the_scene_orchestrator_spec.rb spec/jobs/the_scene_advance_after_reveal_job_spec.rb` — 35 examples
- [x] Full experiences + jobs + block controller specs pass (164 examples locally)
- [ ] `yarn typecheck` clean
- [ ] `yarn test` passes (41 vitest examples)
- [ ] Visual review in Storybook: `Experiences/TheScene` (14 participant/monitor/manage variants including winner reveal animation), `Core/GlassCaseButton`, `Core/PerformerStoriesBar`, `Experiences/TheScene/BuzzerPanel`
- [ ] End-to-end smoke: create a Scene block with 3 audience + 2 performers, start scene, verify only non-performers receive prompt/buzzer, submit 2+ suggestions, vote, edit a suggestion (votes preserved), press buzzer, watch rank-1 animation + 15s auto-advance
- [ ] Manage view: force-next-scene during `collecting` and during `winner_reveal`, reassign performers mid-scene and confirm prompts/buzzer reshuffle as needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)