### PR TITLE
Add performer CSV importer with S3 photo pipeline

### DIFF
--- a/app/services/performers/csv_importer.rb
+++ b/app/services/performers/csv_importer.rb
@@ -1,0 +1,110 @@
+require "csv"
+
+module Performers
+  # Imports performers from a CSV export (e.g. a Google Form responses sheet).
+  #
+  # Columns are matched by header keyword so the importer tolerates the verbose
+  # question-style headers Google Forms produces. Each row resolves a User by
+  # email (creating one when absent), upserts that user's Performer profile, and
+  # attaches the linked photo. Re-running is idempotent: existing performers are
+  # updated in place and photos are only re-fetched when missing (or forced).
+  class CsvImporter
+    Result = Struct.new(:created, :updated, :skipped, :photos_attached, :errors, keyword_init: true) do
+      def summary
+        "created=#{created} updated=#{updated} skipped=#{skipped} " \
+          "photos_attached=#{photos_attached} errors=#{errors.size}"
+      end
+    end
+
+    def initialize(path, downloader: DrivePhotoDownloader.new, force_photos: false)
+      @path = path
+      @downloader = downloader
+      @force_photos = force_photos
+      @result = Result.new(created: 0, updated: 0, skipped: 0, photos_attached: 0, errors: [])
+    end
+
+    def call
+      CSV.foreach(@path, headers: true) do |row|
+        import_row(row)
+      end
+
+      @result
+    end
+
+    private
+
+    def import_row(row)
+      attrs = extract(row)
+
+      if attrs[:email].blank? || attrs[:name].blank?
+        @result.skipped += 1
+        return
+      end
+
+      user = find_or_create_user(attrs)
+      performer = upsert_performer(user, attrs)
+      attach_photo(performer, attrs[:photo_url])
+    rescue ActiveRecord::RecordInvalid => e
+      @result.errors << "#{attrs[:email]}: #{e.message}"
+    end
+
+    def extract(row)
+      mapped = {}
+      row.each do |header, value|
+        key = column_key(header)
+        mapped[key] = value if key
+      end
+
+      {
+        name: mapped[:name]&.strip,
+        email: mapped[:email]&.strip&.downcase,
+        bio: mapped[:bio]&.strip,
+        photo_url: mapped[:photo_url]&.strip
+      }
+    end
+
+    def column_key(header)
+      normalized = header.to_s.downcase
+      return :email if normalized.include?("email")
+      return :photo_url if normalized.include?("photo") || normalized.include?("headshot")
+      return :bio if normalized.include?("bio")
+      return :name if normalized.include?("name")
+
+      nil
+    end
+
+    def find_or_create_user(attrs)
+      User.find_or_create_by!(email: attrs[:email]) do |user|
+        user.name = attrs[:name]
+        user.role = :user
+      end
+    end
+
+    def upsert_performer(user, attrs)
+      performer = Performer.find_or_initialize_by(user: user)
+      new_record = performer.new_record?
+
+      performer.name = attrs[:name]
+      performer.bio = attrs[:bio]
+      performer.save!
+
+      new_record ? @result.created += 1 : @result.updated += 1
+      performer
+    end
+
+    def attach_photo(performer, url)
+      return if url.blank?
+      return if performer.photo.attached? && !@force_photos
+
+      photo = @downloader.call(url: url, name: performer.name)
+      return if photo.nil?
+
+      performer.photo.attach(
+        io: photo.io,
+        filename: photo.filename,
+        content_type: photo.content_type
+      )
+      @result.photos_attached += 1
+    end
+  end
+end

