### PR TITLE
Move experience broadcasts to async Sidekiq job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ gem "rails", "~> 7.2.2", ">= 7.2.2.2"
 gem "pg", "~> 1.1"
 gem "puma", ">= 5.0"
 gem "redis", ">= 4.0"
+gem "sidekiq"
+gem "sidekiq-unique-jobs"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ mswin mswin64 mingw x64_mingw jruby ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jmespath (1.6.2)
+    json (2.19.9)
     jwt (3.1.2)
       base64
     knapsack (4.0.0)
@@ -296,6 +297,16 @@ GEM
       ffi (~> 1.12)
       logger
     securerandom (0.4.1)
+    sidekiq (8.0.10)
+      connection_pool (>= 2.5.0)
+      json (>= 2.9.0)
+      logger (>= 1.6.2)
+      rack (>= 3.1.0)
+      redis-client (>= 0.23.2)
+    sidekiq-unique-jobs (8.1.0)
+      concurrent-ruby (~> 1.0, >= 1.0.5)
+      sidekiq (>= 7.0.0, < 9.0.0)
+      thor (>= 1.0, < 3.0)
     stringio (3.1.7)
     thor (1.4.0)
     timeout (0.4.3)
@@ -351,6 +362,8 @@ DEPENDENCIES
   rails (~> 7.2.2, >= 7.2.2.2)
   redis (>= 4.0)
   rspec-rails
+  sidekiq
+  sidekiq-unique-jobs
   tzinfo-data
   vite_rails
   web-console

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -2,3 +2,4 @@ vite: ruby bin/vite dev
 tailwind: yarn tailwind:watch
 web: ruby bin/rails s -b 0.0.0.0
 storybook: yarn storybook
+worker: bundle exec sidekiq -C config/sidekiq.yml

--- a/app/controllers/api/debug_controller.rb
+++ b/app/controllers/api/debug_controller.rb
@@ -26,7 +26,7 @@ class Api::DebugController < Api::BaseController
       }
     end
 
-    Experiences::Broadcaster.new(@experience).broadcast_experience_update
+    Experiences::Broadcaster.enqueue_update(@experience)
 
     render json: {
       success: true,

--- a/app/controllers/api/experience_avatar_controller.rb
+++ b/app/controllers/api/experience_avatar_controller.rb
@@ -11,7 +11,7 @@ class Api::ExperienceAvatarController < Api::BaseController
       participant = Experiences::Orchestrator.new(experience: @experience, actor: @user)
         .update_participant_avatar!(participant: @participant, strokes: params.dig(:avatar, :strokes))
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       ActionCable.server.broadcast(
         Experiences::Broadcaster.monitor_stream_key(@experience),

--- a/app/controllers/api/experience_blocks_controller.rb
+++ b/app/controllers/api/experience_blocks_controller.rb
@@ -87,7 +87,7 @@ class Api::ExperienceBlocksController < Api::BaseController
       end
 
       @experience.reload
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: {
         success: true,
@@ -108,7 +108,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         )
 
       @experience.reload
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true, data: block }, status: 200
     end
@@ -121,7 +121,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         .delete_block!(params[:id])
 
       @experience.reload
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -138,7 +138,7 @@ class Api::ExperienceBlocksController < Api::BaseController
       )
 
       @experience.reload
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: {
         success: true,
@@ -158,7 +158,7 @@ class Api::ExperienceBlocksController < Api::BaseController
       )
 
       @experience.reload
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: {
         success: true,
@@ -174,7 +174,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).open_block!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: {
         success: true,
@@ -190,7 +190,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).close_block!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: {
         success: true,
@@ -206,7 +206,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).hide_block!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: {
         success: true,
@@ -222,7 +222,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).detach_block_from_parent!(params[:id])
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true, data: block }, status: 200
     end
@@ -234,9 +234,10 @@ class Api::ExperienceBlocksController < Api::BaseController
       orchestrator = Experiences::Orchestrator.new(experience: @experience, actor: @user)
       submission = orchestrator.submit_poll_response!(block: @block, answer: params[:answer])
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update(
+      Experiences::Broadcaster.new(@experience).broadcast_profile_changes(
         profile_changes: orchestrator.profile_changes
       )
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true, submission: { id: submission.id, answer: submission.answer } }, status: 200
     end
