### PR TITLE
Use local active storage in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
-  config.active_storage.service = :amazon
+  config.active_storage.service = :local
 
   config.action_view.annotate_rendered_view_with_filenames = true
 


### PR DESCRIPTION
This may address a Render build failure where Rails is initialized during the Vite build step and attempts to connect to S3. The root cause is not fully confirmed — development should use local storage regardless, so this is a safe change either way.