### PR TITLE
Auto-submit GuessWho poll and move state to client

### DIFF
--- a/app/frontend/Experiences/GuessWho/GuessWhoParticipant.tsx
+++ b/app/frontend/Experiences/GuessWho/GuessWhoParticipant.tsx
@@ -1,10 +1,9 @@
-import { FormEvent, useState } from 'react';
+import { useState } from 'react';
 
+import { useExperienceState } from '@cctv/contexts/ExperienceStateContext';
 import { Button } from '@cctv/core/Button/Button';
-import { Option } from '@cctv/core/Option/Option';
 import { useSubmitPollResponse } from '@cctv/hooks/useSubmitPollResponse';
 import { GuessWhoBlock } from '@cctv/types';
-import { getFormData } from '@cctv/utils';
 
 import styles from './GuessWho.module.scss';
 
@@ -15,6 +14,7 @@ interface GuessWhoParticipantProps {
 export default function GuessWhoParticipant({ block }: GuessWhoParticipantProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { submitPollResponse, error } = useSubmitPollResponse();
+  const { submissionState } = useExperienceState();
   const activePoll = block.payload.active_poll;
 
   if (!activePoll) {
@@ -26,8 +26,14 @@ export default function GuessWhoParticipant({ block }: GuessWhoParticipantProps)
     );
   }
 
-  if (activePoll.user_responded) {
-    const answer = activePoll.user_response?.answer?.selectedOptions?.join(', ') ?? '';
+  const submission = submissionState[activePoll.id];
+  const userResponded = !!submission || !!activePoll.user_responded;
+
+  if (userResponded) {
+    const selected =
+      (submission?.answer?.selectedOptions as string[] | undefined) ??
+      activePoll.user_response?.answer?.selectedOptions;
+    const answer = selected?.join(', ') ?? '';
     return (
       <div className={styles.root}>
         <h2 className={styles.title}>Guess Who?</h2>
@@ -37,16 +43,12 @@ export default function GuessWhoParticipant({ block }: GuessWhoParticipantProps)
     );
   }
 
-  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const formData = getFormData<{ selectedOptions: string[] }>(e.currentTarget);
-    if (!formData.selectedOptions) return;
-
+  const handleSelect = async (option: string) => {
     setIsSubmitting(true);
     const response = await submitPollResponse({
       blockId: activePoll.id,
       answer: {
-        selectedOptions: formData.selectedOptions,
+        selectedOptions: [option],
         submittedAt: new Date().toISOString(),
       },
     });
@@ -56,21 +58,14 @@ export default function GuessWhoParticipant({ block }: GuessWhoParticipantProps)
   return (
     <div className={styles.root}>
       <h2 className={styles.title}>True or False?</h2>
-      <form onSubmit={onSubmit}>
-        <fieldset disabled={isSubmitting} className={styles.fieldset}>
-          {error && <p className={styles.error}>{error}</p>}
-          {activePoll.options.map((option) => (
-            <Option
-              allowMultiple={false}
-              key={option}
-              option={option}
-              name="selectedOptions"
-              disabled={isSubmitting}
-            />
-          ))}
-          <Button type="submit">Submit</Button>
-        </fieldset>
-      </form>
+      {error && <p className={styles.error}>{error}</p>}
+      <div className={styles.fieldset}>
+        {activePoll.options.map((option) => (
+          <Button key={option} disabled={isSubmitting} onClick={() => handleSelect(option)}>
+            {option}
+          </Button>
+        ))}
+      </div>
     </div>
   );
 }

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -148,8 +148,8 @@ export type GuessWhoMonitorView =
 export interface GuessWhoActivePoll {
   id: string;
   options: string[];
-  user_responded: boolean;
-  user_response: { id: string; answer: { selectedOptions?: string[] } } | null;
+  user_responded?: boolean;
+  user_response?: { id: string; answer: { selectedOptions?: string[] } } | null;
 }
 
 export interface GuessWhoPayload {

--- a/app/services/experiences/visibility.rb
+++ b/app/services/experiences/visibility.rb
@@ -471,25 +471,18 @@ module Experiences
 
       payload["active_poll_response_count"] = guess_who_active_poll_response_count(payload)
       payload["active_poll_total_participants"] = guess_who_active_poll_total(payload)
-      payload["active_poll"] = guess_who_active_poll_for(payload, participant) if payload["active_poll_block_id"].present?
+      payload["active_poll"] = guess_who_active_poll_for(payload) if payload["active_poll_block_id"].present?
 
       payload
     end
 
-    def guess_who_active_poll_for(payload, participant)
+    def guess_who_active_poll_for(payload)
       poll_block = @experience.experience_blocks.find_by(id: payload["active_poll_block_id"])
       return nil unless poll_block
 
-      own_submission = participant && ExperiencePollSubmission.find_by(
-        experience_block_id: poll_block.id,
-        experience_participant_id: participant.id
-      )
-
       {
         "id" => poll_block.id,
-        "options" => Array(poll_block.payload["options"]),
-        "user_responded" => own_submission.present?,
-        "user_response" => own_submission && { "id" => own_submission.id, "answer" => own_submission.answer }
+        "options" => Array(poll_block.payload["options"])
       }
     end
 


### PR DESCRIPTION
Replace form + radio options + submit button with direct buttons that call submitPollResponse on click, auto-submitting on True/False press.

Read userResponded from submissionState context (client-authoritative) rather than activePoll.user_responded from the broadcast payload. The profile-based stream passes participant: nil, so user_responded was always false in broadcasts — the old component could never show the responded state after a live submission.

Remove user_responded and user_response from guess_who_active_poll_for entirely. Submission hydration on reconnect is handled by the submission_state websocket message, consistent with all other block types. Make the corresponding fields optional in GuessWhoActivePoll.