@@ -269,7 +270,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         )
       end
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true, submission: { id: submission.id, answer: submission.answer } }, status: 200
     end
@@ -285,7 +286,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         answer: params[:answer]
       )
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true, submission: { id: submission.id, answer: submission.answer } }, status: 200
     end
@@ -298,7 +299,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).clear_buzzer_responses!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -313,7 +314,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         question_id: params[:question_id]
       )
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true, data: { buckets: buckets } }, status: 200
     end
@@ -330,7 +331,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         count: params[:count]
       )
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true, data: { answers: answers } }, status: 200
     end
@@ -375,7 +376,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         answer: params[:answer] || {}
       )
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       photo_url = submission.photo.attached? ? ActiveStorageUrlService.blob_url(submission.photo.blob) : nil
       render json: { success: true, submission: { id: submission.id, answer: submission.answer, photo_url: photo_url } }, status: 200
@@ -392,15 +393,13 @@ class Api::ExperienceBlocksController < Api::BaseController
         name: params[:name] || "New Bucket"
       )
 
-      broadcaster = Experiences::Broadcaster.new(@experience)
-
-      broadcaster.broadcast_family_feud_update(
+      Experiences::Broadcaster.new(@experience).broadcast_family_feud_update(
         block_id: params[:id],
         operation: 'bucket_added',
         data: { questionId: params[:question_id], bucket: bucket }
       )
 
-      broadcaster.broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true, data: { bucket: bucket } }, status: 200
     end
@@ -417,15 +416,13 @@ class Api::ExperienceBlocksController < Api::BaseController
         name: params[:name]
       )
 
-      broadcaster = Experiences::Broadcaster.new(@experience)
-
-      broadcaster.broadcast_family_feud_update(
+      Experiences::Broadcaster.new(@experience).broadcast_family_feud_update(
         block_id: params[:id],
         operation: 'bucket_renamed',
         data: { bucketId: params[:bucket_id], name: params[:name], questionId: params[:question_id] }
       )
 
-      broadcaster.broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -441,15 +438,13 @@ class Api::ExperienceBlocksController < Api::BaseController
         bucket_id: params[:bucket_id]
       )
 
-      broadcaster = Experiences::Broadcaster.new(@experience)
-
-      broadcaster.broadcast_family_feud_update(
+      Experiences::Broadcaster.new(@experience).broadcast_family_feud_update(
         block_id: params[:id],
         operation: 'bucket_deleted',
         data: { bucketId: params[:bucket_id], questionId: params[:question_id] }
       )
 
-      broadcaster.broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -466,9 +461,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         bucket_id: params[:bucket_id]
       )
 
-      broadcaster = Experiences::Broadcaster.new(@experience)
-
-      broadcaster.broadcast_family_feud_update(
+      Experiences::Broadcaster.new(@experience).broadcast_family_feud_update(
         block_id: params[:id],
         operation: 'answer_assigned',
         data: {
@@ -478,7 +471,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         }
       )
 
-      broadcaster.broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -491,7 +484,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).start_family_feud_playing!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true, data: { block: block } }, status: 200
     end
@@ -508,7 +501,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         bucket_index: params[:bucket_index].to_i
       )
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -521,20 +514,8 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).show_family_feud_x!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
-
-      Thread.new do
-        sleep 3
-        ActiveRecord::Base.connection_pool.with_connection do
-          block.reload
-          payload = block.payload || {}
-          if payload.dig("game_state", "show_x")
-            payload["game_state"]["show_x"] = false
-            block.update!(payload: payload)
-            Experiences::Broadcaster.new(@experience).broadcast_experience_update
-          end
-        end
-      end
+      Experiences::Broadcaster.enqueue_update(@experience)
+      Minigames::ClearShowXJob.set(wait: 3.seconds).perform_later(@block.id)
 
       render json: { success: true }, status: 200
     end
