### PR TITLE
Center desktop nav links with CSS grid layout

### DIFF
--- a/app/frontend/Components/navigation/Navigation.module.scss
+++ b/app/frontend/Components/navigation/Navigation.module.scss
@@ -16,13 +16,11 @@
   width: 100%;
   max-width: calc(100vw - 2rem);
   margin: 0 auto;
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
   padding: 0 2rem;
   height: var(--nav-h);
-  flex-wrap: nowrap;
 }
 
 /* ── Logo lockup ── */
@@ -98,6 +96,7 @@
   display: flex;
   gap: 16px;
   align-items: center;
+  justify-self: end;
 }
 
 .navRight .dropdownMenu {


### PR DESCRIPTION
Converts the desktop nav bar (`.topnav__inner`) from flexbox `justify-content: space-between` to a 3-column CSS grid (`grid-template-columns: 1fr auto 1fr`), with `justify-self: end` on `.navRight`. This places the center nav links in the auto-sized middle column so they are truly centered in the viewport regardless of the logo or right-side control widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)