### PR TITLE
Disable dark mode TV glow effect

### DIFF
--- a/app/frontend/styles.css
+++ b/app/frontend/styles.css
@@ -24,7 +24,7 @@
   --space-sm: 1rem;
   --space-md: 2rem;
   --space-lg: 4rem;
-  --tv-glow: 0 0 4px rgba(200, 240, 96, 0.45), 0 0 10px rgba(200, 240, 96, 0.3);
+  --tv-glow: none;
 }
 
 /* Shadcn theme tokens (HSL triplets) */


### PR DESCRIPTION
Sets the `--tv-glow` design token to `none` in `app/frontend/styles.css`, removing the phosphor text-shadow/box-shadow glow everywhere it's consumed. This disables the glow on dark mode headings (h1–h6), the minigame timers/labels/titles, the Calendar live tally, and the Experience focus ring in a single place. Neutralizing the token rather than the heading selector ensures all consumers are covered at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)