--- a/app/services/performers/drive_photo_downloader.rb
+++ b/app/services/performers/drive_photo_downloader.rb
@@ -1,0 +1,65 @@
+require "open-uri"
+
+module Performers
+  # Downloads a photo from a public URL (handling Google Drive share links) and
+  # returns the data needed to attach it via ActiveStorage. Returns nil when the
+  # URL is blank, cannot be fetched, or does not resolve to an image (e.g. Google
+  # Drive's HTML interstitial for non-public files).
+  class DrivePhotoDownloader
+    MAX_BYTES = 10.megabytes
+    DRIVE_HOST = "drive.google.com".freeze
+
+    Result = Struct.new(:io, :filename, :content_type, keyword_init: true)
+
+    def call(url:, name: nil)
+      return nil if url.blank?
+
+      download_url = normalize(url.strip)
+      io = URI.parse(download_url).open(
+        "rb",
+        read_timeout: 30,
+        "User-Agent" => "cctv-performer-importer"
+      )
+
+      content_type = io.content_type.presence || Marcel::MimeType.for(io)
+      return nil unless content_type.to_s.start_with?("image/")
+      return nil if io.size && io.size > MAX_BYTES
+
+      Result.new(
+        io: io,
+        filename: filename_for(io, download_url, content_type),
+        content_type: content_type
+      )
+    rescue OpenURI::HTTPError, SocketError, URI::InvalidURIError, Net::OpenTimeout, Net::ReadTimeout => e
+      Rails.logger.warn("[Performers::DrivePhotoDownloader] failed to fetch #{url}: #{e.message}")
+      nil
+    end
+
+    private
+
+    # Converts a Google Drive share/preview link into a direct-download URL.
+    # Leaves non-Drive URLs untouched.
+    def normalize(url)
+      return url unless url.include?(DRIVE_HOST)
+
+      id = drive_file_id(url)
+      return url if id.nil?
+
+      "https://#{DRIVE_HOST}/uc?export=download&id=#{id}"
+    end
+
+    def drive_file_id(url)
+      url[%r{/file/d/([^/]+)}, 1] ||
+        url[/[?&]id=([^&]+)/, 1] ||
+        url[%r{/d/([^/?]+)}, 1]
+    end
+
+    def filename_for(io, url, content_type)
+      from_disposition = io.meta["content-disposition"].to_s[/filename="?([^"]+)"?/, 1]
+      return from_disposition if from_disposition.present?
+
+      ext = Rack::Mime::MIME_TYPES.invert[content_type.to_s.split(";").first] || ".jpg"
+      "performer-photo#{ext}"
+    end
+  end
+end

--- a/app/services/performers/local_photo_resolver.rb
+++ b/app/services/performers/local_photo_resolver.rb
@@ -1,0 +1,84 @@
+module Performers
+  # Resolves a performer's photo from a local directory instead of a URL, for
+  # cases where the source images are behind auth (e.g. private Google Drive)
+  # and have been downloaded by hand.
+  #
+  # Real-world downloads carry noisy names like "IMG_3537 - Jessica Benson.jpeg"
+  # or "Capture - Taylor Jones.JPG", so matching: takes the name portion after
+  # the last " - " (when present), tokenizes it, and matches a performer when
+  # every token of the performer's name maps to a file token by equality or
+  # prefix (e.g. CSV "Jes Benson" matches file token "jessica"). Surnames must
+  # match for multi-word names. Ambiguous matches are skipped with a warning.
+  class LocalPhotoResolver
+    Result = DrivePhotoDownloader::Result
+
+    Candidate = Struct.new(:path, :tokens, keyword_init: true)
+
+    def initialize(dir)
+      @dir = dir
+      @candidates = build_candidates
+    end
+
+    def call(url: nil, name:)
+      return nil if name.blank?
+
+      tokens = tokenize(name)
+      return nil if tokens.empty?
+
+      matches = @candidates.select { |candidate| matches?(tokens, candidate.tokens) }
+
+      if matches.size > 1
+        Rails.logger.warn(
+          "[Performers::LocalPhotoResolver] ambiguous match for #{name.inspect}: " \
+          "#{matches.map { |m| File.basename(m.path) }.join(', ')}"
+        )
+        return nil
+      end
+
+      candidate = matches.first
+      return nil if candidate.nil?
+
+      content_type = Marcel::MimeType.for(Pathname.new(candidate.path))
+      return nil unless content_type.to_s.start_with?("image/")
+
+      Result.new(
+        io: File.open(candidate.path, "rb"),
+        filename: File.basename(candidate.path),
+        content_type: content_type
+      )
+    end
+
+    private
+
+    def build_candidates
+      Dir.glob(File.join(@dir, "*")).filter_map do |path|
+        next if File.directory?(path)
+
+        tokens = tokenize(name_portion(path))
+        next if tokens.empty?
+
+        Candidate.new(path: path, tokens: tokens)
+      end
+    end
+
+    # "IMG_3537 - Jessica Benson.jpeg" -> "Jessica Benson"; "Sami Smith.png" -> "Sami Smith"
+    def name_portion(path)
+      base = File.basename(path, ".*")
+      base.include?(" - ") ? base.split(" - ").last : base
+    end
+
+    def tokenize(value)
+      value.to_s.downcase.scan(/[a-z0-9]+/)
+    end
+
+    # Every performer token must map to a file token (equality or prefix in
+    # either direction). For multi-token names the surname must match exactly,
+    # to avoid first-name-only collisions.
+    def matches?(performer_tokens, file_tokens)
+      surname_ok = performer_tokens.size < 2 || file_tokens.include?(performer_tokens.last)
+      surname_ok && performer_tokens.all? do |token|
+        file_tokens.any? { |ft| token == ft || ft.start_with?(token) || token.start_with?(ft) }
+      end
+    end
+  end
+end

