### PR TITLE
Centralize participant-name templating into renderNameTemplate

### DIFF
--- a/app/frontend/Experiences/Announcement/Announcement.stories.tsx
+++ b/app/frontend/Experiences/Announcement/Announcement.stories.tsx
@@ -30,6 +30,12 @@ export const WithParticipantName: Story = {
   },
 };
 
+export const WithoutParticipantFallback: Story = {
+  args: {
+    message: 'Hey {{ participant_name }}, get ready!',
+  },
+};
+
 export const LongMessage: Story = {
   args: {
     message:

--- a/app/frontend/Experiences/Announcement/Announcement.tsx
+++ b/app/frontend/Experiences/Announcement/Announcement.tsx
@@ -1,4 +1,5 @@
 import { AnnouncementPayload, ParticipantSummary } from '@cctv/types';
+import { renderNameTemplate } from '@cctv/utils';
 
 import styles from './Announcement.module.scss';
 
@@ -7,13 +8,9 @@ interface AnnouncementProps extends AnnouncementPayload {
 }
 
 export default function Announcement({ participant, message }: AnnouncementProps) {
-  const processedMessage = participant
-    ? message.replace(/\{\{\s*participant_name\s*\}\}/g, participant.name || participant.email)
-    : message;
-
   return (
     <div className={styles.announcement}>
-      <p className={styles.message}>{processedMessage}</p>
+      <p className={styles.message}>{renderNameTemplate(message, participant)}</p>
     </div>
   );
 }

--- a/app/frontend/Pages/Playbill/Playbill.stories.tsx
+++ b/app/frontend/Pages/Playbill/Playbill.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
+import { BlockKind } from '@cctv/types';
+
 import { ExperienceSeeder } from '../../../../.storybook/ExperienceSeeder';
 import { experienceNoPlaybill, lobbyExperience } from '../../../../.storybook/fixtures';
 import Playbill from './Playbill';
@@ -46,6 +48,36 @@ export const RunningOrderPopulated: Story = {
   decorators: [
     (Story) => (
       <ExperienceSeeder experience={lobbyExperience} participant={undefined}>
+        <Story />
+      </ExperienceSeeder>
+    ),
+  ],
+};
+
+export const RunningOrderWithTemplatedTitle: Story = {
+  decorators: [
+    (Story) => (
+      <ExperienceSeeder
+        experience={{
+          ...lobbyExperience,
+          playbill_running_order: [
+            {
+              id: 'block-greeting',
+              kind: BlockKind.ANNOUNCEMENT,
+              position: 0,
+              playbill_mysterious: false,
+              title: 'Hello {{ participant_name }}',
+            },
+          ],
+        }}
+        participant={{
+          id: 'p1',
+          user_id: 'u1',
+          name: 'Jordan',
+          email: 'jordan@example.com',
+          role: 'player',
+        }}
+      >
         <Story />
       </ExperienceSeeder>
     ),

--- a/app/frontend/Pages/Playbill/Playbill.tsx
+++ b/app/frontend/Pages/Playbill/Playbill.tsx
@@ -6,7 +6,13 @@ import { ChevronLeft } from 'lucide-react';
 
 import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { Button } from '@cctv/core';
-import { BLOCK_KIND_LABELS, BlockKind, PlaybillRunningOrderEntry } from '@cctv/types';
+import {
+  BLOCK_KIND_LABELS,
+  BlockKind,
+  ParticipantSummary,
+  PlaybillRunningOrderEntry,
+} from '@cctv/types';
+import { renderNameTemplate } from '@cctv/utils';
 
 import styles from './Playbill.module.scss';
 
@@ -94,7 +100,7 @@ export default function Playbill() {
 }
 
 function PerformersTab() {
-  const { experience } = useExperience();
+  const { experience, participant } = useExperience();
   const sections = experience?.playbill || [];
 
   if (sections.length === 0) {
@@ -118,7 +124,7 @@ function PerformersTab() {
               <img
                 className={styles.image}
                 src={section.image_url}
-                alt={section.title || `Performer ${index + 1}`}
+                alt={renderNameTemplate(section.title, participant) || `Performer ${index + 1}`}
                 loading="lazy"
                 decoding="async"
                 width={section.image_width}
@@ -127,8 +133,8 @@ function PerformersTab() {
             </div>
           )}
           <div className={styles.textWrap}>
-            <h3 className={styles.itemTitle}>{section.title}</h3>
-            <p className={styles.itemBody}>{section.body}</p>
+            <h3 className={styles.itemTitle}>{renderNameTemplate(section.title, participant)}</h3>
+            <p className={styles.itemBody}>{renderNameTemplate(section.body, participant)}</p>
           </div>
         </div>
       ))}
@@ -137,7 +143,7 @@ function PerformersTab() {
 }
 
 function RunningOrderTab() {
-  const { experience } = useExperience();
+  const { experience, participant } = useExperience();
   const entries = experience?.playbill_running_order || [];
 
   if (entries.length === 0) {
@@ -151,13 +157,21 @@ function RunningOrderTab() {
   return (
     <ol className={styles.runningOrder}>
       {entries.map((entry, index) => (
-        <RunningOrderItem key={entry.id} entry={entry} index={index} />
+        <RunningOrderItem key={entry.id} entry={entry} index={index} participant={participant} />
       ))}
     </ol>
   );
 }
 
-function RunningOrderItem({ entry, index }: { entry: PlaybillRunningOrderEntry; index: number }) {
+function RunningOrderItem({
+  entry,
+  index,
+  participant,
+}: {
+  entry: PlaybillRunningOrderEntry;
+  index: number;
+  participant?: ParticipantSummary | null;
+}) {
   if (entry.playbill_mysterious) {
     return (
       <li className={`${styles.runningOrderItem} ${styles.runningOrderItemMysterious}`}>
@@ -176,7 +190,9 @@ function RunningOrderItem({ entry, index }: { entry: PlaybillRunningOrderEntry; 
     <li className={styles.runningOrderItem}>
       <span className={styles.runningOrderIndex}>{index + 1}</span>
       <div className={styles.runningOrderText}>
-        <h3 className={styles.runningOrderTitle}>{entry.title || BLOCK_KIND_LABELS[entry.kind]}</h3>
+        <h3 className={styles.runningOrderTitle}>
+          {renderNameTemplate(entry.title, participant) || BLOCK_KIND_LABELS[entry.kind]}
+        </h3>
         <p className={styles.runningOrderDescription}>{BLOCK_KIND_DESCRIPTIONS[entry.kind]}</p>
       </div>
     </li>

--- a/app/frontend/utils.test.ts
+++ b/app/frontend/utils.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { TEMPLATE_NAME_FALLBACK, renderNameTemplate } from './utils';
+
+describe('renderNameTemplate', () => {
+  it('substitutes the participant name', () => {
+    expect(
+      renderNameTemplate('Hello {{ participant_name }}', { name: 'Alice', email: 'a@x.com' }),
+    ).toBe('Hello Alice');
+  });
+
+  it('matches the token regardless of inner whitespace', () => {
+    const participant = { name: 'Alice', email: 'a@x.com' };
+    expect(renderNameTemplate('{{participant_name}}', participant)).toBe('Alice');
+    expect(renderNameTemplate('{{   participant_name   }}', participant)).toBe('Alice');
+  });
+
+  it('substitutes every occurrence', () => {
+    expect(
+      renderNameTemplate('{{ participant_name }} & {{ participant_name }}', {
+        name: 'Bob',
+        email: 'b@x.com',
+      }),
+    ).toBe('Bob & Bob');
+  });
+
+  it('falls back to email when name is blank', () => {
+    expect(renderNameTemplate('Hi {{ participant_name }}', { name: '  ', email: 'b@x.com' })).toBe(
+      'Hi b@x.com',
+    );
+  });
+
+  it('falls back to a generic name when no participant is available', () => {
+    expect(renderNameTemplate('Hi {{ participant_name }}')).toBe(`Hi ${TEMPLATE_NAME_FALLBACK}`);
+    expect(renderNameTemplate('Hi {{ participant_name }}', null)).toBe(
+      `Hi ${TEMPLATE_NAME_FALLBACK}`,
+    );
+  });
+
+  it('leaves text without tokens unchanged', () => {
+    expect(renderNameTemplate('Welcome to the show!', { name: 'Alice', email: 'a@x.com' })).toBe(
+      'Welcome to the show!',
+    );
+  });
+
+  it('returns an empty string for nullish templates', () => {
+    expect(renderNameTemplate(null)).toBe('');
+    expect(renderNameTemplate(undefined)).toBe('');
+  });
+});

--- a/app/frontend/utils.ts
+++ b/app/frontend/utils.ts
@@ -1,6 +1,21 @@
+import type { ParticipantSummary } from '@cctv/types';
+
 export function getFormData<T>(form: HTMLFormElement): Partial<T> {
   const formData = new FormData(form);
   return Object.fromEntries(formData.entries()) as Partial<T>;
+}
+
+export const TEMPLATE_NAME_FALLBACK = 'friend';
+
+const PARTICIPANT_NAME_TOKEN = /\{\{\s*participant_name\s*\}\}/g;
+
+export function renderNameTemplate(
+  template: string | null | undefined,
+  participant?: Pick<ParticipantSummary, 'name' | 'email'> | null,
+): string {
+  if (!template) return '';
+  const name = participant?.name?.trim() || participant?.email?.trim() || TEMPLATE_NAME_FALLBACK;
+  return template.replace(PARTICIPANT_NAME_TOKEN, name);
 }
 
 export function isNotNull<T>(value: T): value is NonNullable<T> {

--- a/spec/system/experiences/announcement_block_spec.rb
+++ b/spec/system/experiences/announcement_block_spec.rb
@@ -58,11 +58,11 @@ RSpec.describe "Announcement Block", type: :system do
     expect(page).to have_text("Welcome Bob to the show!")
 
     within("[aria-label='Preview mode']") { click_button "Monitor" }
-    expect(page).to have_text("Welcome {{ participant_name }} to the show!")
+    expect(page).to have_text("Welcome friend to the show!")
 
     using_session(:monitor) do
       visit "/experiences/test-exp/monitor"
-      expect(page).to have_text("Welcome {{ participant_name }} to the show!")
+      expect(page).to have_text("Welcome friend to the show!")
     end
   end
 

--- a/spec/system/experiences/block_management_spec.rb
+++ b/spec/system/experiences/block_management_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe "Managing Blocks", type: :system do
       select "#{participant_name} (player)", from: "View as participant"
       expect(page).to have_text("Welcome #{participant_name}")
       within("[aria-label='Preview mode']") { click_button "Monitor" }
-      expect(page).to have_text("Welcome {{ participant_name }}")
+      expect(page).to have_text("Welcome friend")
 
       # Queue new block
       queue_block(n: 2) do
@@ -125,7 +125,7 @@ RSpec.describe "Managing Blocks", type: :system do
 
       # Assert original block is still displayed. New block is only enqueued
       within("[aria-label='Preview mode']") { click_button "Monitor" }
-      expect(page).to have_text("Welcome {{ participant_name }}")
+      expect(page).to have_text("Welcome friend")
 
       # Present new block
       select_block(2, kind: "announcement")
@@ -137,7 +137,7 @@ RSpec.describe "Managing Blocks", type: :system do
       select "#{participant_name} (player)", from: "View as participant"
       expect(page).to have_text("Welcome #{participant_name} again")
       within("[aria-label='Preview mode']") { click_button "Monitor" }
-      expect(page).to have_text("Welcome {{ participant_name }} again")
+      expect(page).to have_text("Welcome friend again")
     end
   end
 end


### PR DESCRIPTION
Extracts the `{{ participant_name }}` substitution that previously lived inline in `Announcement` into a shared `renderNameTemplate` util in `app/frontend/utils.ts`, with consistent name → email → `'friend'` fallback handling. Applies the same templating to the Playbill performer titles/bodies/image alt text and running-order entry titles, so participant names now render across the playbill. Adds Vitest unit tests for `renderNameTemplate` and Storybook stories covering the no-participant fallback and templated playbill titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)