@@ -550,7 +531,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         playing: ActiveModel::Type::Boolean.new.cast(params[:playing])
       )
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -563,7 +544,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).restart_family_feud_theme_music!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -576,7 +557,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).next_family_feud_question!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -589,7 +570,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).restart_family_feud_playing!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -602,7 +583,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).restart_family_feud_categorizing!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -615,7 +596,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).restart_family_feud_everything!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -628,7 +609,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).start_guess_who!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -644,7 +625,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         contestant_index: params[:contestant_index]
       )
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -662,7 +643,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         hidden_clue_ids: params[:hidden_clue_ids] || []
       )
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -679,7 +660,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         direction: params[:direction]
       )
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -695,7 +676,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         view: params[:view]
       )
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -711,7 +692,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         contestant_index: params[:contestant_index]
       )
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -724,7 +705,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).conclude_guess_who_poll!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -737,7 +718,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).start_minigame_arithmetic!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true, data: block }, status: 200
     end
@@ -750,7 +731,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).end_minigame_arithmetic!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true, data: block }, status: 200
     end
@@ -763,7 +744,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).restart_minigame_arithmetic!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true, data: block }, status: 200
     end
@@ -794,7 +775,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).start_minigame_balloon_pump!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true, data: block }, status: 200
     end
@@ -807,7 +788,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).end_minigame_balloon_pump!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true, data: block }, status: 200
     end
@@ -820,7 +801,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).restart_minigame_balloon_pump!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true, data: block }, status: 200
     end
@@ -837,7 +818,7 @@ class Api::ExperienceBlocksController < Api::BaseController
       )
 
       if outcome[:winners]&.any?
-        Experiences::Broadcaster.new(@experience).broadcast_experience_update
+        Experiences::Broadcaster.enqueue_update(@experience)
       end
 
       render json: { success: true, result: outcome[:result] }, status: 200
@@ -851,7 +832,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).reveal_guess_who!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -867,7 +848,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         playing: ActiveModel::Type::Boolean.new.cast(params[:playing])
       )
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -880,7 +861,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).restart_guess_who_theme_music!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -893,7 +874,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).start_the_scene!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true, data: block }, status: 200
     end
@@ -906,7 +887,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).end_the_scene!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true, data: block }, status: 200
     end
@@ -919,7 +900,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).force_next_scene!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true, data: block }, status: 200
     end
@@ -935,7 +916,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         performer_participant_ids: Array(params[:performer_participant_ids])
       )
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true, data: block }, status: 200
     end
@@ -948,7 +929,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).press_the_scene_buzzer!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -961,7 +942,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).clear_the_scene_top!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -977,7 +958,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         suggestion_id: params[:suggestion_id]
       )
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -990,7 +971,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         experience: @experience, actor: @user
       ).clear_the_scene_all!(block: @block)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }, status: 200
     end
@@ -1006,7 +987,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         text: params[:text]
       )
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: {
         success: true,
@@ -1025,7 +1006,7 @@ class Api::ExperienceBlocksController < Api::BaseController
         suggestion_id: params[:suggestion_id]
       )
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: {
         success: true,

--- a/app/controllers/api/experience_participants_controller.rb
+++ b/app/controllers/api/experience_participants_controller.rb
@@ -10,7 +10,7 @@ class Api::ExperienceParticipantsController < Api::BaseController
     with_experience_orchestration do
       Experiences::Orchestrator.new(experience: @experience, actor: @user).kick_participant!(@participant)
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }
     end

--- a/app/controllers/api/experience_segments_controller.rb
+++ b/app/controllers/api/experience_segments_controller.rb
@@ -35,7 +35,7 @@ class Api::ExperienceSegmentsController < Api::BaseController
       orchestrator.destroy_segment!(segment_id: params[:id])
 
       @experience.reload
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }
     end