--- a/lib/tasks/performers.rake
+++ b/lib/tasks/performers.rake
@@ -1,0 +1,31 @@
+namespace :performers do
+  desc "Import performers from a CSV export. Usage: rake performers:import[path/to/file.csv]"
+  task :import, [:path] => :environment do |_task, args|
+    path = args[:path]
+    abort("Provide a CSV path: rake performers:import[path/to/file.csv]") if path.blank?
+    abort("File not found: #{path}") unless File.exist?(path)
+
+    # Optionally pin the ActiveStorage service for this run (e.g. STORAGE_SERVICE=amazon
+    # to push to S3 from an environment whose default service is local disk).
+    if (service = ENV["STORAGE_SERVICE"]).present?
+      ActiveStorage::Blob.service = ActiveStorage::Blob.services.fetch(service.to_sym)
+      puts "Using ActiveStorage service: #{service} (bucket=#{ENV['CCTV_AWS_S3_BUCKET']})"
+    end
+
+    force = ENV["FORCE_PHOTOS"].present?
+    photos_dir = ENV["PHOTOS_DIR"]
+
+    downloader =
+      if photos_dir.present?
+        abort("Photos dir not found: #{photos_dir}") unless Dir.exist?(photos_dir)
+        Performers::LocalPhotoResolver.new(photos_dir)
+      else
+        Performers::DrivePhotoDownloader.new
+      end
+
+    result = Performers::CsvImporter.new(path, downloader: downloader, force_photos: force).call
+
+    puts "Performer import complete: #{result.summary}"
+    result.errors.each { |error| warn "  error: #{error}" }
+  end
+end

--- a/spec/factories/performers_factory.rb
+++ b/spec/factories/performers_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :performer do
+    user
+    sequence(:name) { |n| "Performer #{n}" }
+    bio { "A seasoned improviser." }
+  end
+end

--- a/spec/services/performers/csv_importer_spec.rb
+++ b/spec/services/performers/csv_importer_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+RSpec.describe Performers::CsvImporter do
+  # Stub downloader so specs never hit the network. Returns a tiny PNG.
+  let(:downloader) do
+    Class.new do
+      attr_reader :calls
+
+      def initialize
+        @calls = []
+      end
+
+      def call(url:, name: nil)
+        @calls << url
+        Performers::DrivePhotoDownloader::Result.new(
+          io: StringIO.new("fakeimagebytes"),
+          filename: "headshot.png",
+          content_type: "image/png"
+        )
+      end
+    end.new
+  end
+
+  def write_csv(rows)
+    file = Tempfile.new(["performers", ".csv"])
+    file.write(<<~HEADER)
+      Timestamp,What is your name?,What is your email (for contact)?,Please upload a photo or headshot <10MB.,"Please add a short bio."
+    HEADER
+    rows.each { |row| file.write(CSV.generate_line(row)) }
+    file.rewind
+    file.path
+  end
+
+  let(:path) do
+    write_csv([
+      ["5/27/2026 14:54", "Jes Benson", "Jfaye3@gmail.com", "https://drive.google.com/open?id=ABC", "A teaching artist and comedian."],
+      ["5/28/2026 14:32", "Derek Cox", "Derek.g.cox@gmail.com", "https://drive.google.com/open?id=DEF", "A director of photography."]
+    ])
+  end
+
+  it "creates users and performers from the CSV" do
+    result = described_class.new(path, downloader: downloader).call
+
+    expect(result.created).to eq(2)
+    expect(Performer.count).to eq(2)
+
+    jes = Performer.find_by(name: "Jes Benson")
+    expect(jes.bio).to eq("A teaching artist and comedian.")
+    expect(jes.user.email).to eq("jfaye3@gmail.com")
+    expect(jes.photo).to be_attached
+  end
+
+  it "reuses an existing user matched by email (case-insensitive)" do
+    existing = create(:user, email: "jfaye3@gmail.com", name: "Existing Name")
+
+    result = described_class.new(path, downloader: downloader).call
+
+    expect(User.where(email: "jfaye3@gmail.com").count).to eq(1)
+    expect(existing.reload.performer.name).to eq("Jes Benson")
+    expect(result.created).to eq(2)
+  end
+
+  it "is idempotent across re-runs and does not re-download attached photos" do
+    described_class.new(path, downloader: downloader).call
+    second = described_class.new(path, downloader: downloader).call
+
+    expect(Performer.count).to eq(2)
+    expect(User.count).to eq(2)
+    expect(second.updated).to eq(2)
+    expect(second.created).to eq(0)
+    # 2 downloads on first run, none on the second (photos already attached)
+    expect(downloader.calls.size).to eq(2)
+  end
+
+  it "skips rows missing an email or name" do
+    incomplete = write_csv([
+      ["ts", "No Email", "", "https://drive.google.com/open?id=X", "bio"],
+      ["ts", "", "no-name@gmail.com", "https://drive.google.com/open?id=Y", "bio"]
+    ])
+
+    result = described_class.new(incomplete, downloader: downloader).call
+
+    expect(result.skipped).to eq(2)
+    expect(Performer.count).to eq(0)
+  end
+end

