### PR TITLE
Allow admins to upload performer photos

### DIFF
--- a/app/controllers/api/direct_uploads_controller.rb
+++ b/app/controllers/api/direct_uploads_controller.rb
@@ -1,5 +1,6 @@
 class Api::DirectUploadsController < ActiveStorage::DirectUploadsController
   skip_forgery_protection
+  include Passwordless::ControllerHelpers
 
   before_action :authenticate_jwt
   before_action :validate_upload_params
@@ -9,14 +10,20 @@ class Api::DirectUploadsController < ActiveStorage::DirectUploadsController
   def authenticate_jwt
     token = request.headers["Authorization"]&.to_s&.match(/\ABearer\s+(.+)\z/i)&.captures&.first
 
-    unless token
+    if token
+      Experiences::AuthService.decode!(token)
+    elsif session_admin?
+      # Session-authenticated admin, allow
+    else
       render json: { error: "Missing authorization token" }, status: :unauthorized
-      return
     end
-
-    Experiences::AuthService.decode!(token)
   rescue Experiences::AuthService::TokenInvalid, Experiences::AuthService::TokenExpired
     render json: { error: "Invalid or expired token" }, status: :unauthorized
+  end
+
+  def session_admin?
+    user = authenticate_by_session(User)
+    user&.admin? || user&.superadmin?
   end
 
   def validate_upload_params

--- a/app/frontend/Hooks/index.ts
+++ b/app/frontend/Hooks/index.ts
@@ -44,3 +44,4 @@ export { useFollowPerformer } from './useFollowPerformer';
 export { useMinigameArithmetic } from './useMinigameArithmetic';
 export { useMinigameBalloonPump } from './useMinigameBalloonPump';
 export { useTheScene } from './useTheScene';
+export { useUploadPerformerPhoto } from './useUploadPerformerPhoto';

--- a/app/frontend/Hooks/useUploadPerformerPhoto.ts
+++ b/app/frontend/Hooks/useUploadPerformerPhoto.ts
@@ -1,0 +1,76 @@
+import { useCallback, useState } from 'react';
+
+import { Blob as ActiveStorageBlob, DirectUpload } from '@rails/activestorage';
+
+import { Performer } from '@cctv/types';
+
+interface UploadPerformerPhotoResult {
+  performer: Performer;
+}
+
+export function useUploadPerformerPhoto() {
+  const [isUploading, setIsUploading] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  const uploadPhoto = useCallback(
+    async (file: File, slug: string): Promise<UploadPerformerPhotoResult | null> => {
+      setIsUploading(true);
+      setProgress(0);
+      setError(null);
+
+      try {
+        const signedId = await new Promise<string>((resolve, reject) => {
+          const delegate = {
+            directUploadWillStoreFileWithXHR(xhr: XMLHttpRequest) {
+              xhr.upload.addEventListener('progress', (event: ProgressEvent) => {
+                if (event.lengthComputable) {
+                  setProgress(Math.round((event.loaded / event.total) * 100));
+                }
+              });
+            },
+          };
+
+          const directUpload = new DirectUpload(
+            file,
+            '/rails/active_storage/direct_uploads',
+            delegate,
+          );
+
+          directUpload.create((uploadError: Error, blob: ActiveStorageBlob) => {
+            if (uploadError) {
+              reject(uploadError);
+            } else {
+              setProgress(100);
+              resolve(blob.signed_id);
+            }
+          });
+        });
+
+        const res = await fetch(`/api/performers/${encodeURIComponent(slug)}`, {
+          method: 'PATCH',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ photo: signedId }),
+        });
+
+        const data = await res.json();
+
+        if (!res.ok) {
+          throw new Error(data.error || 'Failed to update performer photo');
+        }
+
+        return data as UploadPerformerPhotoResult;
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : 'Upload failed';
+        setError(msg);
+        return null;
+      } finally {
+        setIsUploading(false);
+      }
+    },
+    [],
+  );
+
+  return { uploadPhoto, isUploading, progress, error };
+}

--- a/app/frontend/Pages/Performers/PerformerProfile.tsx
+++ b/app/frontend/Pages/Performers/PerformerProfile.tsx
@@ -1,10 +1,12 @@
+import { useCallback, useRef } from 'react';
+
 import { Link, useParams } from 'react-router-dom';
 
-import { Edit2 } from 'lucide-react';
+import { Camera, Edit2 } from 'lucide-react';
 
 import { useUser } from '@cctv/contexts';
 import { Button, Panel } from '@cctv/core';
-import { useFollowPerformer, usePerformer } from '@cctv/hooks';
+import { useFollowPerformer, usePerformer, useUploadPerformerPhoto } from '@cctv/hooks';
 import { formatEventTime } from '@cctv/utils/calendar';
 
 import styles from './Performers.module.scss';
