### PR TITLE
Flesh out About page with organization content

### DIFF
--- a/app/frontend/Pages/about.module.scss
+++ b/app/frontend/Pages/about.module.scss
@@ -1,0 +1,51 @@
+.about {
+  align-items: stretch;
+  text-align: left;
+  gap: var(--space-lg);
+  padding-top: var(--space-lg);
+  padding-bottom: var(--space-lg);
+  min-height: auto;
+}
+
+.intro {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.title {
+  font-size: clamp(3rem, 10vw, 7rem);
+  text-align: center;
+}
+
+.tagline {
+  text-align: center;
+  color: var(--phosphor);
+  font-family: var(--font-ui);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  border-top: 1px solid hsl(var(--border));
+  padding-top: var(--space-md);
+}
+
+.heading {
+  font-size: clamp(1.75rem, 5vw, 3rem);
+  font-family: var(--font-display);
+  color: hsl(var(--foreground));
+}
+
+.lead {
+  font-size: clamp(1.125rem, 3vw, 1.5rem);
+  color: hsl(var(--muted-foreground));
+}
+
+.body {
+  max-width: 50ch;
+  line-height: 1.6;
+}

--- a/app/frontend/Pages/about.tsx
+++ b/app/frontend/Pages/about.tsx
@@ -1,8 +1,44 @@
+import styles from './about.module.scss';
+
 export default function About() {
   return (
-    <section className="page flex-centered">
-      {/* <h2 className="hero-title">{'About'}</h2> */}
-      <p className="hero-subtitle">{'More information coming Spring 2026'}</p>
+    <section className={`page flex-centered ${styles.about}`}>
+      <div className={styles.intro}>
+        <h1 className={styles.title}>{'CCTV'}</h1>
+        <p className={styles.tagline}>{'Chicago Comedy . TV'}</p>
+        <p className={styles.lead}>
+          {
+            'We build interactive experiences for live audiences — shows where the crowd is part of the cast. Pull out your phone, join the broadcast, and help shape what happens on stage in real time.'
+          }
+        </p>
+      </div>
+
+      <div className={styles.section}>
+        <h2 className={styles.heading}>{'What we do today'}</h2>
+        <p className={styles.body}>
+          {
+            'Right now we produce interactive comedy shows. The audience votes, answers, guesses, and reacts in the moment, and every response feeds straight into the performance. No two nights play out the same way, because the room writes the show alongside the performers.'
+          }
+        </p>
+      </div>
+
+      <div className={styles.section}>
+        <h2 className={styles.heading}>{'Where we are headed'}</h2>
+        <p className={styles.body}>
+          {
+            'Our next act is a dedicated studio space in the city — a home for producing streamed theater and filmed entertainment. A place to record live, broadcast to audiences anywhere, and turn the same interactive format we love into shows people can watch from their couch or their seat in the house.'
+          }
+        </p>
+      </div>
+
+      <div className={styles.section}>
+        <h2 className={styles.heading}>{'Learning the craft'}</h2>
+        <p className={styles.body}>
+          {
+            'The studio will also be a classroom. We plan to offer education in performance, production, and the technology behind interactive media — sharing the tools and techniques we use, and giving the next generation of makers a stage and a camera to learn on.'
+          }
+        </p>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
Replaces the "More information coming Spring 2026" placeholder on the About page with descriptive content about the organization. Adds an intro framing CCTV as a builder of interactive experiences for live audiences, a section on the interactive comedy shows we produce today, the goal of opening a city studio space for producing streamed theater and filmed entertainment, and the planned education offering. Layout uses a new `about.module.scss` built on the existing design tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)