--- a/spec/services/performers/local_photo_resolver_spec.rb
+++ b/spec/services/performers/local_photo_resolver_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe Performers::LocalPhotoResolver do
+  # 1x1 transparent PNG.
+  let(:png_bytes) do
+    Base64.decode64(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+    )
+  end
+
+  let(:dir) { Dir.mktmpdir }
+
+  after { FileUtils.remove_entry(dir) }
+
+  def write_photo(filename)
+    File.binwrite(File.join(dir, filename), png_bytes)
+  end
+
+  it "matches a plain display-name file" do
+    write_photo("Sami Smith.png")
+    expect(described_class.new(dir).call(name: "Sami Smith")&.filename).to eq("Sami Smith.png")
+  end
+
+  it "matches a file with a noisy prefix after the last ' - '" do
+    write_photo("IMG_1926 - Derek Cox.jpeg")
+    expect(described_class.new(dir).call(name: "Derek Cox")&.filename).to eq("IMG_1926 - Derek Cox.jpeg")
+  end
+
+  it "matches a shortened first name by prefix (Jes -> Jessica)" do
+    write_photo("IMG_3537 - Jessica Benson.jpeg")
+    expect(described_class.new(dir).call(name: "Jes Benson")&.filename).to eq("IMG_3537 - Jessica Benson.jpeg")
+  end
+
+  it "matches a single-token performer name against a fuller filename (Ateeq -> Ateeq Rehman)" do
+    write_photo("IMG_5124 - Ateeq Rehman.png")
+    expect(described_class.new(dir).call(name: "Ateeq")&.filename).to eq("IMG_5124 - Ateeq Rehman.png")
+  end
+
+  it "does not collide on first name alone when surnames differ" do
+    write_photo("Sami Jones.png")
+    expect(described_class.new(dir).call(name: "Sami Smith")).to be_nil
+  end
+
+  it "returns nil when no file matches" do
+    write_photo("someone-else.png")
+    expect(described_class.new(dir).call(name: "Tom Korabik")).to be_nil
+  end
+
+  it "skips ambiguous matches" do
+    write_photo("IMG_1 - Derek Cox.png")
+    write_photo("IMG_2 - Derek Cox.jpeg")
+    expect(described_class.new(dir).call(name: "Derek Cox")).to be_nil
+  end
+
+  it "ignores non-image files" do
+    File.write(File.join(dir, "Tom Korabik.txt"), "not an image")
+    expect(described_class.new(dir).call(name: "Tom Korabik")).to be_nil
+  end
+end


### PR DESCRIPTION
Import performers from a Google-Form CSV export: find-or-create User by email, upsert Performer, and attach the photo via ActiveStorage. Two photo sources are supported — public URLs (DrivePhotoDownloader, handling Google Drive share links) and a local directory (LocalPhotoResolver, matching downloaded files to performers by normalized name). Exposed as `rake performers:import[path]`; STORAGE_SERVICE pins the ActiveStorage service so the import can push to S3 from an environment defaulting to disk.