@@ -21,8 +23,10 @@ const dateParts = (iso: string) => {
 export default function PerformerProfile() {
   const { slug } = useParams<{ slug: string }>();
   const { performer, isLoading, refetch } = usePerformer(slug ?? '');
-  const { user } = useUser();
+  const { user, isAdmin } = useUser();
   const { follow, unfollow, isLoading: followLoading } = useFollowPerformer();
+  const { uploadPhoto, isUploading, progress } = useUploadPerformerPhoto();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const isOwner = !!performer?.editable_by_current_user;
 
@@ -35,6 +39,15 @@ export default function PerformerProfile() {
     }
     refetch();
   };
+
+  const handlePhotoFileSelect = useCallback(
+    async (file: File) => {
+      if (!performer) return;
+      const result = await uploadPhoto(file, performer.slug);
+      if (result) refetch();
+    },
+    [performer, uploadPhoto, refetch],
+  );
 
   if (isLoading) {
     return (
@@ -57,21 +70,48 @@ export default function PerformerProfile() {
       <div className={styles.profileContainer}>
         <Panel className={styles.profilePanel}>
           <header className={styles.hero}>
-            {performer.photo_url ? (
-              <img
-                src={performer.photo_url}
-                alt={performer.name}
-                className={styles.heroPhoto}
-                width={140}
-                height={140}
-              />
-            ) : (
-              <div className={styles.heroPhoto} aria-hidden>
-                <span className={styles.heroPhotoInitial}>
-                  {performer.name.charAt(0).toUpperCase()}
-                </span>
-              </div>
-            )}
+            <div
+              className={`${styles.heroPhotoWrapper}${isAdmin ? ` ${styles.heroPhotoWrapperEditable}` : ''}`}
+              onClick={isAdmin ? () => fileInputRef.current?.click() : undefined}
+              role={isAdmin ? 'button' : undefined}
+              aria-label={isAdmin ? 'Upload performer photo' : undefined}
+            >
+              {performer.photo_url ? (
+                <img
+                  src={performer.photo_url}
+                  alt={performer.name}
+                  className={styles.heroPhoto}
+                  width={140}
+                  height={140}
+                />
+              ) : (
+                <div className={styles.heroPhoto} aria-hidden>
+                  <span className={styles.heroPhotoInitial}>
+                    {performer.name.charAt(0).toUpperCase()}
+                  </span>
+                </div>
+              )}
+              {isAdmin && (
+                <div className={styles.heroPhotoOverlay} aria-hidden>
+                  {isUploading ? (
+                    <span className={styles.heroPhotoOverlayText}>{progress}%</span>
+                  ) : (
+                    <Camera size={20} />
+                  )}
+                </div>
+              )}
+            </div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              style={{ display: 'none' }}
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) handlePhotoFileSelect(file);
+                e.target.value = '';
+              }}
+            />
             <div className={styles.heroIdentity}>
               <span className={styles.heroEyebrow}>Performer</span>
               <h1 className={styles.heroName}>{performer.name}</h1>

--- a/app/frontend/Pages/Performers/Performers.module.scss
+++ b/app/frontend/Pages/Performers/Performers.module.scss
@@ -186,8 +186,28 @@
   }
 }
 
-.heroPhoto {
+.heroPhotoWrapper {
   grid-area: photo;
+  position: relative;
+  width: 140px;
+  height: 140px;
+  flex-shrink: 0;
+
+  @media (max-width: 480px) {
+    width: 96px;
+    height: 96px;
+  }
+}
+
+.heroPhotoWrapperEditable {
+  cursor: pointer;
+
+  &:hover .heroPhotoOverlay {
+    opacity: 1;
+  }
+}
+
+.heroPhoto {
   width: 140px;
   height: 140px;
   border-radius: 999px;
@@ -203,6 +223,26 @@
     width: 96px;
     height: 96px;
   }
+}
+
+.heroPhotoOverlay {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  background: hsl(var(--foreground) / 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: hsl(var(--background));
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.heroPhotoOverlayText {
+  font-family: var(--font-ui);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
 }
 
 .heroPhotoInitial {

--- a/app/policies/performer_policy.rb
+++ b/app/policies/performer_policy.rb
@@ -12,10 +12,10 @@ class PerformerPolicy < ApplicationPolicy
   end
 
   def update?
-    user.present? && record.user_id == user.id
+    user.present? && (user.admin? || user.superadmin? || record.user_id == user.id)
   end
 
   def destroy?
-    user.present? && record.user_id == user.id
+    user.present? && (user.admin? || user.superadmin? || record.user_id == user.id)
   end
 end


### PR DESCRIPTION
Admins and superadmins can now click the photo on a performer profile page to upload or replace it via ActiveStorage direct upload.

Extend DirectUploadsController to accept session-authenticated admins as an alternative to JWT, so uploads work outside the experience context. Extend PerformerPolicy so admins can update any performer. Add useUploadPerformerPhoto hook that does a session-cookie-based direct upload then PATCHes the performer with the signed blob ID.