### PR TITLE
Remove Status: Draft element from Lobby screen

### DIFF
--- a/app/frontend/Pages/Experience/Experience.tsx
+++ b/app/frontend/Pages/Experience/Experience.tsx
@@ -207,7 +207,6 @@ export default function Experience() {
             {experience && (
               <div className={styles.experienceInfo}>
                 <h2 className={styles.experienceName}>{experience.name}</h2>
-                <p className={styles.experienceStatus}>Status: {experience.status}</p>
               </div>
             )}
 


### PR DESCRIPTION
## Summary
Removes the `Status: {status}` text element from the Lobby screen. This status display isn't needed.

The `.experienceStatus` SCSS class is left intact since `Avatar.tsx` still uses it via the shared `Experience.module.scss`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)