### PR TITLE
Fix Guess Who board: avatars, name wrapping, density, eliminations

### DIFF
--- a/app/frontend/Experiences/GuessWho/BoardGrid.tsx
+++ b/app/frontend/Experiences/GuessWho/BoardGrid.tsx
@@ -11,6 +11,11 @@ interface BoardGridProps {
   contestant: GuessWhoContestant;
 }
 
+// Four rows of eight fit comfortably on the monitor. When there are more
+// candidates than that, the final tile becomes an "and N more" overflow marker.
+const MAX_TILES = 32;
+const AVATAR_SIZE = 48;
+
 export default function BoardGrid({ contestant }: BoardGridProps) {
   const { monitorView, experience } = useExperience();
   const exp = monitorView ?? experience;
@@ -27,20 +32,21 @@ export default function BoardGrid({ contestant }: BoardGridProps) {
   const eliminated = new Set(contestant.eliminated_user_ids);
   const unanswered = new Set(contestant.unanswered_user_ids);
 
+  const remainingIds = contestant.board_candidate_ids.filter((uid) => !eliminated.has(uid));
+  const hasOverflow = remainingIds.length > MAX_TILES;
+  const visibleIds = hasOverflow ? remainingIds.slice(0, MAX_TILES - 1) : remainingIds;
+  const overflowCount = remainingIds.length - visibleIds.length;
+
   return (
     <div className={styles.board}>
-      {contestant.board_candidate_ids.map((uid) => {
+      {visibleIds.map((uid) => {
         const p = participantsByUserId.get(uid);
-        const isEliminated = eliminated.has(uid);
         const isUnanswered = unanswered.has(uid);
 
         return (
-          <div
-            key={uid}
-            className={`${styles.boardCell} ${isEliminated ? styles.boardCellEliminated : ''}`}
-          >
+          <div key={uid} className={styles.boardCell}>
             <div className={styles.boardAvatarWrap}>
-              <Avatar strokes={p?.avatar?.strokes ?? null} size={96} />
+              <Avatar strokes={p?.avatar?.strokes ?? null} size={AVATAR_SIZE} />
               {isUnanswered && (
                 <span className={styles.shameBadge} aria-label="Did not respond">
                   ?
@@ -51,6 +57,11 @@ export default function BoardGrid({ contestant }: BoardGridProps) {
           </div>
         );
       })}
+      {hasOverflow && (
+        <div className={`${styles.boardCell} ${styles.boardCellMore}`}>
+          and {overflowCount} more {overflowCount === 1 ? 'user' : 'users'}…
+        </div>
+      )}
     </div>
   );
 }

--- a/app/frontend/Experiences/GuessWho/GuessWho.module.scss
+++ b/app/frontend/Experiences/GuessWho/GuessWho.module.scss
@@ -148,29 +148,31 @@
 
 .board {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  // Cap at 8 columns: each column is at least 1/8th of the row (minus the 7
+  // gaps), and never narrower than 6rem so it wraps on smaller screens.
+  grid-template-columns: repeat(auto-fit, minmax(max(6rem, calc((100% - 5.25rem) / 8)), 1fr));
   gap: 0.75rem;
   width: 100%;
 }
 
 .boardCell {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
+  gap: 0.375rem;
+  padding: 0.5rem 0.375rem;
   background: hsl(var(--card));
   border: 1px solid hsl(var(--border));
   border-radius: 0.5rem;
-  transition:
-    opacity 0.4s,
-    filter 0.4s;
 }
 
-.boardCellEliminated {
-  opacity: 0.25;
-  filter: grayscale(1);
+.boardCellMore {
+  justify-content: center;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-align: center;
+  color: hsl(var(--muted-foreground));
 }
 
 .boardAvatarWrap {
@@ -179,15 +181,15 @@
 
 .shameBadge {
   position: absolute;
-  top: -6px;
-  right: -6px;
-  width: 28px;
-  height: 28px;
+  top: -4px;
+  right: -4px;
+  width: 18px;
+  height: 18px;
   border-radius: 50%;
   background: hsl(var(--destructive));
   color: hsl(var(--destructive-foreground, 0 0% 100%));
   font-weight: 700;
-  font-size: 1.1rem;
+  font-size: 0.75rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -195,15 +197,18 @@
 }
 
 .boardLabel {
-  flex: 1;
-  min-width: 0;
-  font-size: 1rem;
+  width: 100%;
+  font-size: 0.8rem;
   font-weight: 600;
-  text-align: left;
+  line-height: 1.2;
+  text-align: center;
   color: hsl(var(--foreground));
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 /* Donut ------------------------------------------------------------------- */

--- a/app/frontend/Experiences/GuessWho/GuessWho.stories.tsx
+++ b/app/frontend/Experiences/GuessWho/GuessWho.stories.tsx
@@ -1,6 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { BlockKind, GuessWhoBlock, GuessWhoClue, GuessWhoContestant } from '@cctv/types';
+import {
+  BlockKind,
+  ExperienceParticipant,
+  GuessWhoBlock,
+  GuessWhoClue,
+  GuessWhoContestant,
+} from '@cctv/types';
 
 import { ExperienceSeeder } from '../../../../.storybook/ExperienceSeeder';
 import { lobbyExperience, mockParticipants } from '../../../../.storybook/fixtures';
@@ -60,6 +66,91 @@ const contestant2: GuessWhoContestant = {
   mystery: { user_id: 'u4', name: 'Diana', avatar: mockParticipants[3].avatar },
 };
 
+// A 50-strong board: names include some long ones to exercise label wrapping,
+// and avatars cycle through the mock fixtures so every cell renders a drawing.
+// More than MAX_TILES (32) so the board fills four rows of eight and the final
+// tile collapses into an "and N more users…" overflow marker.
+const boardNames = [
+  'Alice',
+  'Bob',
+  'Charlie',
+  'Diana',
+  'Maximilian Featherstonehaugh',
+  'Eve',
+  'Frank',
+  'Grace',
+  'Henrietta-Wilhelmina',
+  'Ivan',
+  'Jada',
+  'Konstantinos Papadopoulos',
+  'Lin',
+  'Mateo',
+  'Nadia',
+  'Oluwaseun Adebayo-Johnson',
+  'Priya',
+  'Quincy',
+  'Rosalind',
+  'Sven',
+  'Tatiana',
+  'Umberto',
+  'Valentina Rodríguez-García',
+  'Wendell',
+  'Xiomara',
+  'Yusuf',
+  'Zara',
+  'Bartholomew',
+  'Clementine',
+  'Desmond',
+  'Esmeralda',
+  'Fitzgerald',
+  'Gwendolyn',
+  'Hieronymus',
+  'Isadora',
+  'Jeremiah',
+  'Anastasia Vasilievna Romanova',
+  'Lakshmi',
+  'Montgomery',
+  'Genevieve',
+  'Nikolai',
+  'Ophelia',
+  'Percival',
+  'Rosalind-Marie',
+  'Sebastián',
+  'Theodora',
+  'Ulrich',
+  'Vivienne',
+  'Wolfgang',
+  'Ximena',
+];
+
+const boardParticipants: ExperienceParticipant[] = boardNames.map((name, i) => {
+  const src = mockParticipants[i % mockParticipants.length];
+  return {
+    ...src,
+    id: `bp${i + 1}`,
+    user_id: `b${i + 1}`,
+    name,
+    role: 'player',
+  };
+});
+
+const bigBoardExperience = {
+  ...lobbyExperience,
+  hosts: [boardParticipants[0]],
+  participants: boardParticipants,
+};
+
+const bigBoardContestant: GuessWhoContestant = {
+  ...contestant1,
+  contestant_user_id: 'b1',
+  contestant: { user_id: 'b1', name: boardNames[0], avatar: boardParticipants[0].avatar },
+  mystery_user_id: 'b2',
+  mystery: { user_id: 'b2', name: boardNames[1], avatar: boardParticipants[1].avatar },
+  board_candidate_ids: boardParticipants.map((p) => p.user_id),
+  eliminated_user_ids: ['b5', 'b12', 'b23', 'b29'],
+  unanswered_user_ids: ['b8', 'b16'],
+};
+
 function buildBlock(overrides: Partial<GuessWhoBlock['payload']> = {}): GuessWhoBlock {
   return {
     id: 'gw1',
@@ -85,11 +176,14 @@ const meta: Meta<typeof GuessWhoMonitor> = {
   component: GuessWhoMonitor,
   tags: ['autodocs'],
   decorators: [
-    (Story) => (
-      <ExperienceSeeder experience={lobbyExperience} monitorView={lobbyExperience}>
-        <Story />
-      </ExperienceSeeder>
-    ),
+    (Story, context) => {
+      const experience = context.parameters.seedExperience ?? lobbyExperience;
+      return (
+        <ExperienceSeeder experience={experience} monitorView={experience}>
+          <Story />
+        </ExperienceSeeder>
+      );
+    },
   ],
 };
 export default meta;
@@ -128,6 +222,16 @@ export const MonitorBoardWithActivePoll: Story = {
       active_poll_contestant_index: 0,
       active_poll_response_count: 7,
       active_poll_total_participants: 12,
+    }),
+  },
+};
+
+export const MonitorBoardManyParticipants: Story = {
+  parameters: { seedExperience: bigBoardExperience },
+  args: {
+    block: buildBlock({
+      monitor_view: 'c1_board',
+      contestants: [bigBoardContestant, contestant2],
     }),
   },
 };

--- a/app/services/experiences/visibility.rb
+++ b/app/services/experiences/visibility.rb
@@ -755,6 +755,7 @@ module Experiences
           segments:      p.segment_names,
           joined_at:     p.joined_at,
           fingerprint:   p.fingerprint,
+          avatar:        p.avatar.presence,
           created_at:    p.created_at,
           updated_at:    p.updated_at
         }

--- a/spec/services/experiences/visibility_spec.rb
+++ b/spec/services/experiences/visibility_spec.rb
@@ -30,6 +30,26 @@ RSpec.describe Experiences::Visibility do
     it "does not include next_block" do
       expect(result).not_to have_key(:next_block)
     end
+
+    it "includes each participant's committed avatar" do
+      participant = create(
+        :experience_participant,
+        experience: experience,
+        role: :audience,
+        avatar: { "strokes" => [{ "points" => [1, 2, 3, 4], "color" => "#ff0000", "width" => 4 }] }
+      )
+
+      entry = result[:participants].find { |p| p[:id] == participant.id.to_s }
+      expect(entry[:avatar]).to eq("strokes" => [{ "points" => [1, 2, 3, 4], "color" => "#ff0000", "width" => 4 }])
+    end
+
+    it "serializes a nil avatar for participants who have not drawn one" do
+      participant = create(:experience_participant, experience: experience, role: :audience)
+
+      entry = result[:participants].find { |p| p[:id] == participant.id.to_s }
+      expect(entry).to have_key(:avatar)
+      expect(entry[:avatar]).to be_nil
+    end
   end
 
   describe ".for_monitor" do


### PR DESCRIPTION
## Summary

Fixes a batch of bugs and UX issues on the **Guess Who** board view.

- **Avatars restored.** `Experiences::Visibility#serialize_participants` was omitting the `avatar` field from the experience payload, so `experience.participants[].avatar` arrived `undefined` and the board rendered blank placeholders. Now serializes `avatar: p.avatar.presence` (nil when no drawing committed).
- **Name wrapping.** Board labels no longer clip with an ellipsis — names wrap and are clamped to 2 lines.
- **Density.** Board cells are now compact vertical cards with a smaller avatar (96px → 48px). The grid is capped at 8 columns with a halved column floor. This fixes cells stretching to ~1000px tall (a 96px avatar in a ~109px column left ~0 width for the name, forcing one-character-per-line wrapping).
- **Capped at 4 rows of 8 (32 tiles).** When the remaining pool is larger, the final tile collapses into an **"and N more users…"** overflow marker.
- **Eliminations remove tiles.** Eliminated candidates are now removed from the board entirely so the pool visibly shrinks, instead of being grayed out.

## Tests
- Added regression specs for participant avatar serialization (`spec/services/experiences/visibility_spec.rb`).
- Added a `MonitorBoardManyParticipants` Storybook story (50 candidates) to exercise the dense grid, long-name wrapping, and the overflow tile.

## QA Checklist

**Setup**
- [x] Run an experience with a Guess Who block and at least 2 contestants; switch the monitor to a board view (`c1_board` / `c2_board`).

**Avatars**
- [x] Each candidate tile shows the participant's hand-drawn avatar (not a blank/muted placeholder).
- [x] Participants who never drew an avatar fall back to the muted placeholder (no crash, no broken render).
- [x] Host participants on the board also render their avatars.
- [x] Contestant header avatar still renders correctly.

**Names**
- [x] Long participant names wrap onto a second line instead of clipping off the tile.
- [x] Names longer than two lines are truncated cleanly (no overflow past the card).
- [x] Tile heights stay uniform across short and long names (no runaway-tall cells).

**Density & layout**
- [x] Board lays out at most 8 columns wide.
- [x] With many candidates the board fills at most 4 rows of 8 and stays comfortably within the monitor without scrolling.
- [x] On a narrower monitor/window the grid wraps to fewer columns gracefully.

**Overflow tile**
- [ ] With ≤ 32 remaining candidates, every candidate has a tile and there is **no** "and N more" tile.
- [ ] With > 32 remaining candidates, the board shows 31 avatars plus a final "and N more users…" tile with the correct count.
- [ ] Singular/plural is correct ("and 1 more user…" vs "and 5 more users…").

**Eliminations**
- [x] Eliminating a candidate removes their tile from the board (it is not grayed out).
- [x] The "and N more" count and the rows shown both shrink as candidates are eliminated.
- [x] An eliminated candidate that had been hidden in the overflow correctly reduces the overflow count.

**Unanswered ("shame") badge**
- [x] Candidates in `unanswered_user_ids` show the red "?" badge, sized proportionally to the smaller avatar.

**Regression**
- [ ] Reveal screen, clue view, idle view, and active-poll donut overlay all still render correctly.
- [ ] Participant view (poll voting) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)