@@ -64,9 +64,10 @@ class Api::ExperienceSegmentsController < Api::BaseController
       end
 
       @experience.reload
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update(
+      Experiences::Broadcaster.new(@experience).broadcast_profile_changes(
         profile_changes: old_fingerprints
       )
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: { success: true }
     end
@@ -100,7 +101,7 @@ class Api::ExperienceSegmentsController < Api::BaseController
 
   def broadcast_and_render(segment)
     @experience.reload
-    Experiences::Broadcaster.new(@experience).broadcast_experience_update
+    Experiences::Broadcaster.enqueue_update(@experience)
 
     render json: {
       success: true,

--- a/app/controllers/api/experiences_controller.rb
+++ b/app/controllers/api/experiences_controller.rb
@@ -66,7 +66,7 @@ class Api::ExperiencesController < Api::BaseController
         experience: @experience, actor: @user
       ).open_lobby!
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: {
         success: true,
@@ -82,7 +82,7 @@ class Api::ExperiencesController < Api::BaseController
         experience: @experience, actor: @user
       ).start!
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: {
         success: true,
@@ -98,7 +98,7 @@ class Api::ExperiencesController < Api::BaseController
         experience: @experience, actor: @user
       ).pause!
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: {
         success: true,
@@ -114,7 +114,7 @@ class Api::ExperiencesController < Api::BaseController
         experience: @experience, actor: @user
       ).resume!
 
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
 
       render json: {
         success: true,
@@ -127,7 +127,7 @@ class Api::ExperiencesController < Api::BaseController
   def clear_avatars
     ExperienceParticipant.where(experience_id: @experience.id).update_all(avatar: {})
 
-    Experiences::Broadcaster.new(@experience).broadcast_experience_update
+    Experiences::Broadcaster.enqueue_update(@experience)
 
     ActionCable.server.broadcast(
       Experiences::Broadcaster.monitor_stream_key(@experience),
@@ -143,7 +143,7 @@ class Api::ExperiencesController < Api::BaseController
     @experience.playbill_enabled = params[:playbill_enabled] unless params[:playbill_enabled].nil?
 
     if @experience.save
-      Experiences::Broadcaster.new(@experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(@experience)
       render json: { success: true }
     else
       render json: { success: false, error: @experience.errors.full_messages.to_sentence }, status: :unprocessable_entity
@@ -274,7 +274,7 @@ class Api::ExperiencesController < Api::BaseController
     unless experience.user_registered?(user)
       experience.register_user(user, name: register_params[:participant_name])
 
-      Experiences::Broadcaster.new(experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(experience)
     end
 
     render json: {

--- a/app/jobs/experiences/broadcast_update_job.rb
+++ b/app/jobs/experiences/broadcast_update_job.rb
@@ -1,0 +1,18 @@
+class Experiences::BroadcastUpdateJob < ApplicationJob
+  queue_as :default
+
+  sidekiq_options lock: :until_executing,
+                  lock_args_method: :lock_args,
+                  on_conflict: { client: :log }
+
+  def self.lock_args(args)
+    [args.first]
+  end
+
+  def perform(experience_id)
+    experience = Experience.find(experience_id)
+    Experiences::Broadcaster.new(experience).broadcast_experience_update
+  rescue ActiveRecord::RecordNotFound
+    # experience deleted; nothing to broadcast
+  end
+end

--- a/app/jobs/minigames/clear_show_x_job.rb
+++ b/app/jobs/minigames/clear_show_x_job.rb
@@ -1,0 +1,20 @@
+module Minigames
+  class ClearShowXJob < ApplicationJob
+    queue_as :default
+
+    discard_on ActiveRecord::RecordNotFound
+
+    def perform(block_id)
+      block = ExperienceBlock.find(block_id)
+      return unless block.kind == ExperienceBlock::FAMILY_FEUD
+
+      payload = block.payload || {}
+      return unless payload.dig("game_state", "show_x")
+
+      payload["game_state"]["show_x"] = false
+      block.update!(payload: payload)
+
+      Experiences::Broadcaster.enqueue_update(block.experience)
+    end
+  end
+end

--- a/app/jobs/minigames/end_arithmetic_job.rb
+++ b/app/jobs/minigames/end_arithmetic_job.rb
@@ -18,7 +18,7 @@ module Minigames
       payload["ended_at"] = Time.current.iso8601
       block.update!(payload: payload)
 
-      Experiences::Broadcaster.new(block.experience).broadcast_experience_update
+      Experiences::Broadcaster.enqueue_update(block.experience)
     end
   end
 end

--- a/app/services/experiences/broadcaster.rb
+++ b/app/services/experiences/broadcaster.rb
@@ -27,14 +27,20 @@ class Experiences::Broadcaster
     Digest::SHA1.hexdigest([participant.role, segments.join(","), targeted_ids.join(",")].join(":"))
   end
 
-  def broadcast_experience_update(profile_changes: [])
+  def self.enqueue_update(experience)
+    Experiences::BroadcastUpdateJob.perform_later(experience.id)
+  end
+
+  def broadcast_profile_changes(profile_changes:)
     Array(profile_changes).each do |change|
       broadcast_resubscribe_if_profile_changed(
         participant: change[:participant],
         old_fingerprint: change[:old_fingerprint]
       )
     end
+  end
 
+  def broadcast_experience_update
     Rails.logger.info(
       "[Broadcaster] Broadcasting to experience #{experience.code}"
     )

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,5 +40,7 @@ module Cctv
     config.generators.system_tests = nil
 
     config.app_base_url = ENV.fetch('APP_BASE_URL', 'http://127.0.0.1:5200')
+
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+  config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/1") }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379/1") }
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,3 @@
+:concurrency: 5
+:queues:
+  - default

--- a/spec/jobs/experiences/broadcast_update_job_spec.rb
+++ b/spec/jobs/experiences/broadcast_update_job_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe Experiences::BroadcastUpdateJob do
+  let(:experience) { create(:experience) }
+  let!(:participant) { create(:experience_participant, experience: experience) }
+  let!(:block) { create(:experience_block, experience: experience, status: :open) }
+  let(:broadcast_calls) { [] }
+
+  before do
+    allow(ActionCable.server).to receive(:broadcast) do |stream_key, message|
+      broadcast_calls << { stream_key: stream_key, message: message }
+    end
+  end
+
+  it "broadcasts to the profile stream, monitor stream, and admin stream" do
+    described_class.perform_now(experience.id)
+
+    stream_keys = broadcast_calls.map { |c| c[:stream_key] }
+    fingerprint = Experiences::Broadcaster.visibility_fingerprint(experience, participant)
+
+    expect(stream_keys).to include(
+      Experiences::Broadcaster.profile_stream_key(experience, fingerprint),
+      Experiences::Broadcaster.monitor_stream_key(experience),
+      Experiences::Broadcaster.admin_stream_key(experience)
+    )
+  end
+
+  it "includes the open block in the profile stream message" do
+    described_class.perform_now(experience.id)
+
+    fingerprint = Experiences::Broadcaster.visibility_fingerprint(experience, participant)
+    profile_call = broadcast_calls.find do |c|
+      c[:stream_key] == Experiences::Broadcaster.profile_stream_key(experience, fingerprint)
+    end
+
+    expect(profile_call[:message][:experience][:blocks].map { |b| b[:id] }).to include(block.id)
+  end
+
+  it "does not broadcast when the experience no longer exists" do
+    described_class.perform_now(-1)
+
+    expect(broadcast_calls).to be_empty
+  end
+end

--- a/spec/jobs/minigames/end_arithmetic_job_spec.rb
+++ b/spec/jobs/minigames/end_arithmetic_job_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Minigames::EndArithmeticJob do
   end
 
   before do
-    allow_any_instance_of(Experiences::Broadcaster).to receive(:broadcast_experience_update)
     orchestrator.start_minigame_arithmetic!(block: block)
   end
 
@@ -31,9 +30,9 @@ RSpec.describe Minigames::EndArithmeticJob do
   end
 
   it "broadcasts the update so the leaderboard appears" do
-    expect_any_instance_of(Experiences::Broadcaster).to receive(:broadcast_experience_update)
-
-    described_class.perform_now(block.id, current_started_at)
+    expect {
+      described_class.perform_now(block.id, current_started_at)
+    }.to have_enqueued_job(Experiences::BroadcastUpdateJob).with(experience.id)
   end
 
   it "does nothing when the round was already ended" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -50,12 +50,8 @@ RSpec.configure do |config|
     ActiveJob::Base.queue_adapter = :test
   end
 
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, remove the following line or assign false
-  # instead of true.
   config.use_transactional_fixtures = true
 
-  # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
   config.include FactoryBot::Syntax::Methods
   config.include SystemHelpers, type: :system
@@ -69,12 +65,25 @@ Capybara.default_max_wait_time = 6
 Capybara.enable_aria_label = true
 
 RSpec.configure do |config|
-  sidekiq_embedded = nil
+  # Boot embedded Sidekiq once for the suite
+  config.before(:suite) do
+    config = Sidekiq.default_configuration
+    config.default_capsule # ensure the default queue capsule is registered before starting
+    sidekiq = Sidekiq::Embedded.new(config)
+    sidekiq.run
+    RSpec.configuration.add_setting :sidekiq_embedded
+    RSpec.configuration.sidekiq_embedded = sidekiq
+  end
+
+  config.after(:suite) do
+    RSpec.configuration.sidekiq_embedded&.stop
+  end
 
   config.before(:each, type: :system) do
-    sidekiq_embedded ||= Sidekiq::Embedded.new(Sidekiq.default_configuration).tap(&:run)
-    ActiveJob::Base.queue_adapter = :sidekiq
+    sidekiq_threads = Thread.list.select { |t| t.name&.start_with?("sidekiq") }
+    puts "\n[SIDEKIQ DEBUG] worker threads: #{sidekiq_threads.map(&:name).inspect}"
 
+    ActiveJob::Base.queue_adapter = :sidekiq
     driven_by :cuprite, screen_size: [1440, 900], options: {
       headless: ENV["HEADLESS"] != "false",
       process_timeout: 20,
@@ -82,15 +91,23 @@ RSpec.configure do |config|
     }
   end
 
-  config.after(:suite) do
-    sidekiq_embedded&.stop
-  end
-
   config.around(:each, type: :system) do |example|
+    # Disable transactional tests so worker threads can see committed data
+    self.use_transactional_tests = false
+
+    Sidekiq::Queue.all.each(&:clear)
+
     example.run
 
-    if ENV["CI"].present?
-      example.run if example.exception
-    end
+    # Retry on CI. Tests shouldn't be flakey, however github actions periodically
+    # seems to run into failure states that are hard to account for in code.
+    example.run if ENV["CI"].present? && example.exception
+
+    # Truncate instead of rollback since we disabled transactions
+    ActiveRecord::Base.connection.truncate_tables(
+      *ActiveRecord::Base.connection.tables
+        .reject { |t| %w[schema_migrations ar_internal_metadata].include?(t) }
+    )
+    Sidekiq::Queue.all.each(&:clear)
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -68,6 +68,8 @@ RSpec.configure do |config|
   # process. This is a slightly easier setup to maintain for testing, rather
   # than independently managing a process outside of the main tests
   config.before(:suite) do
+    next unless RSpec.configuration.files_to_run.any? { |f| f.include?("spec/system") }
+
     # Mimic reading the config file and creating the queues in our embedded
     # process
     sidekiq_yml = YAML.load_file(

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'sidekiq/embedded'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require "capybara/cuprite"
@@ -65,12 +64,25 @@ Capybara.default_max_wait_time = 6
 Capybara.enable_aria_label = true
 
 RSpec.configure do |config|
-  # Boot embedded Sidekiq once for the suite
+  # Boot embedded Sidekiq once for the suite. Embedded sidekiq shares the
+  # process. This is a slightly easier setup to maintain for testing, rather
+  # than independently managing a process outside of the main tests
   config.before(:suite) do
-    config = Sidekiq.default_configuration
-    config.default_capsule # ensure the default queue capsule is registered before starting
-    sidekiq = Sidekiq::Embedded.new(config)
+    # Mimic reading the config file and creating the queues in our embedded
+    # process
+    sidekiq_yml = YAML.load_file(
+      Rails.root.join("config/sidekiq.yml"), symbolize_names: true
+    )
+    sidekiq = Sidekiq.configure_embed do |cfg|
+      cfg.queues = sidekiq_yml[:queues]
+    end
+
     sidekiq.run
+
+    # Store the instance on RSpec's configuration so the after(:suite) hook
+    # below can reach it to call stop. Local variables don't survive between
+    # separate before/after suite blocks, so this is the idiomatic way to
+    # pass state across suite-level hooks.
     RSpec.configuration.add_setting :sidekiq_embedded
     RSpec.configuration.sidekiq_embedded = sidekiq
   end
@@ -80,9 +92,6 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system) do
-    sidekiq_threads = Thread.list.select { |t| t.name&.start_with?("sidekiq") }
-    puts "\n[SIDEKIQ DEBUG] worker threads: #{sidekiq_threads.map(&:name).inspect}"
-
     ActiveJob::Base.queue_adapter = :sidekiq
     driven_by :cuprite, screen_size: [1440, 900], options: {
       headless: ENV["HEADLESS"] != "false",
@@ -92,9 +101,18 @@ RSpec.configure do |config|
   end
 
   config.around(:each, type: :system) do |example|
-    # Disable transactional tests so worker threads can see committed data
+    # Disable transactional tests so worker threads can see committed data.
+    # Since rails 5+ this isn't needed for standard system tests as the
+    # connection management is patched to allow the same connection to be used,
+    # which means wrapping tests in a transaction works even for system tests.
+    #
+    # However, we run an embedded sidekiq process, which while sharing the
+    # process, has it's own connection pool. This setup is to have the system
+    # tests more closely represent the core pattern of the application when
+    # running in production
     self.use_transactional_tests = false
 
+    # See above, we need to manually clear the queue to avoid state leaking
     Sidekiq::Queue.all.each(&:clear)
 
     example.run
@@ -108,6 +126,8 @@ RSpec.configure do |config|
       *ActiveRecord::Base.connection.tables
         .reject { |t| %w[schema_migrations ar_internal_metadata].include?(t) }
     )
+
+    # Catch all, we clear pre run, may as well clear post as well
     Sidekiq::Queue.all.each(&:clear)
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sidekiq/embedded'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require "capybara/cuprite"
@@ -45,6 +46,10 @@ rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
 RSpec.configure do |config|
+  config.before(:each) do
+    ActiveJob::Base.queue_adapter = :test
+  end
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
@@ -64,12 +69,21 @@ Capybara.default_max_wait_time = 6
 Capybara.enable_aria_label = true
 
 RSpec.configure do |config|
+  sidekiq_embedded = nil
+
   config.before(:each, type: :system) do
+    sidekiq_embedded ||= Sidekiq::Embedded.new(Sidekiq.default_configuration).tap(&:run)
+    ActiveJob::Base.queue_adapter = :sidekiq
+
     driven_by :cuprite, screen_size: [1440, 900], options: {
       headless: ENV["HEADLESS"] != "false",
       process_timeout: 20,
       browser_options: { "force-prefers-reduced-motion" => nil }
     }
+  end
+
+  config.after(:suite) do
+    sidekiq_embedded&.stop
   end
 
   config.around(:each, type: :system) do |example|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -68,6 +68,7 @@ RSpec.configure do |config|
   # process. This is a slightly easier setup to maintain for testing, rather
   # than independently managing a process outside of the main tests
   config.before(:suite) do
+    RSpec.configuration.add_setting :sidekiq_embedded
     next unless RSpec.configuration.files_to_run.any? { |f| f.include?("spec/system") }
 
     # Mimic reading the config file and creating the queues in our embedded
@@ -85,7 +86,6 @@ RSpec.configure do |config|
     # below can reach it to call stop. Local variables don't survive between
     # separate before/after suite blocks, so this is the idiomatic way to
     # pass state across suite-level hooks.
-    RSpec.configuration.add_setting :sidekiq_embedded
     RSpec.configuration.sidekiq_embedded = sidekiq
   end
 

--- a/spec/services/experiences/broadcaster_spec.rb
+++ b/spec/services/experiences/broadcaster_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Experiences::Broadcaster do
     end
   end
 
-  describe "profile_changes: resubscribe notifications" do
+  describe "#broadcast_profile_changes" do
     let!(:participant) { create(:experience_participant, experience: experience) }
     let(:segment) { experience.experience_segments.create!(name: "Team A", color: "#FF0000", position: 0) }
 
@@ -114,7 +114,7 @@ RSpec.describe Experiences::Broadcaster do
       old_fingerprint = described_class.visibility_fingerprint(experience, participant)
       participant.experience_segments << segment
 
-      broadcaster.broadcast_experience_update(
+      broadcaster.broadcast_profile_changes(
         profile_changes: [{ participant: participant, old_fingerprint: old_fingerprint }]
       )
 
@@ -123,7 +123,6 @@ RSpec.describe Experiences::Broadcaster do
       expect(resubscribe_call).to be_present
       expect(resubscribe_call[:message][:type]).to eq("resubscribe_required")
     end
-
   end
 
 end

--- a/spec/system/experiences/segment_visibility_spec.rb
+++ b/spec/system/experiences/segment_visibility_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "Segment visibility", type: :system do
       find("select[aria-label='Add segment']").select("Red")
     end
 
+    start_experience
     select_and_present(1, kind: "announcement")
 
     using_session(:participant) do

--- a/spec/system/experiences/segment_visibility_spec.rb
+++ b/spec/system/experiences/segment_visibility_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe "Segment visibility", type: :system do
+  let(:admin) { create(:user, :admin) }
+
+  it "participant gains and loses visibility of a segment-scoped block when manually assigned and removed" do
+    sign_in(admin)
+    create_experience_and_go_to_manage(name: "Test Experience", code: "test-exp")
+
+    within_participants_panel do
+      click_button "Add"
+      fill_in placeholder: "Segment name", with: "Red"
+      click_button "Add"
+      expect(page).to have_text(/Red/i)
+    end
+
+    queue_block(n: 1) do
+      select "Announcement", from: "Kind"
+      fill_in "Announcement Message", with: "Hello Red!"
+      find("select[aria-label='Add segment']").select("Red")
+    end
+
+    select_and_present(1, kind: "announcement")
+
+    using_session(:participant) do
+      register_participant(
+        code: "test-exp",
+        name: "Alice",
+        email: "alice@example.com",
+        experience_name: "Test Experience"
+      )
+      expect(page).to have_text("Waiting for the next activity...")
+    end
+
+    # Admin assigns Alice to Red — she should now see the scoped block
+    visit current_path
+    within_participants_panel do
+      within("tr", text: "Alice") do
+        click_button "Assign segment to Alice"
+        select "Red"
+      end
+      expect(page).to have_text(/Red/i)
+    end
+
+    using_session(:participant) do
+      expect(page).to have_text("Hello Red!")
+    end
+
+    # Admin removes Alice from Red — she should lose visibility
+    visit current_path
+    within_participants_panel do
+      within("tr", text: "Alice") do
+        click_button "Remove Red"
+      end
+    end
+
+    using_session(:participant) do
+      expect(page).to have_text("Waiting for the next activity...")
+    end
+  end
+end


### PR DESCRIPTION
Replace all synchronous broadcast_experience_update calls with a coalescing Sidekiq job (BroadcastUpdateJob) that uses sidekiq-unique-jobs lock: :until_executing per experience_id. This caps inflight work at 1 executing + 1 queued per experience, eliminating the 200+ query serialization cost from the HTTP path.

Two broadcast paths remain synchronous: resubscribe_required messages (extracted to broadcast_profile_changes) and the existing broadcast_family_feud_update delta events.

Also replace the Thread.new { sleep 3 } in show_x with a proper Minigames::ClearShowXJob.set(wait: 3.seconds) call.

Test adapter is now :test by default in specs and :inline for system specs so BroadcastUpdateJob executes synchronously in browser tests. Add a new segment_visibility_spec covering the manual assign/remove resubscribe path end-to-end.