### PR TITLE
Add PostHog analytics and error tracking

### DIFF
--- a/.claude/skills/integration-ruby-on-rails/references/identify-users.md
+++ b/.claude/skills/integration-ruby-on-rails/references/identify-users.md
@@ -1,0 +1,304 @@
+> AI agents: this is one page from PostHog's docs. Full index of Markdown docs for LLMs: https://posthog.com/llms.txt
+
+# Identify users - Docs
+
+Copy page
+
+# Identify users - Docs
+
+Linking events to specific users enables you to build a full picture of how they're using your product across different sessions, devices, and platforms.
+
+This is straightforward to do when [capturing backend events](/docs/product-analytics/capture-events?tab=Node.js.md), as you associate events to a specific user using a `distinct_id`, which is a required argument.
+
+However, in the frontend of a [web](/docs/libraries/js/usage.md#capturing-events) or [mobile app](/docs/libraries/ios.md#capturing-events), a `distinct_id` is not a required argument — PostHog's SDKs will generate an anonymous `distinct_id` for you automatically and you can capture events anonymously, provided you use the appropriate [configuration](/docs/libraries/js/usage.md#capturing-anonymous-events).
+
+To link events to specific users, call `identify`:
+
+PostHog AI
+
+### Web
+
+```javascript
+posthog.identify(
+  'distinct_id', // Replace 'distinct_id' with your user's unique identifier
+  { email: 'max@hedgehogmail.com', name: 'Max Hedgehog' }, // optional: set additional person properties
+);
+```
+
+### Android
+
+```kotlin
+PostHog.identify(
+    distinctId = distinctID, // Replace 'distinctID' with your user's unique identifier
+    // optional: set additional person properties
+    userProperties = mapOf(
+        "name" to "Max Hedgehog",
+        "email" to "max@hedgehogmail.com"
+    )
+)
+```
+
+### iOS
+
+```swift
+PostHogSDK.shared.identify("distinct_id", // Replace "distinct_id" with your user's unique identifier
+                           userProperties: ["name": "Max Hedgehog", "email": "max@hedgehogmail.com"]) // optional: set additional person properties
+```
+
+### React Native
+
+```jsx
+posthog.identify('distinct_id', {
+  // Replace "distinct_id" with your user's unique identifier
+  email: 'max@hedgehogmail.com', // optional: set additional person properties
+  name: 'Max Hedgehog',
+});
+```
+
+### Dart
+
+```dart
+await Posthog().identify(
+  userId: 'distinct_id', // Replace "distinct_id" with your user's unique identifier
+  userProperties: {
+    'email': 'max@hedgehogmail.com', // optional: set additional person properties
+    'name': 'Max Hedgehog',
+  },
+);
+```
+
+Events captured after calling `identify` are identified events and this creates a person profile if one doesn't exist already.
+
+Due to the cost of processing them, anonymous events can be up to 4x cheaper than identified events, so it's recommended you only capture identified events when needed.
+
+## How identify works
+
+When a user starts browsing your website or app, PostHog automatically assigns them an **anonymous ID**, which is stored locally.
+
+Provided you've [configured persistence](/docs/libraries/js/persistence.md) to use cookies or `localStorage`, this enables us to track anonymous users – even across different sessions.
+
+By calling `identify` with a `distinct_id` of your choice (usually the user's ID in your database, or their email), you link the anonymous ID and distinct ID together.
+
+Thus, all past and future events made with that anonymous ID are now associated with the distinct ID.
+
+This enables you to do things like associate events with a user from before they log in for the first time, or associate their events across different devices or platforms.
+
+Using identify in the backend
+
+Although you can call `identify` using our backend SDKs, it is used most in frontends. This is because there is no concept of anonymous sessions in the backend SDKs, so calling `identify` only updates person profiles.
+
+## Best practices when using `identify`
+
+### 1\. Call `identify` as soon as you're able to
+
+In your frontend, you should call `identify` as soon as you're able to.
+
+Typically, this is every time your **app loads** for the first time, and directly after your **users log in**.
+
+This ensures that events sent during your users' sessions are correctly associated with them.
+
+You only need to call `identify` once per session, and you should avoid calling it multiple times unnecessarily.
+
+If you call `identify` multiple times with the same data without reloading the page in between, PostHog will ignore the subsequent calls.
+
+#### Identify users when the web SDK loads
+
+If your app already knows the signed-in user when you initialize the JavaScript web SDK, the [`loaded` callback](/docs/libraries/js/config.md) is a convenient place to call `identify`. This identifies the user as soon as the SDK has loaded:
+
+Web
+
+PostHog AI
+
+```javascript
+posthog.init('<ph_project_token>', {
+  api_host: 'https://us.i.posthog.com',
+  defaults: '2026-05-30',
+  loaded: (posthog) => {
+    if (currentUser?.id) {
+      posthog.identify(currentUser.id, {
+        email: currentUser.email,
+        name: currentUser.name,
+      });
+    }
+  },
+});
+```
+
+In this example, `currentUser` represents user data already available from your authentication system. If your app loads the user asynchronously, call `posthog.identify()` as soon as that data becomes available instead.
+
+### 2\. Use unique strings for distinct IDs
+
+If two users have the same distinct ID, their data is merged and they are considered one user in PostHog. Two common ways this can happen are:
+
+- Your logic for generating IDs does not generate sufficiently strong IDs and you can end up with a clash where 2 users have the same ID.
+- There's a bug, typo, or mistake in your code leading to most or all users being identified with generic IDs like `null`, `true`, or `distinctId`.
+
+PostHog also has built-in protections to stop the most common distinct ID mistakes.
+
+### 3\. Reset after logout
+
+If a user logs out on your frontend, you should call `reset()` to unlink any future events made on that device with that user.
+
+This is important if your users are sharing a computer, as otherwise all of those users are grouped together into a single user due to shared cookies between sessions.
+
+**We strongly recommend you call `reset` on logout even if you don't expect users to share a computer.**
+
+You can do that like so:
+
+PostHog AI
+
+### Web
+
+```javascript
+posthog.reset();
+```
+
+### iOS
+
+```swift
+PostHogSDK.shared.reset()
+```
+
+### Android
+
+```kotlin
+PostHog.reset()
+```
+
+### React Native
+
+```jsx
+posthog.reset();
+```
+
+### Dart
+
+```dart
+await Posthog().reset();
+```
+
+If you _also_ want to reset the `device_id` so that the device will be considered a new device in future events, you can pass `true` as an argument:
+
+Web
+
+PostHog AI
+
+```javascript
+posthog.reset(true);
+```
+
+### 4\. Person profiles and properties
+
+You'll notice that one of the parameters in the `identify` method is a `properties` object.
+
+This enables you to set [person properties](/docs/product-analytics/person-properties.md).
+
+Whenever possible, we recommend passing in all person properties you have available each time you call identify, as this ensures their person profile on PostHog is up to date.
+
+Person properties can also be set being adding a `$set` property to a event `capture` call.
+
+**\`$set\` and \`$set_once\` aren't stored on events**
+
+These properties only tell PostHog how to update person data during ingestion — they aren't kept on the stored event, so you can't filter, break down, or query events by them. To query the values you set, use [person properties](/docs/product-analytics/person-properties.md) instead.
+
+See our [person properties docs](/docs/product-analytics/person-properties.md) for more details on how to work with them and best practices.
+
+### 5\. Use deep links between platforms
+
+We recommend you call `identify` [as soon as you're able](#1-call-identify-as-soon-as-youre-able), typically when a user signs up or logs in.
+
+This doesn't work if one or both platforms are unauthenticated. Some examples of such cases are:
+
+- Onboarding and signup flows before authentication.
+- Unauthenticated web pages redirecting to authenticated mobile apps.
+- Authenticated web apps prompting an app download.
+
+In these cases, you can use a [deep link](https://developer.android.com/training/app-links/deep-linking) on Android and [universal links](https://developer.apple.com/documentation/xcode/supporting-universal-links-in-your-app) on iOS to identify users.
+
+1.  Use `posthog.get_distinct_id()` to get the current distinct ID. Even if you cannot call identify because the user is unauthenticated, this will return an anonymous distinct ID generated by PostHog.
+2.  Add the distinct ID to the deep link as query parameters, along with other properties like UTM parameters.
+3.  When the user is redirected to the app, parse the deep link and handle the following cases:
+
+- The mobile app is already authenticated. In this case, call [`posthog.alias()`](/docs/libraries/js/usage.md#alias) with the distinct ID from the web. This associates the two distinct IDs as a single person.
+- The mobile app is unauthenticated. In this case, call [`posthog.identify()`](/docs/libraries/js/usage.md#identifying-users) with the distinct ID from the web so pre-login mobile events stay connected to the web session. When the user later logs in on mobile, call `identify()` again with your canonical user ID.
+
+As long as you associate the distinct IDs with `posthog.identify()` or `posthog.alias()`, you can track events generated across platforms.
+
+Here's an example implementation for handling deep links from web to mobile:
+
+PostHog AI
+
+### iOS
+
+```swift
+import PostHog
+class DeepLinkIdentityManager {
+    static let shared = DeepLinkIdentityManager()
+    // MARK: - Deep Link Received
+    func handleDeepLink(_ url: URL, isAuthenticatedOnMobile: Bool) {
+        guard let webDistinctId = URLComponents(url: url, resolvingAgainstBaseURL: true)?
+            .queryItems?.first(where: { $0.name == "ph_distinct_id" })?.value else {
+            return
+        }
+        if isAuthenticatedOnMobile {
+            // The mobile app already knows the current user.
+            // Alias the incoming web distinct ID to that user.
+            PostHogSDK.shared.alias(webDistinctId)
+        } else {
+            // Reuse the web distinct ID until login on mobile.
+            PostHogSDK.shared.identify(webDistinctId)
+        }
+    }
+    // MARK: - Login/Signup
+    func handleLogin(canonicalUserId: String) {
+        // Switch from the web distinct ID (or a mobile anon ID)
+        // to your canonical user ID.
+        PostHogSDK.shared.identify(canonicalUserId)
+        // Set user properties, track signup event, etc.
+    }
+    func handleLogout() {
+        PostHogSDK.shared.reset()
+    }
+}
+```
+
+### Android
+
+```kotlin
+import android.net.Uri
+import com.posthog.PostHog
+object DeepLinkIdentityManager {
+    // Deep Link Received
+    fun handleDeepLink(uri: Uri, isAuthenticatedOnMobile: Boolean) {
+        val webDistinctId = uri.getQueryParameter("ph_distinct_id") ?: return
+        if (isAuthenticatedOnMobile) {
+            // The mobile app already knows the current user.
+            // Alias the incoming web distinct ID to that user.
+            PostHog.alias(webDistinctId)
+        } else {
+            // Reuse the web distinct ID until login on mobile.
+            PostHog.identify(webDistinctId)
+        }
+    }
+    // Login/Signup
+    fun handleLogin(canonicalUserId: String) {
+        // Switch from the web distinct ID (or a mobile anon ID)
+        // to your canonical user ID.
+        PostHog.identify(canonicalUserId)
+        // Set user properties, track signup event, etc.
+    }
+    fun handleLogout() {
+        PostHog.reset()
+    }
+}
+```
+
+## Further reading
+
+- [Identifying users docs](/docs/product-analytics/identify.md)
+- [How person processing works](/docs/how-posthog-works/ingestion-pipeline.md#2-person-processing)
+- [An introductory guide to identifying users in PostHog](/tutorials/identifying-users-guide.md)
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/.claude/skills/integration-ruby-on-rails/references/ruby-on-rails.md
+++ b/.claude/skills/integration-ruby-on-rails/references/ruby-on-rails.md
@@ -1,0 +1,606 @@
+> AI agents: this is one page from PostHog's docs. Full index of Markdown docs for LLMs: https://posthog.com/llms.txt
+
+# Ruby on Rails - Docs
+
+Copy page
+
+# Ruby on Rails - Docs
+
+PostHog makes it easy to get data about traffic and usage of your Ruby on Rails app. Integrating PostHog enables analytics, custom event capture, feature flags, and automatic exception tracking.
+
+This guide walks you through integrating PostHog into your Rails app using the [posthog-rails gem](https://github.com/PostHog/posthog-ruby/tree/main/posthog-rails).
+
+## Beta: integration via LLM
+
+Install PostHog for Rails in seconds with our wizard by running this prompt with [LLM coding agents](/blog/envoy-wizard-llm-agent.md) like Cursor and Bolt, or by running it in your terminal.
+
+`npx @posthog/wizard`
+
+[Learn more](/wizard.md)
+
+Or, to integrate manually, continue with the rest of this guide.
+
+## Features
+
+- **Automatic exception tracking** – Captures unhandled and rescued exceptions
+- **ActiveJob instrumentation** – Tracks background job exceptions
+- **User context** – Automatically associates exceptions with the current user
+- **Smart filtering** – Excludes common Rails exceptions (404s, etc.) by default
+- **Request context** – Adds request metadata and optional PostHog tracing header identity/session context to captured events
+- **Rails 7.0+ error reporter** – Integrates with Rails' built-in error reporting
+- **Log forwarding** – Optionally forwards `Rails.logger` output to [PostHog Logs](/docs/logs.md) over OpenTelemetry, automatically correlated with request context (Ruby 3.3+)
+
+## Installation
+
+Add both gems to your Gemfile:
+
+Gemfile
+
+PostHog AI
+
+```ruby
+gem 'posthog-ruby', require: 'posthog'
+gem 'posthog-rails'
+```
+
+Then run:
+
+Terminal
+
+PostHog AI
+
+```bash
+bundle install
+```
+
+## Identifying users
+
+> **Identifying users is required.** Backend events need a `distinct_id` that matches the ID your frontend uses when calling `posthog.identify()`. Without this, backend events are orphaned — they can't be linked to frontend event captures, [session replays](/docs/session-replay.md), [LLM traces](/docs/ai-engineering.md), or [error tracking](/docs/error-tracking.md).
+>
+> See our guide on [identifying users](/docs/getting-started/identify-users.md) for how to set this up.
+
+### Generate the initializer
+
+Run the install generator to create the PostHog initializer:
+
+Terminal
+
+PostHog AI
+
+```bash
+rails generate posthog:install
+```
+
+This creates `config/initializers/posthog.rb` with sensible defaults and documentation.
+
+## Configuration
+
+`PostHog.init` creates a single client instance used across your app. Avoid creating multiple `PostHog::Client` instances with the same API key, as this can cause dropped events and inconsistent behavior.
+
+The generated initializer includes the most common options:
+
+config/initializers/posthog.rb
+
+PostHog AI
+
+```ruby
+# Rails-specific configuration
+PostHog::Rails.configure do |config|
+  config.auto_capture_exceptions = true           # Enable automatic exception capture (default: false)
+  config.report_rescued_exceptions = true         # Report exceptions Rails rescues (default: false)
+  config.auto_instrument_active_job = true        # Instrument background jobs (default: false)
+  config.use_tracing_headers = true               # Use PostHog tracing headers for identity/session context (default: true)
+  config.capture_user_context = true              # Include authenticated user info in exceptions (default: true)
+  config.current_user_method = :current_user      # Method to get current user (default: :current_user)
+  config.user_id_method = nil                     # Method to get ID from user object (default: auto-detect)
+  # Add additional exceptions to ignore
+  config.excluded_exceptions = ['MyCustomError']
+end
+# Core PostHog client initialization
+PostHog.init do |config|
+  # Required: Your PostHog project API key
+  config.api_key = '<ph_project_token>'
+  # Optional: Your PostHog instance URL
+  config.host = 'https://us.i.posthog.com'
+  # Optional: Personal API key for feature flags
+  config.personal_api_key = 'phx_xxxxxxxxx'
+  # Maximum number of events to queue before dropping (default: 10000)
+  config.max_queue_size = 10_000
+  # Send events synchronously on the calling thread (default: false)
+  config.sync_mode = false
+  # Feature flags polling interval in seconds (default: 30)
+  config.feature_flags_polling_interval = 30
+  # Feature flag request timeout in seconds (default: 3)
+  config.feature_flag_request_timeout_seconds = 3
+  # Error callback to detect misconfiguration
+  config.on_error = proc { |status, msg|
+    Rails.logger.error("PostHog error: #{msg}")
+  }
+  # Before-send callback to modify or drop events
+  config.before_send = proc { |event|
+    event[:properties] ||= {}
+    event[:properties]['environment'] = Rails.env
+    event
+  }
+  # Disable network calls in test mode
+  config.test_mode = true if Rails.env.test?
+end
+```
+
+You can find your project token and instance address in [your project settings](https://us.posthog.com/project/settings).
+
+> **Tip:** Use [`Rails.application.credentials`](https://guides.rubyonrails.org/security.html#custom-credentials) to avoid hardcoding API keys. First, add your keys and then reference them in your initializer:
+>
+> Terminal
+>
+> PostHog AI
+>
+> ```bash
+> rails credentials:edit
+> ```
+>
+> config/credentials.yml.enc
+>
+> PostHog AI
+>
+> ```yaml
+> posthog:
+>   api_key: <ph_project_token>
+>   host: https://us.i.posthog.com
+>   personal_api_key: phx_xxxxxxxxx
+> ```
+>
+> config/initializers/posthog.rb
+>
+> PostHog AI
+>
+> ```ruby
+> config.api_key = Rails.application.credentials.posthog[:api_key]
+> config.host = Rails.application.credentials.posthog[:host]
+> config.personal_api_key = Rails.application.credentials.posthog[:personal_api_key]
+> ```
+
+## Capturing events
+
+Track custom events anywhere in your Rails app:
+
+Ruby
+
+PostHog AI
+
+```ruby
+PostHog.capture({
+  distinct_id: current_user.id,
+  event: 'post_created',
+  properties: { title: @post.title }
+})
+```
+
+Identify a user and set their person properties:
+
+Ruby
+
+PostHog AI
+
+```ruby
+PostHog.identify({
+  distinct_id: current_user.id,
+  properties: {
+    email: current_user.email,
+    plan: current_user.plan
+  }
+})
+```
+
+The Rails integration delegates methods like `capture`, `identify`, `alias`, `group_identify`, `evaluate_flags`, `capture_exception`, `flush`, and `shutdown` to the initialized `PostHog::Client`.
+
+## Request context
+
+PostHog Rails automatically applies request-scoped context to events captured during web requests. Request metadata such as `$current_url`, `$request_method`, `$request_path`, `$user_agent`, and `$ip` is added to event properties.
+
+When `use_tracing_headers` is enabled, PostHog tracing headers (`X-PostHog-Distinct-Id` and `X-PostHog-Session-Id`) are also used as default `distinct_id` and `$session_id` values. Explicit `distinct_id` and properties passed to `PostHog.capture` always take precedence.
+
+If you're using [PostHog JS](/docs/libraries/js.md) on the frontend, configure [`tracing_headers`](/docs/libraries/js/config.md#tracing-headers) for your Rails backend hostname so browser requests include the session and distinct ID headers.
+
+Tracing headers are client-controlled analytics context, not authentication or authorization. Pass an authenticated `distinct_id` explicitly for security-sensitive server-side decisions.
+
+Disable tracing header identity/session capture if you do not want client-supplied tracing headers used for server-side events. Request metadata is still captured:
+
+Ruby
+
+PostHog AI
+
+```ruby
+PostHog::Rails.config.use_tracing_headers = false
+```
+
+## Logs
+
+To set up [PostHog Logs](/docs/logs.md) in your Rails app, follow the [Ruby on Rails logs installation guide](/docs/logs/installation/ruby-on-rails.md). The integration forwards `Rails.logger` output to PostHog Logs over OpenTelemetry, automatically correlated with each request's distinct ID and session ID. Requires Ruby 3.3+.
+
+## Error tracking
+
+For full details on setting up error tracking with Rails, see our [Rails error tracking installation guide](/docs/error-tracking/installation/ruby-on-rails.md).
+
+### Automatic exception tracking
+
+When `auto_capture_exceptions` is enabled, exceptions are automatically captured:
+
+Ruby
+
+PostHog AI
+
+```ruby
+class PostsController < ApplicationController
+  def show
+    @post = Post.find(params[:id])
+    # Any exception here is automatically captured
+  end
+end
+```
+
+`report_rescued_exceptions` controls whether exceptions Rails rescues (for example, exceptions rendered by Rails error pages) are captured. Enable it along with `auto_capture_exceptions` for complete error visibility, or leave it disabled to capture only unhandled exceptions.
+
+### Manual exception capture
+
+You can also manually capture exceptions:
+
+Ruby
+
+PostHog AI
+
+```ruby
+PostHog.capture_exception(
+  exception,
+  current_user.id,
+  { custom_property: 'value' }
+)
+```
+
+If you evaluated feature flags for the request, pass the same snapshot to include matching flag properties on the exception event:
+
+Ruby
+
+PostHog AI
+
+```ruby
+flags = PostHog.evaluate_flags(current_user.id)
+PostHog.capture_exception(
+  exception,
+  current_user.id,
+  { custom_property: 'value' },
+  flags: flags
+)
+```
+
+### Background job exceptions
+
+When `auto_instrument_active_job` is enabled, ActiveJob exceptions are automatically captured with job context:
+
+Ruby
+
+PostHog AI
+
+```ruby
+class EmailJob < ApplicationJob
+  def perform(user_id)
+    user = User.find(user_id)
+    UserMailer.welcome(user).deliver_now
+    # Exceptions are automatically captured
+  end
+end
+```
+
+#### Associating jobs with users
+
+By default, PostHog extracts a `distinct_id` from job arguments by looking for a `user_id` key in hash arguments:
+
+Ruby
+
+PostHog AI
+
+```ruby
+# PostHog will automatically use options[:user_id] as the distinct_id
+ProcessOrderJob.perform_later(order.id, user_id: current_user.id)
+```
+
+For more control, use the `posthog_distinct_id` class method. The proc or block receives the same arguments as `perform`:
+
+Ruby
+
+PostHog AI
+
+```ruby
+class SendWelcomeEmailJob < ApplicationJob
+  posthog_distinct_id ->(user, _options) { user.id }
+  def perform(user, options = {})
+    UserMailer.welcome(user).deliver_now
+  end
+end
+```
+
+You can also use a block:
+
+Ruby
+
+PostHog AI
+
+```ruby
+class ProcessOrderJob < ApplicationJob
+  posthog_distinct_id do |_order, notify_user_id|
+    notify_user_id
+  end
+  def perform(order, notify_user_id)
+    # Process the order...
+  end
+end
+```
+
+### Rails 7.0+ error reporter
+
+PostHog integrates with Rails' built-in error reporting:
+
+Ruby
+
+PostHog AI
+
+```ruby
+# These errors are automatically sent to PostHog
+Rails.error.handle do
+  # Code that might raise an error
+end
+Rails.error.record(exception, context: { user_id: current_user.id })
+```
+
+PostHog automatically extracts the user's distinct ID from `user_id` or `distinct_id` in the context hash. Other context keys are included as properties on the exception event.
+
+### User context
+
+PostHog Rails automatically captures authenticated user information from your controllers for exceptions. Authenticated Rails user context takes precedence over client-supplied tracing headers for exception identity.
+
+If your user method has a different name, configure it:
+
+Ruby
+
+PostHog AI
+
+```ruby
+PostHog::Rails.config.current_user_method = :logged_in_user
+```
+
+#### User ID extraction
+
+By default, PostHog Rails auto-detects the user's distinct ID by trying these methods in order:
+
+1.  `posthog_distinct_id` – Define this on your User model for full control
+2.  `distinct_id` – Common analytics convention
+3.  `id` – Standard ActiveRecord primary key
+4.  `pk` – Primary key alias
+5.  `uuid` – For UUID-based primary keys
+
+It also checks hash-like users for `id`, `pk`, and `uuid` keys.
+
+You can configure a specific method:
+
+Ruby
+
+PostHog AI
+
+```ruby
+PostHog::Rails.config.user_id_method = :email
+```
+
+Or define a method on your User model:
+
+Ruby
+
+PostHog AI
+
+```ruby
+class User < ApplicationRecord
+  def posthog_distinct_id
+    "user_#{id}"  # or external_id, or any unique identifier
+  end
+end
+```
+
+### Excluded exceptions
+
+The following exceptions are not reported by default (common 4xx errors):
+
+- `AbstractController::ActionNotFound`
+- `ActionController::BadRequest`
+- `ActionController::InvalidAuthenticityToken`
+- `ActionController::InvalidCrossOriginRequest`
+- `ActionController::MethodNotAllowed`
+- `ActionController::NotImplemented`
+- `ActionController::ParameterMissing`
+- `ActionController::RoutingError`
+- `ActionController::UnknownFormat`
+- `ActionController::UnknownHttpMethod`
+- `ActionDispatch::Http::Parameters::ParseError`
+- `ActiveRecord::RecordNotFound`
+- `ActiveRecord::RecordNotUnique`
+
+Add more with:
+
+Ruby
+
+PostHog AI
+
+```ruby
+PostHog::Rails.config.excluded_exceptions = ['MyException']
+```
+
+## Feature flags
+
+Evaluate flags once for the current user, then read values from the returned snapshot:
+
+Ruby
+
+PostHog AI
+
+```ruby
+class PostsController < ApplicationController
+  def show
+    flags = PostHog.evaluate_flags(current_user.id)
+    if flags.enabled?('new-post-design')
+      render 'posts/show_new'
+    else
+      render 'posts/show'
+    end
+  end
+end
+```
+
+For multivariate flags and experiments, use `get_flag`:
+
+Ruby
+
+PostHog AI
+
+```ruby
+flags = PostHog.evaluate_flags(current_user.id)
+variant = flags.get_flag('checkout-experiment')
+if variant == 'test'
+  # Do something differently
+end
+```
+
+When capturing an event after branching on a flag, pass the same `flags` snapshot so the event includes the exact flag values used by your code:
+
+Ruby
+
+PostHog AI
+
+```ruby
+flags = PostHog.evaluate_flags(current_user.id)
+PostHog.capture({
+  distinct_id: current_user.id,
+  event: 'checkout_started',
+  flags: flags.only_accessed
+})
+```
+
+For local evaluation, ensure you've set `personal_api_key`:
+
+Ruby
+
+PostHog AI
+
+```ruby
+config.personal_api_key = Rails.application.credentials.posthog[:personal_api_key]
+```
+
+See our [Ruby SDK docs](/docs/libraries/ruby.md#local-evaluation) for details on local evaluation with Puma and Unicorn servers.
+
+> **Note:** `PostHog.is_feature_enabled`, `PostHog.get_feature_flag`, `PostHog.get_feature_flag_result`, `PostHog.get_feature_flag_payload`, and `PostHog.capture({ ..., send_feature_flags: true })` still work during the migration period, but they're deprecated. Prefer `PostHog.evaluate_flags` for new code.
+
+## Testing
+
+In your test environment, disable network calls with test mode:
+
+config/environments/test.rb
+
+PostHog AI
+
+```ruby
+PostHog.init do |config|
+  config.api_key = '<ph_project_token>'
+  config.test_mode = true
+end
+```
+
+Or in your specs:
+
+spec/rails_helper.rb
+
+PostHog AI
+
+```ruby
+RSpec.configure do |config|
+  config.before(:each) do
+    allow(PostHog).to receive(:capture)
+  end
+end
+```
+
+## Configuration reference
+
+### Core PostHog options
+
+| Option                               | Type    | Default                  | Description                                                                                                                |
+| ------------------------------------ | ------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| api_key                              | String  | required                 | Your PostHog project token.                                                                                                |
+| host                                 | String  | https://us.i.posthog.com | Fully qualified PostHog API host.                                                                                          |
+| personal_api_key                     | String  | nil                      | Personal API key for local feature flag evaluation and remote config payloads.                                             |
+| max_queue_size                       | Integer | 10000                    | Maximum number of events to keep in the async queue before dropping new events.                                            |
+| test_mode                            | Boolean | false                    | Keep events queued and do not send them. Useful for tests.                                                                 |
+| sync_mode                            | Boolean | false                    | Send events synchronously on the calling thread.                                                                           |
+| on_error                             | Proc    | no-op                    | Callback called as on_error.call(status, error).                                                                           |
+| feature_flags_polling_interval       | Integer | 30                       | Seconds between local feature flag definition polls.                                                                       |
+| feature_flag_request_timeout_seconds | Integer | 3                        | Timeout, in seconds, for feature flag requests.                                                                            |
+| before_send                          | Proc    | nil                      | Callback that receives the event hash before it is queued or sent. Return a modified event hash, or nil to drop the event. |
+
+The `PostHog.init` block supports the options above. Less common core options like `batch_size`, `disable_singleton_warning`, `skip_ssl_verification`, and `flag_definition_cache_provider` can be passed as an options hash to `PostHog.init(...)`; see the [Ruby SDK docs](/docs/libraries/ruby.md#configuration) for details.
+
+### Rails-specific options
+
+Configure these via `PostHog::Rails.configure` or `PostHog::Rails.config`:
+
+| Option                     | Type    | Default       | Description                                                                         |
+| -------------------------- | ------- | ------------- | ----------------------------------------------------------------------------------- |
+| auto_capture_exceptions    | Boolean | false         | Automatically capture exceptions.                                                   |
+| report_rescued_exceptions  | Boolean | false         | Report exceptions Rails rescues.                                                    |
+| auto_instrument_active_job | Boolean | false         | Capture ActiveJob exceptions with job context.                                      |
+| excluded_exceptions        | Array   | []            | Additional exception class names to ignore.                                         |
+| use_tracing_headers        | Boolean | true          | Use X-PostHog-Distinct-Id and X-PostHog-Session-Id as request-scoped defaults.      |
+| capture_user_context       | Boolean | true          | Include authenticated user info in exceptions.                                      |
+| current_user_method        | Symbol  | :current_user | Controller method used to fetch the current user.                                   |
+| user_id_method             | Symbol  | nil           | Method used to extract the distinct ID from the user object. Auto-detects when nil. |
+
+## Troubleshooting
+
+### Exceptions not being captured
+
+1.  Verify PostHog is initialized:
+
+    Ruby
+
+    PostHog AI
+
+    ```ruby
+    Rails.console
+    > PostHog.initialized?
+    => true
+    ```
+
+2.  Check your excluded exceptions list.
+
+3.  Verify middleware is installed:
+
+    Ruby
+
+    PostHog AI
+
+    ```ruby
+    Rails.application.middleware
+    ```
+
+### User context not working
+
+1.  Verify `current_user_method` matches your controller method.
+2.  Check that the user object responds to `posthog_distinct_id`, `distinct_id`, `id`, `pk`, or `uuid`.
+3.  If using a custom identifier, set `PostHog::Rails.config.user_id_method = :your_method`.
+
+### Feature flags not working
+
+Ensure you've set `personal_api_key` in your configuration.
+
+## Next steps
+
+For any technical questions for how to integrate specific PostHog features into Rails (such as analytics, feature flags, A/B testing, etc.), have a look at our [Ruby SDK docs](/docs/libraries/ruby.md).
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/.claude/skills/integration-ruby-on-rails/references/ruby.md
+++ b/.claude/skills/integration-ruby-on-rails/references/ruby.md
@@ -1,0 +1,761 @@
+> AI agents: this is one page from PostHog's docs. Full index of Markdown docs for LLMs: https://posthog.com/llms.txt
+
+# Ruby - Docs
+
+Copy page
+
+# Ruby - Docs
+
+The `posthog-ruby` library provides tracking functionality on the server-side for applications built in Ruby.
+
+It uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server-side application that needs performance.
+
+> **Use a single client instance (singleton)** — Create the PostHog client once and reuse it throughout your application. Multiple client instances with the same API key can cause dropped events and inconsistent behavior. The SDK logs a warning if it detects multiple instances.
+
+## Installation
+
+Add this to your `Gemfile`:
+
+Terminal
+
+PostHog AI
+
+```bash
+gem "posthog-ruby"
+```
+
+In your app, set your API key **before** making any calls. If setting a custom `host`, make sure to include the protocol (e.g. `https://`).
+
+Ruby
+
+PostHog AI
+
+```ruby
+require 'posthog'
+posthog = PostHog::Client.new({
+  api_key: "<ph_project_token>",
+  host: "https://us.i.posthog.com",
+  on_error: Proc.new { |status, msg| print msg }
+})
+```
+
+You can find your project token and instance address in the [project settings](https://app.posthog.com/project/settings) page in PostHog.
+
+## Configuration
+
+Initialize the client with your project token before making any calls:
+
+Ruby
+
+PostHog AI
+
+```ruby
+require 'posthog'
+posthog = PostHog::Client.new({
+  api_key: '<ph_project_token>',
+  host: 'https://us.i.posthog.com',
+  on_error: Proc.new { |status, msg| print msg }
+})
+```
+
+Available client options:
+
+| Option                               | Type    | Default                  | Description                                                                                                                                |
+| ------------------------------------ | ------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| api_key                              | String  | required                 | Your PostHog project token.                                                                                                                |
+| host                                 | String  | https://us.i.posthog.com | Fully qualified PostHog API host. Include the protocol, for example https://us.i.posthog.com or https://eu.i.posthog.com.                  |
+| personal_api_key                     | String  | nil                      | Personal API key. Required for local feature flag evaluation and remote config payloads.                                                   |
+| max_queue_size                       | Integer | 10000                    | Maximum number of events to keep in the async queue before dropping new events.                                                            |
+| batch_size                           | Integer | 100                      | Maximum number of events to send in one async batch.                                                                                       |
+| test_mode                            | Boolean | false                    | Keep events queued and do not send them. Useful for tests.                                                                                 |
+| sync_mode                            | Boolean | false                    | Send events synchronously on the calling thread. Useful in forking environments like Sidekiq and Resque.                                   |
+| on_error                             | Proc    | no-op                    | Callback called as on_error.call(status, error) for API or serialization errors.                                                           |
+| feature_flags_polling_interval       | Integer | 30                       | Seconds between local feature flag definition polls.                                                                                       |
+| feature_flag_request_timeout_seconds | Integer | 3                        | Timeout, in seconds, for feature flag requests.                                                                                            |
+| before_send                          | Proc    | nil                      | Callback that receives the event hash before it is queued or sent. Return a modified event hash, or nil to drop the event.                 |
+| disable_singleton_warning            | Boolean | false                    | Suppress warnings about multiple clients with the same API key. Use only when you intentionally need multiple clients.                     |
+| skip_ssl_verification                | Boolean | false                    | Disable SSL certificate verification. Intended only for local development or custom deployments.                                           |
+| flag_definition_cache_provider       | Object  | nil                      | Provider for distributed feature flag definition caching. See [distributed flag definition caching](#distributed-flag-definition-caching). |
+
+### Filtering or modifying events before sending
+
+Use `before_send` to add, modify, or drop events immediately before the SDK queues or sends them:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog = PostHog::Client.new({
+  api_key: '<ph_project_token>',
+  before_send: Proc.new do |event|
+    event[:properties] ||= {}
+    event[:properties]['environment'] = ENV['RACK_ENV']
+    # Return nil to drop the event
+    event[:properties]['internal_user'] == true ? nil : event
+  end
+})
+```
+
+### Flushing and shutting down
+
+For short-lived scripts, call `flush` before the process exits. Call `shutdown` when your application is stopping to flush pending events and stop background resources.
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.capture({ distinct_id: 'user_123', event: 'script_finished' })
+posthog.flush
+posthog.shutdown
+```
+
+## Identifying users
+
+> **Identifying users is required.** Backend events need a `distinct_id` that matches the ID your frontend uses when calling `posthog.identify()`. Without this, backend events are orphaned — they can't be linked to frontend event captures, [session replays](/docs/session-replay.md), [LLM traces](/docs/ai-engineering.md), or [error tracking](/docs/error-tracking.md).
+>
+> See our guide on [identifying users](/docs/getting-started/identify-users.md) for how to set this up.
+
+Identify a user and set their person properties with `identify`:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.identify({
+  distinct_id: 'distinct_id_of_your_user',
+  properties: {
+    email: 'john@doe.com',
+    pro_user: false
+  }
+})
+```
+
+## Capturing events
+
+You can send custom events using `capture`:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.capture({
+    distinct_id: 'distinct_id_of_the_user',
+    event: 'user_signed_up'
+})
+```
+
+> **Tip:** We recommend using a `[object] [verb]` format for your event names, where `[object]` is the entity that the behavior relates to, and `[verb]` is the behavior itself. For example, `project created`, `user signed up`, or `invite sent`.
+
+### Setting event properties
+
+Optionally, you can include additional information with the event by including a [properties](/docs/data/events.md#event-properties) object:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.capture({
+    distinct_id: 'distinct_id_of_the_user',
+    event: 'user_signed_up',
+    properties: {
+        login_type: 'email',
+        is_free_trial: true
+    }
+})
+```
+
+### Sending pageviews
+
+If you're aiming for a backend-only implementation of PostHog and won't be capturing events from your frontend, you can send `pageviews` from your backend like so:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.capture({
+    distinct_id: 'distinct_id_of_the_user',
+    event: '$pageview',
+    properties: {
+        '$current_url': 'https://example.com'
+    }
+})
+```
+
+`capture` accepts these fields:
+
+| Field              | Type                                               | Description                                                                                                                                        |
+| ------------------ | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| distinct_id        | String                                             | The user ID. If omitted, framework integrations can provide request context; otherwise the SDK generates a UUID and marks the event as personless. |
+| event              | String                                             | Event name. Required.                                                                                                                              |
+| properties         | Hash                                               | Event properties.                                                                                                                                  |
+| groups             | Hash                                               | Group analytics mapping from group type to group key.                                                                                              |
+| timestamp          | Time                                               | When the event occurred. Defaults to the current time.                                                                                             |
+| message_id         | String                                             | Optional message ID.                                                                                                                               |
+| uuid               | String                                             | Optional event UUID used for deduplication. Must be a valid UUID.                                                                                  |
+| flags              | PostHog::FeatureFlagEvaluations                    | Snapshot returned by evaluate_flags. Adds $feature/<key> and $active_feature_flags properties without another /flags request.                      |
+| send_feature_flags | Boolean, Hash, or PostHog::SendFeatureFlagsOptions | Deprecated. Prefer passing flags: from evaluate_flags.                                                                                             |
+
+## Person profiles and properties
+
+The Ruby SDK captures identified events by default. These create [person profiles](/docs/data/persons.md). To set [person properties](/docs/data/user-properties.md) in these profiles, include them when capturing an event:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.capture({
+    distinct_id: 'distinct_id',
+    event: 'event_name',
+    properties: {
+        '$set': { name: 'Max Hedgehog' },
+        '$set_once': { initial_url: '/blog' }
+    }
+})
+```
+
+For more details on the difference between `$set` and `$set_once`, see our [person properties docs](/docs/data/user-properties.md#what-is-the-difference-between-set-and-set_once).
+
+To capture [anonymous events](/docs/data/anonymous-vs-identified-events.md) without person profiles, set the event's `$process_person_profile` property to `false`:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.capture({
+    distinct_id: 'distinct_id',
+    event: 'event_name',
+    properties: {
+        '$process_person_profile': false
+    }
+})
+```
+
+## Alias
+
+Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend.
+
+In this case, you can use `alias` to assign another distinct ID to the same user.
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.alias({
+  distinct_id: 'distinct_id',
+  alias: 'alias_id'
+})
+```
+
+We strongly recommend reading our docs on [alias](/docs/data/identify.md#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
+
+## Feature flags
+
+PostHog's [feature flags](/docs/feature-flags.md) enable you to safely deploy and roll back new features as well as target specific users and groups with them.
+
+There are two steps to implement feature flags in Ruby:
+
+### Step 1: Evaluate flags once
+
+Call `posthog.evaluate_flags()` once for the user, then read values from the returned snapshot.
+
+#### Boolean feature flags
+
+Ruby
+
+PostHog AI
+
+```ruby
+flags = posthog.evaluate_flags('distinct_id_of_your_user')
+if flags.enabled?('flag-key')
+    # Do something differently for this user
+    # Optional: fetch the payload
+    matched_flag_payload = flags.get_flag_payload('flag-key')
+end
+```
+
+#### Multivariate feature flags
+
+Ruby
+
+PostHog AI
+
+```ruby
+flags = posthog.evaluate_flags('distinct_id_of_your_user')
+enabled_variant = flags.get_flag('flag-key')
+if enabled_variant == 'variant-key' # replace 'variant-key' with the key of your variant
+    # Do something differently for this user
+    # Optional: fetch the payload
+    matched_flag_payload = flags.get_flag_payload('flag-key')
+end
+```
+
+`flags.get_flag()` returns the variant string for multivariate flags, `true` for enabled boolean flags, `false` for disabled flags, and `nil` when the flag wasn't returned by the evaluation.
+
+> **Note:** `posthog.is_feature_enabled()`, `posthog.get_feature_flag()`, `posthog.get_feature_flag_result()`, `posthog.get_feature_flag_payload()`, and `capture({ ..., send_feature_flags: true })` still work during the migration period, but they're deprecated. Prefer `evaluate_flags()` for new code.
+
+### Step 2: Include feature flag information when capturing events
+
+If you want use your feature flag to breakdown or filter events in your [insights](/docs/product-analytics/insights.md), you'll need to include feature flag information in those events. This ensures that the feature flag value is attributed correctly to the event.
+
+> **Note:** This step is only required for events captured using our server-side SDKs or [API](/docs/api.md).
+
+There are two methods you can use to include feature flag information in your events:
+
+#### Method 1: Pass the evaluated flags snapshot to `capture()`
+
+Pass the same `flags` object that you used for branching. This attaches the exact flag values from that evaluation and doesn't make another `/flags` request.
+
+Ruby
+
+PostHog AI
+
+```ruby
+flags = posthog.evaluate_flags('distinct_id_of_your_user')
+if flags.enabled?('flag-key')
+    # Do something differently for this user
+end
+posthog.capture({
+    distinct_id: 'distinct_id_of_your_user',
+    event: 'event_name',
+    flags: flags,
+})
+```
+
+By default, this attaches every flag in the snapshot using `$feature/<flag-key>` properties and `$active_feature_flags`.
+
+To reduce event property bloat, pass a filtered snapshot:
+
+Ruby
+
+PostHog AI
+
+```ruby
+# Attach only flags accessed with enabled?() or get_flag() before this call
+posthog.capture({
+    distinct_id: 'distinct_id_of_your_user',
+    event: 'event_name',
+    flags: flags.only_accessed,
+})
+# Attach only specific flags
+posthog.capture({
+    distinct_id: 'distinct_id_of_your_user',
+    event: 'event_name',
+    flags: flags.only(['checkout-flow', 'new-dashboard']),
+})
+```
+
+`only_accessed` is order-dependent. If you call it before accessing any flags with `enabled?()` or `get_flag()`, no feature flag properties are attached.
+
+#### Method 2: Include the `$feature/feature_flag_name` property manually
+
+In the event properties, include `$feature/feature_flag_name: variant_key`:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.capture({
+    distinct_id: 'distinct_id_of_your_user',
+    event: 'event_name',
+    properties: {
+        # Replace feature-flag-key with your flag key and 'variant-key' with the key of your variant
+        '$feature/feature-flag-key': 'variant-key',
+    },
+})
+```
+
+### Evaluating only specific flags
+
+By default, `evaluate_flags()` evaluates every flag for the user. If you only need a few flags, pass `flag_keys` to request only those flags:
+
+Ruby
+
+PostHog AI
+
+```ruby
+flags = posthog.evaluate_flags(
+    'distinct_id_of_your_user',
+    flag_keys: ['checkout-flow', 'new-dashboard'],
+)
+```
+
+### Evaluating locally only
+
+If you want to skip the remote `/flags` request and only use locally cached definitions, pass `only_evaluate_locally: true`:
+
+Ruby
+
+PostHog AI
+
+```ruby
+flags = posthog.evaluate_flags(
+    'distinct_id_of_your_user',
+    only_evaluate_locally: true,
+)
+```
+
+### Disabling GeoIP for flag evaluation
+
+Pass `disable_geoip: true` to disable GeoIP lookup for remote flag evaluation:
+
+Ruby
+
+PostHog AI
+
+```ruby
+flags = posthog.evaluate_flags(
+    'distinct_id_of_your_user',
+    disable_geoip: true,
+)
+```
+
+### Sending `$feature_flag_called` events
+
+Capturing `$feature_flag_called` events enables PostHog to know when a flag was accessed by a user and provide [analytics and insights](/docs/product-analytics/insights.md) on the flag. With `evaluate_flags()`, the SDK sends this event when you call `flags.enabled?()` or `flags.get_flag()` for a flag.
+
+The SDK deduplicates these events per `(distinct_id, flag, value)` in a local cache. If you reinitialize the PostHog client, the cache resets and `$feature_flag_called` events may be sent again. PostHog handles duplicates, so duplicate `$feature_flag_called` events don't affect your analytics.
+
+`flags.get_flag_payload()` doesn't send `$feature_flag_called` events and doesn't count as an access for `only_accessed`.
+
+### Advanced: Overriding server properties
+
+Sometimes, you may want to evaluate feature flags using [person properties](/docs/product-analytics/person-properties.md), [groups](/docs/product-analytics/group-analytics.md), or group properties that haven't been ingested yet, or were set incorrectly earlier.
+
+You can provide properties to evaluate the flag with by using the `person properties`, `groups`, and `group properties` arguments. PostHog will then use these values to evaluate the flag, instead of any properties currently stored on your PostHog server.
+
+For example:
+
+Ruby
+
+PostHog AI
+
+```ruby
+flags = posthog.evaluate_flags(
+    'distinct_id_of_the_user',
+    person_properties: {
+        property_name: 'value'
+    },
+    groups: {
+        your_group_type: 'your_group_id',
+        another_group_type: 'your_group_id',
+    },
+    group_properties: {
+        your_group_type: {
+            group_property_name: 'value'
+        },
+        another_group_type: {
+            group_property_name: 'value'
+        },
+    },
+)
+if flags.enabled?('flag-key')
+    # Do something differently for this user
+end
+```
+
+### Overriding GeoIP properties
+
+By default, a user's GeoIP properties are set using the IP address they use to capture events on the frontend. You may want to override the these properties when evaluating feature flags. A common reason to do this is when you're not using PostHog on your frontend, so the user has no GeoIP properties.
+
+You can override GeoIP properties by including them in the `person_properties` parameter when evaluating feature flags. This is useful when you're evaluating flags on your backend and want to use the client's location instead of your server's location.
+
+The following GeoIP properties can be overridden:
+
+- `$geoip_country_code`
+- `$geoip_country_name`
+- `$geoip_city_name`
+- `$geoip_city_confidence`
+- `$geoip_continent_code`
+- `$geoip_continent_name`
+- `$geoip_latitude`
+- `$geoip_longitude`
+- `$geoip_postal_code`
+- `$geoip_subdivision_1_code`
+- `$geoip_subdivision_1_name`
+- `$geoip_subdivision_2_code`
+- `$geoip_subdivision_2_name`
+- `$geoip_subdivision_3_code`
+- `$geoip_subdivision_3_name`
+- `$geoip_time_zone`
+
+Simply include any of these properties in the `person_properties` parameter alongside your other person properties when calling feature flags.
+
+### Request timeout
+
+You can configure the `feature_flag_request_timeout_seconds` parameter when initializing your PostHog client to set a flag request timeout. This helps prevent your code from being blocked if PostHog's servers are too slow to respond. By default, this is set to 3 seconds.
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog = PostHog::Client.new({
+    # rest of your configuration...
+    feature_flag_request_timeout_seconds: 3 # Time in seconds. Defaults to 3.
+})
+```
+
+### Legacy single-flag methods
+
+The following methods are still available during the migration period, but are deprecated. Prefer `evaluate_flags` for new code.
+
+| Method                                                       | Replacement                                                                   |
+| ------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| posthog.is_feature_enabled(flag_key, distinct_id, ...)       | posthog.evaluate_flags(distinct_id, ...).enabled?(flag_key)                   |
+| posthog.get_feature_flag(flag_key, distinct_id, ...)         | posthog.evaluate_flags(distinct_id, ...).get_flag(flag_key)                   |
+| posthog.get_feature_flag_payload(flag_key, distinct_id, ...) | posthog.evaluate_flags(distinct_id, ...).get_flag_payload(flag_key)           |
+| posthog.get_feature_flag_result(flag_key, distinct_id, ...)  | posthog.evaluate_flags(distinct_id, ...) and read get_flag / get_flag_payload |
+| posthog.capture({ ..., send_feature_flags: true })           | posthog.capture({ ..., flags: flags })                                        |
+
+### Local Evaluation
+
+Evaluating feature flags requires making a request to PostHog for each flag. However, you can improve performance by evaluating flags locally. Instead of making a request for each flag, PostHog will periodically request and store feature flag definitions locally, enabling you to evaluate flags without making additional requests.
+
+It is best practice to use local evaluation flags when possible, since this enables you to resolve flags faster and with fewer API calls.
+
+For details on how to implement local evaluation, see our [local evaluation guide](/docs/feature-flags/local-evaluation.md).
+
+#### Evaluating feature flags locally in unicorn server
+
+If you have `preload_app true` in your unicorn config, you can use the [`after_fork`](https://www.rubydoc.info/gems/unicorn/Unicorn%2FConfigurator:after_fork) hook (which is part of the unicorn's configuration) to enable the feature flag cache to receive the updates from PostHog.
+
+Ruby
+
+PostHog AI
+
+```ruby
+after_fork do |_server, _worker|
+  $posthog = PostHog::Client.new({
+    api_key: '<ph_project_token>',
+    personal_api_key: '<ph_personal_api_key>',
+    host: 'https://us.i.posthog.com',
+    on_error: Proc.new { |status, msg| print msg }
+  })
+end
+```
+
+#### Evaluating feature flags locally in a Puma server
+
+If you use Puma with multiple workers, you can use the `on_worker_boot` hook (which is part of Puma's configuration) to enable the feature flag cache to receive updates from PostHog.
+
+Ruby
+
+PostHog AI
+
+```ruby
+on_worker_boot do
+  $posthog = PostHog::Client.new({
+    api_key: '<ph_project_token>',
+    personal_api_key: '<ph_personal_api_key>',
+    host: 'https://us.i.posthog.com',
+    on_error: Proc.new { |status, msg| print msg }
+  })
+end
+```
+
+### Distributed flag definition caching
+
+`flag_definition_cache_provider` shares locally evaluated feature flag definitions across multiple workers or processes. The provider object must implement:
+
+- `flag_definitions` – returns cached definitions as a hash with `:flags`, `:group_type_mapping`, and `:cohorts`, or `nil` if empty.
+- `should_fetch_flag_definitions?` – returns `true` if this process should fetch fresh definitions from PostHog.
+- `on_flag_definitions_received(data)` – stores freshly fetched definitions.
+- `shutdown` – releases locks or other resources.
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog = PostHog::Client.new({
+  api_key: '<ph_project_token>',
+  personal_api_key: '<ph_personal_api_key>',
+  flag_definition_cache_provider: my_cache_provider
+})
+```
+
+### Remote config payloads
+
+Use `get_remote_config_payload` to fetch the decrypted remote config payload for a flag. This requires `personal_api_key`.
+
+Ruby
+
+PostHog AI
+
+```ruby
+payload = posthog.get_remote_config_payload('flag-key')
+```
+
+## Experiments (A/B tests)
+
+Since [experiments](/docs/experiments/start-here.md) use feature flags, the code for running an experiment is very similar to the feature flags code:
+
+Ruby
+
+PostHog AI
+
+```ruby
+flags = posthog.evaluate_flags('user_distinct_id')
+variant = flags.get_flag('experiment-feature-flag-key')
+if variant == 'variant-name'
+    # Do something
+end
+```
+
+It's also possible to [run experiments without using feature flags](/docs/experiments/running-experiments-without-feature-flags.md).
+
+## Group analytics
+
+Group analytics allows you to associate an event with a group (e.g. teams, organizations, etc.). Read the [Group Analytics](/docs/user-guides/group-analytics.md) guide for more information.
+
+> **Note:** This is a paid feature and is not available on the open-source or free cloud plan. Learn more on the [pricing page](/pricing.md).
+
+Capture an event and associate it with a group:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.capture({
+    distinct_id: 'distinct_id_of_the_user',
+    event: 'movie_played',
+    properties: {
+        movie_id: '123',
+        category: 'romcom'
+    },
+    groups: {
+        'company': 'company_id_in_your_db'
+    }
+})
+```
+
+Update properties on a group:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.group_identify({
+  group_type: 'company',
+  group_key: 'company_id_in_your_db',
+  properties: {
+    name: 'Awesome Inc.'
+  }
+})
+```
+
+The `name` is a special property which is used in the PostHog UI for the name of the group. If you don't specify a `name` property, the group ID will be used instead.
+
+If the optional `distinct_id` is not provided in the group identify call, it defaults to `$#{group_type}_#{group_key}` (e.g., `$company_company_id_in_your_db` in the example above). This default behavior will result in each group appearing as a separate person in PostHog. To avoid this, it's often more practical to use a consistent `distinct_id`, such as `group_identifier`.
+
+## Exception capture
+
+You can capture exceptions using the `posthog-ruby` library. This enables you to see stack traces and debug errors in your application. Learn more in our [error tracking docs](/docs/error-tracking/installation/ruby.md).
+
+**Using Rails?**
+
+The [posthog-rails](/docs/libraries/ruby-on-rails.md) gem provides automatic exception capture, ActiveJob instrumentation, and user context out of the box. See our [Rails error tracking guide](/docs/error-tracking/installation/ruby-on-rails.md) for details.
+
+For non-Rails Ruby applications, you can manually capture exceptions with `capture_exception`:
+
+Ruby
+
+PostHog AI
+
+```ruby
+begin
+  # Code that might raise an exception
+  raise StandardError, 'Something went wrong'
+rescue => e
+  posthog.capture_exception(
+    e,
+    'user_distinct_id',
+    {
+      custom_property: 'custom_value'
+    }
+  )
+end
+```
+
+The `capture_exception` method accepts the following parameters:
+
+| Parameter             | Type                                        | Description                                                                                                       |
+| --------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| exception             | Exception, String, or exception-like object | The exception to capture. Required.                                                                               |
+| distinct_id           | String                                      | The distinct ID of the user. Optional; request context can provide a default, otherwise the SDK generates a UUID. |
+| additional_properties | Hash                                        | Additional properties to attach to the exception event. Optional.                                                 |
+| flags                 | PostHog::FeatureFlagEvaluations             | Optional keyword argument. Adds the same feature flag properties as capture({ flags: flags }).                    |
+
+You can also override the [fingerprint](/docs/error-tracking/fingerprints.md) to customize how exceptions are grouped into issues:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.capture_exception(
+  e,
+  'user_distinct_id',
+  {
+    '$exception_fingerprint': 'CustomExceptionGroup'
+  }
+)
+```
+
+## Debug mode
+
+The Ruby SDK logs warnings by default. You can change the log level to `DEBUG` to debug the client:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.logger.level = Logger::DEBUG
+```
+
+You can also replace the SDK logger globally:
+
+Ruby
+
+PostHog AI
+
+```ruby
+PostHog::Logging.logger = Rails.logger
+```
+
+## Test helpers
+
+When `test_mode: true`, events remain queued. You can inspect and clear the queue in tests:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog = PostHog::Client.new({ api_key: '<ph_project_token>', test_mode: true })
+posthog.capture({ distinct_id: 'user_123', event: 'test_event' })
+posthog.queued_messages
+posthog.dequeue_last_message
+posthog.clear
+```
+
+## Thank you
+
+This library is largely based on the `analytics-ruby` package.
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,7 @@ CCTV_AWS_ACCESS_KEY_ID=your_aws_access_key_id
 CCTV_AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
 CCTV_AWS_S3_BUCKET=cctv-photo-bucket-dev
 
-# PostHog analytics + error tracking. Analytics is OFF unless POSTHOG_KEY is set
-# (and always off in test). Use a separate project key per environment.
-# POSTHOG_KEY=phc_your_project_key
-# POSTHOG_HOST=https://us.i.posthog.com   # use https://eu.i.posthog.com for EU cloud
+# PostHog analytics + error tracking. Use a separate project key per environment.
+POSTHOG_API_KEY=phc_your_project_key
+POSTHOG_HOST=https://your-posthog-host
 # POSTHOG_SESSION_REPLAY=false            # set true to record sessions (debug mobile issues)

--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,9 @@ GEMINI_API_KEY=your_gemini_api_key_here
 CCTV_AWS_ACCESS_KEY_ID=your_aws_access_key_id
 CCTV_AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
 CCTV_AWS_S3_BUCKET=cctv-photo-bucket-dev
+
+# PostHog analytics + error tracking. Analytics is OFF unless POSTHOG_KEY is set
+# (and always off in test). Use a separate project key per environment.
+# POSTHOG_KEY=phc_your_project_key
+# POSTHOG_HOST=https://us.i.posthog.com   # use https://eu.i.posthog.com for EU cloud
+# POSTHOG_SESSION_REPLAY=false            # set true to record sessions (debug mobile issues)

--- a/Gemfile
+++ b/Gemfile
@@ -43,3 +43,5 @@ group :development do
 end
 
 gem "posthog-ruby", "~> 3.11"
+
+gem "posthog-rails", "~> 3.11"

--- a/Gemfile
+++ b/Gemfile
@@ -41,3 +41,5 @@ group :development do
   gem "letter_opener"
   gem "letter_opener_web"
 end
+
+gem "posthog-ruby", "~> 3.11"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,6 +211,8 @@ GEM
     pg (1.6.2-arm64-darwin)
     pg (1.6.2-x64-mingw-ucrt)
     pg (1.6.2-x86_64-linux)
+    posthog-ruby (3.11.0)
+      concurrent-ruby (~> 1)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
@@ -347,6 +349,7 @@ DEPENDENCIES
   letter_opener_web
   passwordless
   pg (~> 1.1)
+  posthog-ruby (~> 3.11)
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.2)
   redis (>= 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,6 +211,9 @@ GEM
     pg (1.6.2-arm64-darwin)
     pg (1.6.2-x64-mingw-ucrt)
     pg (1.6.2-x86_64-linux)
+    posthog-rails (3.11.1)
+      posthog-ruby (~> 3.11)
+      railties (>= 5.2.0)
     posthog-ruby (3.11.0)
       concurrent-ruby (~> 1)
     pp (0.6.2)
@@ -349,6 +352,7 @@ DEPENDENCIES
   letter_opener_web
   passwordless
   pg (~> 1.1)
+  posthog-rails (~> 3.11)
   posthog-ruby (~> 3.11)
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.2)

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -10,6 +10,24 @@ class Api::BaseController < ApplicationController
   class UnauthorizedError < StandardError; end
   class NotFoundError < StandardError; end
 
+  # Expected control-flow errors that already map to a deliberate response.
+  # Everything else that escapes an action is an unexpected bug worth tracking.
+  # Matched by name (including ancestors) to avoid forcing autoload of the
+  # Experiences::* error constants at class-load time.
+  IGNORED_EXCEPTION_NAMES = %w[
+    Api::BaseController::UnauthorizedError
+    Api::BaseController::NotFoundError
+    ActionPolicy::Unauthorized
+    ActionController::ParameterMissing
+    ActiveRecord::RecordNotFound
+    ActiveRecord::RecordInvalid
+    Experiences::InvalidTransitionError
+    Experiences::MysteryNotRespondedError
+    Experiences::UnsafeEditError
+  ].freeze
+
+  around_action :report_unexpected_errors
+
   def authenticate_and_set_user_and_experience
     # JWT takes precedence over session auth when present
     # This allows simulating requests as different users while logged in as admin
@@ -123,5 +141,42 @@ class Api::BaseController < ApplicationController
         error: e.record.errors.full_messages.first,
       }, status: :unprocessable_entity
     end
+  end
+
+  # Reports genuinely unexpected exceptions to PostHog error tracking, then
+  # re-raises so existing rendering/rescue behavior is unchanged.
+  def report_unexpected_errors
+    yield
+  rescue StandardError => e
+    unless ignored_exception?(e)
+      Analytics::Tracker.capture_exception(
+        e,
+        distinct_id: @user&.id,
+        properties: {
+          controller: controller_name,
+          action: action_name,
+          path: request.path,
+          method: request.method,
+          experience_code: @experience&.code,
+        },
+      )
+    end
+    raise
+  end
+
+  def ignored_exception?(error)
+    error.class.ancestors.any? do |ancestor|
+      ancestor.respond_to?(:name) && IGNORED_EXCEPTION_NAMES.include?(ancestor.name)
+    end
+  end
+
+  # Captures a domain event for the authenticated user and current experience.
+  def track_event(event, properties = {})
+    Analytics::Tracker.capture(
+      distinct_id: @user&.id,
+      event: event,
+      properties: properties,
+      experience: @experience,
+    )
   end
 end

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -45,6 +45,12 @@ class Api::EventsController < Api::BaseController
 
     if event.save
       update_performers(event)
+      Analytics::Tracker.capture(
+        distinct_id: current_user.id,
+        event: Analytics::Events::EVENT_CREATED,
+        properties: { published: event.published? },
+        experience: event.experience,
+      )
 
       render json: {
         type: 'success',
@@ -69,6 +75,12 @@ class Api::EventsController < Api::BaseController
 
     if event.update(event_params)
       update_performers(event) if params[:performer_ids].present?
+      Analytics::Tracker.capture(
+        distinct_id: current_user.id,
+        event: Analytics::Events::EVENT_UPDATED,
+        properties: { published: event.published? },
+        experience: event.experience,
+      )
 
       render json: {
         type: 'success',
@@ -93,7 +105,15 @@ class Api::EventsController < Api::BaseController
 
     authorize! event, to: :destroy?
 
+    published = event.published?
+    experience = event.experience
     event.destroy!
+    Analytics::Tracker.capture(
+      distinct_id: current_user.id,
+      event: Analytics::Events::EVENT_DELETED,
+      properties: { published: published },
+      experience: experience,
+    )
 
     render json: { type: 'success', success: true, message: "Event deleted" }
   rescue ActiveRecord::RecordNotFound

--- a/app/controllers/api/experience_avatar_controller.rb
+++ b/app/controllers/api/experience_avatar_controller.rb
@@ -23,6 +23,8 @@ class Api::ExperienceAvatarController < Api::BaseController
         }
       )
 
+      track_event(Analytics::Events::AVATAR_SAVED, participant_id: participant.id)
+
       render json: { success: true, avatar: participant.avatar }
     end
   end

--- a/app/controllers/api/experience_blocks_controller.rb
+++ b/app/controllers/api/experience_blocks_controller.rb
@@ -89,6 +89,8 @@ class Api::ExperienceBlocksController < Api::BaseController
       @experience.reload
       Experiences::Broadcaster.new(@experience).broadcast_experience_update
 
+      track_event(Analytics::Events::BLOCK_CREATED, block_id: block.id, block_kind: block.kind)
+
       render json: {
         success: true,
         data: block,

--- a/app/controllers/api/experience_blocks_controller.rb
+++ b/app/controllers/api/experience_blocks_controller.rb
@@ -176,6 +176,8 @@ class Api::ExperienceBlocksController < Api::BaseController
 
       Experiences::Broadcaster.new(@experience).broadcast_experience_update
 
+      track_event(Analytics::Events::BLOCK_OPENED, block_id: block.id, block_kind: block.kind)
+
       render json: {
         success: true,
         data: block,
@@ -191,6 +193,8 @@ class Api::ExperienceBlocksController < Api::BaseController
       ).close_block!(block: @block)
 
       Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      track_event(Analytics::Events::BLOCK_CLOSED, block_id: block.id, block_kind: block.kind)
 
       render json: {
         success: true,
@@ -238,6 +242,8 @@ class Api::ExperienceBlocksController < Api::BaseController
         profile_changes: orchestrator.profile_changes
       )
 
+      track_event(Analytics::Events::RESPONSE_SUBMITTED, block_id: @block.id, block_kind: @block.kind, response_kind: "poll")
+
       render json: { success: true, submission: { id: submission.id, answer: submission.answer } }, status: 200
     end
   end
@@ -271,6 +277,8 @@ class Api::ExperienceBlocksController < Api::BaseController
 
       Experiences::Broadcaster.new(@experience).broadcast_experience_update
 
+      track_event(Analytics::Events::RESPONSE_SUBMITTED, block_id: @block.id, block_kind: @block.kind, response_kind: "question")
+
       render json: { success: true, submission: { id: submission.id, answer: submission.answer } }, status: 200
     end
   end
@@ -286,6 +294,8 @@ class Api::ExperienceBlocksController < Api::BaseController
       )
 
       Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      track_event(Analytics::Events::RESPONSE_SUBMITTED, block_id: @block.id, block_kind: @block.kind, response_kind: "buzzer")
 
       render json: { success: true, submission: { id: submission.id, answer: submission.answer } }, status: 200
     end
@@ -376,6 +386,8 @@ class Api::ExperienceBlocksController < Api::BaseController
       )
 
       Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      track_event(Analytics::Events::RESPONSE_SUBMITTED, block_id: @block.id, block_kind: @block.kind, response_kind: "photo_upload")
 
       photo_url = submission.photo.attached? ? ActiveStorageUrlService.blob_url(submission.photo.blob) : nil
       render json: { success: true, submission: { id: submission.id, answer: submission.answer, photo_url: photo_url } }, status: 200

--- a/app/controllers/api/experience_participants_controller.rb
+++ b/app/controllers/api/experience_participants_controller.rb
@@ -12,6 +12,8 @@ class Api::ExperienceParticipantsController < Api::BaseController
 
       Experiences::Broadcaster.new(@experience).broadcast_experience_update
 
+      track_event(Analytics::Events::PARTICIPANT_KICKED)
+
       render json: { success: true }
     end
   end

--- a/app/controllers/api/experiences_controller.rb
+++ b/app/controllers/api/experiences_controller.rb
@@ -30,6 +30,13 @@ class Api::ExperiencesController < Api::BaseController
       if experience.save
         experience.ensure_default_segment!(name: params[:experience][:default_segment_name])
 
+        Analytics::Tracker.identify_experience(experience)
+        Analytics::Tracker.capture(
+          distinct_id: current_user.id,
+          event: Analytics::Events::EXPERIENCE_CREATED,
+          experience: experience,
+        )
+
         render json: {
           type: 'success',
           success: true,
@@ -68,6 +75,8 @@ class Api::ExperiencesController < Api::BaseController
 
       Experiences::Broadcaster.new(@experience).broadcast_experience_update
 
+      track_event(Analytics::Events::LOBBY_OPENED)
+
       render json: {
         success: true,
         data: @experience,
@@ -83,6 +92,8 @@ class Api::ExperiencesController < Api::BaseController
       ).start!
 
       Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      track_event(Analytics::Events::EXPERIENCE_STARTED)
 
       render json: {
         success: true,
@@ -100,6 +111,8 @@ class Api::ExperiencesController < Api::BaseController
 
       Experiences::Broadcaster.new(@experience).broadcast_experience_update
 
+      track_event(Analytics::Events::EXPERIENCE_PAUSED)
+
       render json: {
         success: true,
         data: @experience,
@@ -115,6 +128,8 @@ class Api::ExperiencesController < Api::BaseController
       ).resume!
 
       Experiences::Broadcaster.new(@experience).broadcast_experience_update
+
+      track_event(Analytics::Events::EXPERIENCE_RESUMED)
 
       render json: {
         success: true,
@@ -275,6 +290,12 @@ class Api::ExperiencesController < Api::BaseController
       experience.register_user(user, name: register_params[:participant_name])
 
       Experiences::Broadcaster.new(experience).broadcast_experience_update
+
+      Analytics::Tracker.capture(
+        distinct_id: user.id,
+        event: Analytics::Events::PARTICIPANT_REGISTERED,
+        experience: experience,
+      )
     end
 
     render json: {

--- a/app/controllers/api/performers_controller.rb
+++ b/app/controllers/api/performers_controller.rb
@@ -46,6 +46,10 @@ class Api::PerformersController < Api::BaseController
 
     if performer.save
       performer.photo.attach(params[:photo]) if params[:photo].present?
+      Analytics::Tracker.capture(
+        distinct_id: current_user.id,
+        event: Analytics::Events::PERFORMER_PROFILE_CREATED,
+      )
 
       render json: {
         type: 'success',
@@ -108,6 +112,12 @@ class Api::PerformersController < Api::BaseController
     authorize! Follow, to: :create?
 
     follow = current_user.follows.find_or_create_by!(performer: performer)
+    if follow.previously_new_record?
+      Analytics::Tracker.capture(
+        distinct_id: current_user.id,
+        event: Analytics::Events::PERFORMER_FOLLOWED,
+      )
+    end
 
     render json: {
       type: 'success',
@@ -125,7 +135,14 @@ class Api::PerformersController < Api::BaseController
 
     authorize! Follow, to: :destroy?
 
-    current_user.follows.find_by(performer: performer)&.destroy
+    follow = current_user.follows.find_by(performer: performer)
+    if follow
+      follow.destroy
+      Analytics::Tracker.capture(
+        distinct_id: current_user.id,
+        event: Analytics::Events::PERFORMER_UNFOLLOWED,
+      )
+    end
 
     render json: {
       type: 'success',

--- a/app/frontend/Analytics/AnalyticsErrorBoundary.module.scss
+++ b/app/frontend/Analytics/AnalyticsErrorBoundary.module.scss
@@ -1,0 +1,44 @@
+.fallback {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-md);
+  min-height: 60vh;
+  padding: var(--space-lg);
+  text-align: center;
+  color: var(--foreground);
+}
+
+.icon {
+  width: 48px;
+  height: 48px;
+  color: var(--destructive);
+}
+
+.title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+}
+
+.message {
+  margin: 0;
+  max-width: 28rem;
+  color: var(--muted-foreground);
+}
+
+.button {
+  margin-top: var(--space-sm);
+  padding: var(--space-sm) var(--space-lg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--primary);
+  color: var(--primary-foreground);
+  font-family: var(--font-ui);
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.9;
+  }
+}

--- a/app/frontend/Analytics/AnalyticsErrorBoundary.stories.tsx
+++ b/app/frontend/Analytics/AnalyticsErrorBoundary.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { ThemeProvider } from '@cctv/contexts/ThemeContext';
+
+import { AnalyticsErrorBoundary } from './AnalyticsErrorBoundary';
+
+function Boom(): never {
+  throw new Error('Storybook demo: simulated render error');
+}
+
+const meta: Meta<typeof AnalyticsErrorBoundary> = {
+  title: 'Analytics/AnalyticsErrorBoundary',
+  component: AnalyticsErrorBoundary,
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof AnalyticsErrorBoundary>;
+
+// A child renders successfully — the boundary is transparent.
+export const Healthy: Story = {
+  args: {
+    children: <p style={{ padding: '2rem', textAlign: 'center' }}>Everything is fine.</p>,
+  },
+};
+
+// A child throws on render — the default fallback UI is shown. PostHog capture
+// is a no-op here since analytics never initializes in Storybook.
+export const ErrorState: Story = {
+  args: {
+    children: <Boom />,
+  },
+};
+
+// A custom fallback can replace the default.
+export const CustomFallback: Story = {
+  args: {
+    children: <Boom />,
+    fallback: <p style={{ padding: '2rem', textAlign: 'center' }}>Custom fallback content.</p>,
+  },
+};

--- a/app/frontend/Analytics/AnalyticsErrorBoundary.test.tsx
+++ b/app/frontend/Analytics/AnalyticsErrorBoundary.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AnalyticsErrorBoundary } from './AnalyticsErrorBoundary';
+
+const { captureExceptionMock } = vi.hoisted(() => ({ captureExceptionMock: vi.fn() }));
+vi.mock('./client', () => ({ captureException: captureExceptionMock }));
+
+function Boom(): never {
+  throw new Error('kaboom');
+}
+
+// React logs caught errors to console.error; silence it for these cases.
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore();
+  vi.clearAllMocks();
+});
+
+describe('AnalyticsErrorBoundary', () => {
+  it('renders children and reports nothing when there is no error', () => {
+    render(
+      <AnalyticsErrorBoundary>
+        <p>All good</p>
+      </AnalyticsErrorBoundary>,
+    );
+
+    expect(screen.getByText('All good')).toBeInTheDocument();
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it('renders the fallback and reports the error when a child throws', () => {
+    render(
+      <AnalyticsErrorBoundary>
+        <Boom />
+      </AnalyticsErrorBoundary>,
+    );
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    const [error, properties] = captureExceptionMock.mock.calls[0];
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe('kaboom');
+    expect(properties).toMatchObject({ source: 'react_error_boundary' });
+  });
+
+  it('renders a custom fallback when provided', () => {
+    render(
+      <AnalyticsErrorBoundary fallback={<p>Custom fallback</p>}>
+        <Boom />
+      </AnalyticsErrorBoundary>,
+    );
+
+    expect(screen.getByText('Custom fallback')).toBeInTheDocument();
+  });
+});

--- a/app/frontend/Analytics/AnalyticsErrorBoundary.tsx
+++ b/app/frontend/Analytics/AnalyticsErrorBoundary.tsx
@@ -1,0 +1,55 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+import { TriangleAlert } from 'lucide-react';
+
+import { captureException } from './client';
+
+import styles from './AnalyticsErrorBoundary.module.scss';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+/**
+ * Catches render-time errors anywhere below it, reports them to PostHog error
+ * tracking, and shows a recoverable fallback instead of a blank screen.
+ */
+export class AnalyticsErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    captureException(error, {
+      react_component_stack: info.componentStack,
+      source: 'react_error_boundary',
+    });
+  }
+
+  render(): ReactNode {
+    if (!this.state.hasError) return this.props.children;
+    return this.props.fallback ?? <ErrorFallback />;
+  }
+}
+
+function ErrorFallback() {
+  return (
+    <div className={styles.fallback} role="alert">
+      <TriangleAlert className={styles.icon} aria-hidden="true" />
+      <h1 className={styles.title}>Something went wrong</h1>
+      <p className={styles.message}>
+        This page hit an unexpected error. Reloading usually fixes it.
+      </p>
+      <button type="button" className={styles.button} onClick={() => window.location.reload()}>
+        Reload page
+      </button>
+    </div>
+  );
+}

--- a/app/frontend/Analytics/AnalyticsIdentity.test.tsx
+++ b/app/frontend/Analytics/AnalyticsIdentity.test.tsx
@@ -1,0 +1,70 @@
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AnalyticsIdentity } from './AnalyticsIdentity';
+
+const { useUserMock, identifyUserMock, resetAnalyticsMock } = vi.hoisted(() => ({
+  useUserMock: vi.fn(),
+  identifyUserMock: vi.fn(),
+  resetAnalyticsMock: vi.fn(),
+}));
+
+vi.mock('@cctv/contexts', () => ({ useUser: useUserMock }));
+vi.mock('./client', () => ({ identifyUser: identifyUserMock, resetAnalytics: resetAnalyticsMock }));
+
+const user = {
+  id: 'user-1',
+  email: 'a@b.com',
+  name: 'A',
+  role: 'user',
+  admin: false,
+  super_admin: false,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useUserMock.mockReturnValue({ user: null });
+});
+
+describe('AnalyticsIdentity', () => {
+  it('identifies the user once when a user is present', () => {
+    useUserMock.mockReturnValue({ user });
+    const { rerender } = render(<AnalyticsIdentity />);
+
+    expect(identifyUserMock).toHaveBeenCalledWith(
+      'user-1',
+      expect.objectContaining({ email: 'a@b.com', name: 'A', role: 'user', is_admin: false }),
+    );
+
+    rerender(<AnalyticsIdentity />);
+    expect(identifyUserMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when there is no user', () => {
+    useUserMock.mockReturnValue({ user: null });
+    render(<AnalyticsIdentity />);
+
+    expect(identifyUserMock).not.toHaveBeenCalled();
+    expect(resetAnalyticsMock).not.toHaveBeenCalled();
+  });
+
+  it('resets analytics when the user logs out', () => {
+    useUserMock.mockReturnValue({ user });
+    const { rerender } = render(<AnalyticsIdentity />);
+
+    useUserMock.mockReturnValue({ user: null });
+    rerender(<AnalyticsIdentity />);
+
+    expect(resetAnalyticsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('flags admins via is_admin', () => {
+    useUserMock.mockReturnValue({ user: { ...user, admin: true } });
+    render(<AnalyticsIdentity />);
+
+    expect(identifyUserMock).toHaveBeenCalledWith(
+      'user-1',
+      expect.objectContaining({ is_admin: true }),
+    );
+  });
+});

--- a/app/frontend/Analytics/AnalyticsIdentity.tsx
+++ b/app/frontend/Analytics/AnalyticsIdentity.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from 'react';
+
+import { useUser } from '@cctv/contexts';
+
+import { identifyUser, resetAnalytics } from './client';
+
+/**
+ * Ties the analytics distinct id to the logged-in User#id so frontend and
+ * backend events stitch together. Resets identity on logout. Renders nothing.
+ * Must be mounted within UserProvider.
+ */
+export function AnalyticsIdentity() {
+  const { user } = useUser();
+  const identifiedId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (user) {
+      if (identifiedId.current === user.id) return;
+      identifyUser(user.id, {
+        email: user.email,
+        name: user.name,
+        role: user.role,
+        is_admin: user.admin || user.super_admin,
+      });
+      identifiedId.current = user.id;
+    } else if (identifiedId.current) {
+      resetAnalytics();
+      identifiedId.current = null;
+    }
+  }, [user]);
+
+  return null;
+}

--- a/app/frontend/Analytics/ExperienceAnalytics.test.tsx
+++ b/app/frontend/Analytics/ExperienceAnalytics.test.tsx
@@ -1,0 +1,73 @@
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ExperienceAnalytics } from './ExperienceAnalytics';
+
+const { useExperienceMock, identifyGroupMock, setPersonPropsMock } = vi.hoisted(() => ({
+  useExperienceMock: vi.fn(),
+  identifyGroupMock: vi.fn(),
+  setPersonPropsMock: vi.fn(),
+}));
+
+vi.mock('@cctv/contexts', () => ({ useExperience: useExperienceMock }));
+vi.mock('./client', () => ({
+  identifyExperienceGroup: identifyGroupMock,
+  setPersonProperties: setPersonPropsMock,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useExperienceMock.mockReturnValue({ experience: undefined, participant: undefined, code: 'ABC' });
+});
+
+describe('ExperienceAnalytics', () => {
+  it('associates events with the experience group when an experience is present', () => {
+    useExperienceMock.mockReturnValue({
+      experience: { id: 'exp-1', name: 'My Show' },
+      participant: undefined,
+      code: 'ABC',
+    });
+
+    render(<ExperienceAnalytics />);
+
+    expect(identifyGroupMock).toHaveBeenCalledWith('exp-1', { code: 'ABC', name: 'My Show' });
+  });
+
+  it('records the participant role on the person profile', () => {
+    useExperienceMock.mockReturnValue({
+      experience: { id: 'exp-1', name: 'My Show' },
+      participant: { role: 'host' },
+      code: 'ABC',
+    });
+
+    render(<ExperienceAnalytics />);
+
+    expect(setPersonPropsMock).toHaveBeenCalledWith({ experience_role: 'host' });
+  });
+
+  it('does nothing without an experience', () => {
+    useExperienceMock.mockReturnValue({
+      experience: undefined,
+      participant: undefined,
+      code: 'ABC',
+    });
+
+    render(<ExperienceAnalytics />);
+
+    expect(identifyGroupMock).not.toHaveBeenCalled();
+    expect(setPersonPropsMock).not.toHaveBeenCalled();
+  });
+
+  it('groups only once for the same experience', () => {
+    useExperienceMock.mockReturnValue({
+      experience: { id: 'exp-1', name: 'My Show' },
+      participant: undefined,
+      code: 'ABC',
+    });
+
+    const { rerender } = render(<ExperienceAnalytics />);
+    rerender(<ExperienceAnalytics />);
+
+    expect(identifyGroupMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/frontend/Analytics/ExperienceAnalytics.tsx
+++ b/app/frontend/Analytics/ExperienceAnalytics.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+
+import { useExperience } from '@cctv/contexts';
+
+import { identifyExperienceGroup, setPersonProperties } from './client';
+
+/**
+ * Associates analytics events with the current experience's PostHog group and
+ * records the participant's experience role on the person profile. Renders
+ * nothing. Must be mounted within ExperienceProvider.
+ */
+export function ExperienceAnalytics() {
+  const { experience, participant, code } = useExperience();
+  const groupedId = useRef<string | null>(null);
+
+  const experienceId = experience?.id;
+  const experienceName = experience?.name;
+  const participantRole = participant?.role;
+
+  useEffect(() => {
+    if (!experienceId || groupedId.current === experienceId) return;
+    identifyExperienceGroup(experienceId, { code, name: experienceName });
+    groupedId.current = experienceId;
+  }, [experienceId, experienceName, code]);
+
+  useEffect(() => {
+    if (!participantRole) return;
+    setPersonProperties({ experience_role: participantRole });
+  }, [participantRole]);
+
+  return null;
+}

--- a/app/frontend/Analytics/RouteAnalytics.tsx
+++ b/app/frontend/Analytics/RouteAnalytics.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+
+import { useLocation } from 'react-router-dom';
+
+import { registerRoute } from './client';
+import { routePattern } from './routes';
+
+/**
+ * Keeps the `route` super property in step with the current SPA location so every
+ * event — autocaptured pageviews included — can be grouped by page rather than by
+ * the raw URL, which embeds experience codes and block ids. Renders nothing.
+ */
+export function RouteAnalytics() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    registerRoute(routePattern(pathname));
+  }, [pathname]);
+
+  return null;
+}

--- a/app/frontend/Analytics/blockImpressions.test.ts
+++ b/app/frontend/Analytics/blockImpressions.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  millisecondsSinceSeen,
+  resetBlockImpressions,
+  trackBlockSeen,
+  trackSubmissionFailed,
+  trackSubmissionSucceeded,
+} from './blockImpressions';
+import { AnalyticsEvent } from './events';
+
+const { clientMock } = vi.hoisted(() => ({ clientMock: { capture: vi.fn() } }));
+vi.mock('./client', () => clientMock);
+
+beforeEach(() => {
+  clientMock.capture.mockClear();
+  resetBlockImpressions();
+});
+
+describe('trackBlockSeen', () => {
+  it('captures the impression with block identity', () => {
+    trackBlockSeen({ blockId: 'block-1', blockKind: 'question' });
+
+    expect(clientMock.capture).toHaveBeenCalledWith(AnalyticsEvent.BlockSeen, {
+      block_id: 'block-1',
+      block_kind: 'question',
+      experience_code: undefined,
+    });
+  });
+
+  it('only counts the first sighting, so websocket remounts do not inflate it', () => {
+    trackBlockSeen({ blockId: 'block-1', blockKind: 'question' });
+    trackBlockSeen({ blockId: 'block-1', blockKind: 'question' });
+    trackBlockSeen({ blockId: 'block-1', blockKind: 'question' });
+
+    expect(clientMock.capture).toHaveBeenCalledTimes(1);
+  });
+
+  it('tracks distinct blocks separately', () => {
+    trackBlockSeen({ blockId: 'block-1', blockKind: 'question' });
+    trackBlockSeen({ blockId: 'block-2', blockKind: 'poll' });
+
+    expect(clientMock.capture).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('millisecondsSinceSeen', () => {
+  it('measures from the first impression', () => {
+    trackBlockSeen({ blockId: 'block-1', blockKind: 'question' });
+    expect(millisecondsSinceSeen('block-1')).toBeGreaterThanOrEqual(0);
+  });
+
+  it('is undefined for a block that was never seen', () => {
+    expect(millisecondsSinceSeen('never-rendered')).toBeUndefined();
+  });
+});
+
+describe('submission tracking', () => {
+  it('attaches time-on-prompt to a successful submit', () => {
+    trackBlockSeen({ blockId: 'block-1', blockKind: 'question' });
+    clientMock.capture.mockClear();
+
+    trackSubmissionSucceeded('block-1', 'question');
+
+    expect(clientMock.capture).toHaveBeenCalledWith(
+      AnalyticsEvent.ResponseSubmitted,
+      expect.objectContaining({
+        block_id: 'block-1',
+        response_kind: 'question',
+        milliseconds_since_seen: expect.any(Number),
+      }),
+    );
+  });
+
+  it('records why a submit failed', () => {
+    trackSubmissionFailed('block-1', 'poll', 'auth_expired', 'Authentication expired');
+
+    expect(clientMock.capture).toHaveBeenCalledWith(
+      AnalyticsEvent.BlockSubmitFailed,
+      expect.objectContaining({
+        block_id: 'block-1',
+        response_kind: 'poll',
+        failure_kind: 'auth_expired',
+        error_message: 'Authentication expired',
+      }),
+    );
+  });
+});

--- a/app/frontend/Analytics/blockImpressions.ts
+++ b/app/frontend/Analytics/blockImpressions.ts
@@ -1,0 +1,73 @@
+import { capture } from './client';
+import { AnalyticsEvent } from './events';
+
+/**
+ * Records when each block first became visible to this participant, so a submit
+ * can report how long the prompt sat on screen before they answered.
+ *
+ * The server cannot answer these questions: it sees the host open a block and it
+ * sees submissions arrive, but never learns who was actually looking at the block
+ * and chose not to respond. `block seen` supplies that missing denominator —
+ * without it, "how many people didn't submit" and "how many never even opened the
+ * question" are both unanswerable.
+ *
+ * Kept in module scope rather than React state so the timestamp survives the
+ * remounts that happen as websocket payloads replace the block tree.
+ */
+const seenAt = new Map<string, number>();
+
+export function trackBlockSeen(properties: {
+  blockId: string;
+  blockKind: string;
+  experienceCode?: string;
+}): void {
+  if (seenAt.has(properties.blockId)) return;
+
+  seenAt.set(properties.blockId, performance.now());
+  capture(AnalyticsEvent.BlockSeen, {
+    block_id: properties.blockId,
+    block_kind: properties.blockKind,
+    experience_code: properties.experienceCode,
+  });
+}
+
+/**
+ * Milliseconds the block had been on screen, or undefined when it was never
+ * recorded as seen (a submit from a view that does not track impressions).
+ */
+export function millisecondsSinceSeen(blockId: string): number | undefined {
+  const start = seenAt.get(blockId);
+  return start === undefined ? undefined : Math.round(performance.now() - start);
+}
+
+export function resetBlockImpressions(): void {
+  seenAt.clear();
+}
+
+/**
+ * Client-side companion to the server's `response submitted`. The server records
+ * the authoritative submission; this one carries the time the participant spent
+ * on the prompt, which only the client can know.
+ */
+export function trackSubmissionSucceeded(blockId: string, responseKind: string): void {
+  capture(AnalyticsEvent.ResponseSubmitted, {
+    block_id: blockId,
+    response_kind: responseKind,
+    milliseconds_since_seen: millisecondsSinceSeen(blockId),
+  });
+}
+
+export function trackSubmissionFailed(
+  blockId: string,
+  responseKind: string,
+  failureKind: 'rejected' | 'network' | 'auth_expired',
+  errorMessage: string,
+): void {
+  capture(AnalyticsEvent.BlockSubmitFailed, {
+    block_id: blockId,
+    response_kind: responseKind,
+    failure_kind: failureKind,
+    error_message: errorMessage,
+    milliseconds_since_seen: millisecondsSinceSeen(blockId),
+  });
+}

--- a/app/frontend/Analytics/client.test.ts
+++ b/app/frontend/Analytics/client.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { posthogMock, configMock } = vi.hoisted(() => ({
+  posthogMock: {
+    init: vi.fn(),
+    register: vi.fn(),
+    capture: vi.fn(),
+    identify: vi.fn(),
+    group: vi.fn(),
+    setPersonProperties: vi.fn(),
+    reset: vi.fn(),
+    captureException: vi.fn(),
+  },
+  configMock: { getAnalyticsConfig: vi.fn() },
+}));
+
+vi.mock('posthog-js', () => ({ default: posthogMock }));
+vi.mock('./config', () => configMock);
+
+const validConfig = {
+  enabled: true,
+  key: 'phc_test',
+  host: 'https://us.i.posthog.com',
+  environment: 'production',
+  sessionReplay: false,
+};
+
+// Each case loads a fresh client so its module-level `initialized` flag resets.
+async function loadClient() {
+  vi.resetModules();
+  return import('./client');
+}
+
+async function loadInitializedClient(config = validConfig) {
+  configMock.getAnalyticsConfig.mockReturnValue(config);
+  const client = await loadClient();
+  client.initAnalytics();
+  return client;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  configMock.getAnalyticsConfig.mockReturnValue(null);
+});
+
+describe('analytics client before initialization', () => {
+  it('makes every call a no-op without touching posthog', async () => {
+    const client = await loadClient();
+
+    client.capture('experience joined', { a: 1 });
+    client.identifyUser('u1');
+    client.identifyExperienceGroup('e1');
+    client.setPersonProperties({ role: 'host' });
+    client.resetAnalytics();
+    client.captureException(new Error('x'));
+
+    expect(client.isAnalyticsReady()).toBe(false);
+    expect(posthogMock.capture).not.toHaveBeenCalled();
+    expect(posthogMock.identify).not.toHaveBeenCalled();
+    expect(posthogMock.group).not.toHaveBeenCalled();
+    expect(posthogMock.reset).not.toHaveBeenCalled();
+    expect(posthogMock.captureException).not.toHaveBeenCalled();
+  });
+});
+
+describe('initAnalytics', () => {
+  it('does not initialize when there is no config', async () => {
+    configMock.getAnalyticsConfig.mockReturnValue(null);
+    const { initAnalytics, isAnalyticsReady } = await loadClient();
+
+    initAnalytics();
+
+    expect(posthogMock.init).not.toHaveBeenCalled();
+    expect(isAnalyticsReady()).toBe(false);
+  });
+
+  it('initializes posthog with SPA + error-tracking options and registers the environment', async () => {
+    const { isAnalyticsReady } = await loadInitializedClient();
+
+    expect(posthogMock.init).toHaveBeenCalledWith(
+      'phc_test',
+      expect.objectContaining({
+        api_host: 'https://us.i.posthog.com',
+        defaults: '2026-01-30',
+        person_profiles: 'identified_only',
+        capture_exceptions: true,
+        disable_session_recording: true,
+      }),
+    );
+    expect(posthogMock.register).toHaveBeenCalledWith({ environment: 'production' });
+    expect(isAnalyticsReady()).toBe(true);
+  });
+
+  it('enables session recording when sessionReplay is on', async () => {
+    await loadInitializedClient({ ...validConfig, sessionReplay: true });
+
+    expect(posthogMock.init).toHaveBeenCalledWith(
+      'phc_test',
+      expect.objectContaining({ disable_session_recording: false }),
+    );
+  });
+
+  it('is idempotent', async () => {
+    const { initAnalytics } = await loadInitializedClient();
+    initAnalytics();
+    expect(posthogMock.init).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('analytics client after initialization', () => {
+  it('forwards capture to posthog', async () => {
+    const { capture } = await loadInitializedClient();
+    capture('experience joined', { status: 'registered' });
+    expect(posthogMock.capture).toHaveBeenCalledWith('experience joined', { status: 'registered' });
+  });
+
+  it('forwards identifyUser to posthog.identify', async () => {
+    const { identifyUser } = await loadInitializedClient();
+    identifyUser('user-1', { email: 'a@b.com' });
+    expect(posthogMock.identify).toHaveBeenCalledWith('user-1', { email: 'a@b.com' });
+  });
+
+  it('forwards identifyExperienceGroup to posthog.group with the experience group type', async () => {
+    const { identifyExperienceGroup } = await loadInitializedClient();
+    identifyExperienceGroup('exp-1', { code: 'ABC' });
+    expect(posthogMock.group).toHaveBeenCalledWith('experience', 'exp-1', { code: 'ABC' });
+  });
+
+  it('forwards resetAnalytics to posthog.reset', async () => {
+    const { resetAnalytics } = await loadInitializedClient();
+    resetAnalytics();
+    expect(posthogMock.reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards captureException to posthog.captureException', async () => {
+    const { captureException } = await loadInitializedClient();
+    const error = new Error('boom');
+    captureException(error, { source: 'test' });
+    expect(posthogMock.captureException).toHaveBeenCalledWith(error, { source: 'test' });
+  });
+});

--- a/app/frontend/Analytics/client.ts
+++ b/app/frontend/Analytics/client.ts
@@ -11,6 +11,17 @@ import type { AnalyticsEventName } from './events';
  */
 let initialized = false;
 
+/**
+ * The monitor is a projected display with no user behind it. Nothing from that
+ * route belongs in analytics, so this drops every event — including autocaptured
+ * pageviews, clicks and web vitals — at the SDK boundary rather than relying on
+ * each call site to remember.
+ */
+export function isMonitorView(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.location.pathname.includes('/monitor');
+}
+
 export function initAnalytics(): void {
   if (initialized) return;
 
@@ -24,6 +35,7 @@ export function initAnalytics(): void {
     person_profiles: 'identified_only',
     capture_exceptions: true,
     disable_session_recording: !config.sessionReplay,
+    before_send: (event) => (isMonitorView() ? null : event),
   });
   posthog.register({ environment: config.environment });
   initialized = true;
@@ -51,6 +63,15 @@ export function identifyExperienceGroup(experienceId: string, properties?: Prope
 export function setPersonProperties(properties: Properties): void {
   if (!initialized) return;
   posthog.setPersonProperties(properties);
+}
+
+/**
+ * Attaches the current route pattern to every subsequent event, so any breakdown
+ * can be sliced by page without each call site passing it.
+ */
+export function registerRoute(pattern: string): void {
+  if (!initialized) return;
+  posthog.register({ route: pattern });
 }
 
 export function resetAnalytics(): void {

--- a/app/frontend/Analytics/client.ts
+++ b/app/frontend/Analytics/client.ts
@@ -1,0 +1,64 @@
+import posthog, { type Properties } from 'posthog-js';
+
+import { getAnalyticsConfig } from './config';
+import type { AnalyticsEventName } from './events';
+
+/**
+ * Centralized, guarded access to the posthog-js singleton. Every export is a
+ * no-op until initAnalytics() has run with a valid server config, so importing
+ * and calling these is always safe — including in tests and Storybook where
+ * analytics never initializes.
+ */
+let initialized = false;
+
+export function initAnalytics(): void {
+  if (initialized) return;
+
+  const config = getAnalyticsConfig();
+  if (!config) return;
+
+  posthog.init(config.key, {
+    api_host: config.host,
+    // Modern defaults: SPA pageviews via history_change + scripts injected into <head>.
+    defaults: '2026-01-30',
+    person_profiles: 'identified_only',
+    capture_exceptions: true,
+    disable_session_recording: !config.sessionReplay,
+  });
+  posthog.register({ environment: config.environment });
+  initialized = true;
+}
+
+export function isAnalyticsReady(): boolean {
+  return initialized;
+}
+
+export function capture(event: AnalyticsEventName, properties?: Properties): void {
+  if (!initialized) return;
+  posthog.capture(event, properties);
+}
+
+export function identifyUser(distinctId: string, properties?: Properties): void {
+  if (!initialized) return;
+  posthog.identify(distinctId, properties);
+}
+
+export function identifyExperienceGroup(experienceId: string, properties?: Properties): void {
+  if (!initialized) return;
+  posthog.group('experience', experienceId, properties);
+}
+
+export function setPersonProperties(properties: Properties): void {
+  if (!initialized) return;
+  posthog.setPersonProperties(properties);
+}
+
+export function resetAnalytics(): void {
+  if (!initialized) return;
+  posthog.reset();
+}
+
+export function captureException(error: unknown, properties?: Properties): void {
+  if (!initialized) return;
+  posthog.captureException(error, properties);
+}

--- a/app/frontend/Analytics/config.test.ts
+++ b/app/frontend/Analytics/config.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const validConfig = {
+  enabled: true,
+  key: 'phc_test',
+  host: 'https://us.i.posthog.com',
+  environment: 'production',
+  sessionReplay: false,
+};
+
+function setConfigBlock(json: string | null) {
+  document.getElementById('analytics-config')?.remove();
+  if (json === null) return;
+  const script = document.createElement('script');
+  script.type = 'application/json';
+  script.id = 'analytics-config';
+  script.textContent = json;
+  document.head.appendChild(script);
+}
+
+// The module caches its first read, so each case loads a fresh module instance.
+async function loadConfig() {
+  vi.resetModules();
+  return (await import('./config')).getAnalyticsConfig();
+}
+
+afterEach(() => setConfigBlock(null));
+
+describe('getAnalyticsConfig', () => {
+  it('returns null when the config block is absent', async () => {
+    setConfigBlock(null);
+    expect(await loadConfig()).toBeNull();
+  });
+
+  it('returns null when analytics is disabled', async () => {
+    setConfigBlock(JSON.stringify({ ...validConfig, enabled: false }));
+    expect(await loadConfig()).toBeNull();
+  });
+
+  it('returns null when the key is missing', async () => {
+    setConfigBlock(JSON.stringify({ ...validConfig, key: null }));
+    expect(await loadConfig()).toBeNull();
+  });
+
+  it('returns null when the host is missing', async () => {
+    const { host: _host, ...withoutHost } = validConfig;
+    setConfigBlock(JSON.stringify(withoutHost));
+    expect(await loadConfig()).toBeNull();
+  });
+
+  it('returns null on malformed JSON', async () => {
+    setConfigBlock('{ not valid json');
+    expect(await loadConfig()).toBeNull();
+  });
+
+  it('parses a valid config block', async () => {
+    setConfigBlock(JSON.stringify({ ...validConfig, sessionReplay: true }));
+    expect(await loadConfig()).toEqual({
+      enabled: true,
+      key: 'phc_test',
+      host: 'https://us.i.posthog.com',
+      environment: 'production',
+      sessionReplay: true,
+    });
+  });
+
+  it('defaults environment and sessionReplay when omitted', async () => {
+    setConfigBlock(
+      JSON.stringify({ enabled: true, key: 'phc_test', host: 'https://us.i.posthog.com' }),
+    );
+    const config = await loadConfig();
+    expect(config?.environment).toBe('unknown');
+    expect(config?.sessionReplay).toBe(false);
+  });
+
+  it('caches the result so a later DOM change is not re-read', async () => {
+    setConfigBlock(JSON.stringify(validConfig));
+    vi.resetModules();
+    const { getAnalyticsConfig } = await import('./config');
+
+    const first = getAnalyticsConfig();
+    setConfigBlock(null);
+    const second = getAnalyticsConfig();
+
+    expect(second).toBe(first);
+  });
+});

--- a/app/frontend/Analytics/config.ts
+++ b/app/frontend/Analytics/config.ts
@@ -1,0 +1,42 @@
+export interface AnalyticsConfig {
+  enabled: boolean;
+  key: string;
+  host: string;
+  environment: string;
+  sessionReplay: boolean;
+}
+
+let cached: AnalyticsConfig | null | undefined;
+
+/**
+ * Reads the analytics config the server embedded as a JSON data block. Returns
+ * null when analytics is disabled or the block is absent (dev without a key,
+ * test, Storybook), which keeps the SDK from ever starting in those contexts.
+ */
+export function getAnalyticsConfig(): AnalyticsConfig | null {
+  if (cached !== undefined) return cached;
+  cached = readConfig();
+  return cached;
+}
+
+function readConfig(): AnalyticsConfig | null {
+  if (typeof document === 'undefined') return null;
+
+  const element = document.getElementById('analytics-config');
+  if (!element?.textContent) return null;
+
+  try {
+    const parsed = JSON.parse(element.textContent) as Partial<AnalyticsConfig>;
+    if (!parsed.enabled || !parsed.key || !parsed.host) return null;
+
+    return {
+      enabled: true,
+      key: parsed.key,
+      host: parsed.host,
+      environment: parsed.environment ?? 'unknown',
+      sessionReplay: parsed.sessionReplay ?? false,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/app/frontend/Analytics/events.ts
+++ b/app/frontend/Analytics/events.ts
@@ -6,9 +6,22 @@
  * Authoritative domain events (created, registered, lifecycle, block open/close,
  * response submitted, avatar saved) are emitted server-side. The frontend owns
  * pageviews and exceptions (autocaptured) plus client-funnel events like joining.
+ *
+ * Client-only events (block impressions, button clicks, request timing/failures,
+ * websocket health, manage actions) have no server counterpart because the server
+ * cannot observe them — a participant who never saw a block never calls an endpoint.
+ * These are declared here only; events.rb intentionally omits them.
  */
 export const AnalyticsEvent = {
   ExperienceJoined: 'experience joined',
+  BlockSeen: 'block seen',
+  BlockSubmitFailed: 'block submit failed',
+  ButtonClicked: 'button clicked',
+  ApiRequestCompleted: 'api request completed',
+  ApiRequestFailed: 'api request failed',
+  WebsocketDisconnected: 'websocket disconnected',
+  WebsocketReconnected: 'websocket reconnected',
+  ManageAction: 'manage action',
   ExperienceCreated: 'experience created',
   ParticipantRegistered: 'participant registered',
   LobbyOpened: 'experience lobby opened',
@@ -19,6 +32,14 @@ export const AnalyticsEvent = {
   BlockClosed: 'block closed',
   ResponseSubmitted: 'response submitted',
   AvatarSaved: 'avatar saved',
+  EventCreated: 'event_created',
+  EventUpdated: 'event_updated',
+  EventDeleted: 'event_deleted',
+  PerformerProfileCreated: 'performer_profile_created',
+  PerformerFollowed: 'performer_followed',
+  PerformerUnfollowed: 'performer_unfollowed',
+  BlockCreated: 'block_created',
+  ParticipantKicked: 'participant_kicked',
 } as const;
 
 export type AnalyticsEventName = (typeof AnalyticsEvent)[keyof typeof AnalyticsEvent];

--- a/app/frontend/Analytics/events.ts
+++ b/app/frontend/Analytics/events.ts
@@ -1,0 +1,24 @@
+/**
+ * Canonical analytics event names. Keep these strings identical to the backend
+ * taxonomy in app/services/analytics/events.rb so each PostHog event represents
+ * the same action no matter which side emitted it.
+ *
+ * Authoritative domain events (created, registered, lifecycle, block open/close,
+ * response submitted, avatar saved) are emitted server-side. The frontend owns
+ * pageviews and exceptions (autocaptured) plus client-funnel events like joining.
+ */
+export const AnalyticsEvent = {
+  ExperienceJoined: 'experience joined',
+  ExperienceCreated: 'experience created',
+  ParticipantRegistered: 'participant registered',
+  LobbyOpened: 'experience lobby opened',
+  ExperienceStarted: 'experience started',
+  ExperiencePaused: 'experience paused',
+  ExperienceResumed: 'experience resumed',
+  BlockOpened: 'block opened',
+  BlockClosed: 'block closed',
+  ResponseSubmitted: 'response submitted',
+  AvatarSaved: 'avatar saved',
+} as const;
+
+export type AnalyticsEventName = (typeof AnalyticsEvent)[keyof typeof AnalyticsEvent];

--- a/app/frontend/Analytics/index.ts
+++ b/app/frontend/Analytics/index.ts
@@ -1,12 +1,26 @@
 export {
   initAnalytics,
   isAnalyticsReady,
+  isMonitorView,
   capture,
   captureException,
   identifyUser,
   identifyExperienceGroup,
+  registerRoute,
   resetAnalytics,
+  setPersonProperties,
 } from './client';
+export { instrumentedFetch } from './instrumentedFetch';
+export {
+  trackBlockSeen,
+  millisecondsSinceSeen,
+  resetBlockImpressions,
+  trackSubmissionSucceeded,
+  trackSubmissionFailed,
+} from './blockImpressions';
+export { trackManageAction } from './manageActions';
+export { routePattern, apiPathPattern } from './routes';
+export { RouteAnalytics } from './RouteAnalytics';
 export { AnalyticsEvent } from './events';
 export type { AnalyticsEventName } from './events';
 export { getAnalyticsConfig } from './config';

--- a/app/frontend/Analytics/index.ts
+++ b/app/frontend/Analytics/index.ts
@@ -1,0 +1,16 @@
+export {
+  initAnalytics,
+  isAnalyticsReady,
+  capture,
+  captureException,
+  identifyUser,
+  identifyExperienceGroup,
+  resetAnalytics,
+} from './client';
+export { AnalyticsEvent } from './events';
+export type { AnalyticsEventName } from './events';
+export { getAnalyticsConfig } from './config';
+export type { AnalyticsConfig } from './config';
+export { AnalyticsErrorBoundary } from './AnalyticsErrorBoundary';
+export { AnalyticsIdentity } from './AnalyticsIdentity';
+export { ExperienceAnalytics } from './ExperienceAnalytics';

--- a/app/frontend/Analytics/instrumentedFetch.test.ts
+++ b/app/frontend/Analytics/instrumentedFetch.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AnalyticsEvent } from './events';
+import { instrumentedFetch } from './instrumentedFetch';
+
+const { clientMock } = vi.hoisted(() => ({ clientMock: { capture: vi.fn() } }));
+vi.mock('./client', () => clientMock);
+
+const URL = '/api/experiences/yay-pie/blocks/abc-123/submit_question_response';
+
+beforeEach(() => {
+  clientMock.capture.mockClear();
+});
+
+describe('instrumentedFetch', () => {
+  it('reports latency and the collapsed path on success', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 200 })));
+
+    await instrumentedFetch(URL, { method: 'POST' }, { source: 'participant' });
+
+    expect(clientMock.capture).toHaveBeenCalledWith(
+      AnalyticsEvent.ApiRequestCompleted,
+      expect.objectContaining({
+        path: '/api/experiences/:code/blocks/:blockId/submit_question_response',
+        method: 'POST',
+        status: 200,
+        source: 'participant',
+      }),
+    );
+    expect(clientMock.capture.mock.calls[0][1].duration_ms).toBeTypeOf('number');
+  });
+
+  it('reports a failure event for a non-ok status', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 500 })));
+
+    await instrumentedFetch(URL, {}, { source: 'admin' });
+
+    expect(clientMock.capture).toHaveBeenCalledWith(
+      AnalyticsEvent.ApiRequestFailed,
+      expect.objectContaining({ status: 500, failure_kind: 'http_status', method: 'GET' }),
+    );
+  });
+
+  it('reports network errors and rethrows them', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+
+    await expect(instrumentedFetch(URL, {}, { source: 'public' })).rejects.toThrow('offline');
+
+    expect(clientMock.capture).toHaveBeenCalledWith(
+      AnalyticsEvent.ApiRequestFailed,
+      expect.objectContaining({ failure_kind: 'network', error_message: 'offline' }),
+    );
+  });
+
+  it('stays silent on aborts, which are the app cancelling itself', async () => {
+    const abort = new DOMException('aborted', 'AbortError');
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abort));
+
+    await expect(instrumentedFetch(URL, {}, { source: 'public' })).rejects.toBe(abort);
+
+    expect(clientMock.capture).not.toHaveBeenCalled();
+  });
+});

--- a/app/frontend/Analytics/instrumentedFetch.ts
+++ b/app/frontend/Analytics/instrumentedFetch.ts
@@ -1,0 +1,53 @@
+import { capture } from './client';
+import { AnalyticsEvent } from './events';
+import { apiPathPattern } from './routes';
+
+/**
+ * Wraps fetch so every API call reports its latency and, when it fails, why.
+ *
+ * All three auth paths (public useQuery, participant experienceFetch, admin
+ * adminFetch) route through here, which keeps timing definitions identical
+ * across them and means new call sites are instrumented by construction.
+ *
+ * Aborts are deliberately not reported: they are the app cancelling its own
+ * in-flight request on rerender, not a user-visible failure.
+ */
+export async function instrumentedFetch(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+  context: { source: string },
+): Promise<Response> {
+  const url = typeof input === 'string' ? input : input.toString();
+  const path = apiPathPattern(url);
+  const method = (init.method ?? 'GET').toUpperCase();
+  const startedAt = performance.now();
+
+  try {
+    const response = await fetch(input, init);
+    const durationMs = Math.round(performance.now() - startedAt);
+
+    capture(response.ok ? AnalyticsEvent.ApiRequestCompleted : AnalyticsEvent.ApiRequestFailed, {
+      path,
+      method,
+      status: response.status,
+      duration_ms: durationMs,
+      source: context.source,
+      ...(response.ok ? {} : { failure_kind: 'http_status' }),
+    });
+
+    return response;
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') throw error;
+
+    capture(AnalyticsEvent.ApiRequestFailed, {
+      path,
+      method,
+      duration_ms: Math.round(performance.now() - startedAt),
+      source: context.source,
+      failure_kind: 'network',
+      error_message: error instanceof Error ? error.message : 'Unknown error',
+    });
+
+    throw error;
+  }
+}

--- a/app/frontend/Analytics/manageActions.ts
+++ b/app/frontend/Analytics/manageActions.ts
@@ -1,0 +1,15 @@
+import { capture } from './client';
+import { AnalyticsEvent } from './events';
+
+/**
+ * Records what the operator did in the tech booth while a show was running, so a
+ * run can be replayed as a sequence of decisions.
+ *
+ * Button presses are already covered generically by Core `Button`; this exists
+ * for the manage interactions that never go through a button — drag reordering,
+ * impersonation switches, selecting a block in the program table — which would
+ * otherwise leave gaps in that timeline.
+ */
+export function trackManageAction(action: string, properties: Record<string, unknown> = {}): void {
+  capture(AnalyticsEvent.ManageAction, { action, ...properties });
+}

--- a/app/frontend/Analytics/routes.test.ts
+++ b/app/frontend/Analytics/routes.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { apiPathPattern, routePattern } from './routes';
+
+describe('routePattern', () => {
+  it('collapses experience codes so pages group across shows', () => {
+    expect(routePattern('/experiences/yay-pie')).toBe('/experiences/:code');
+    expect(routePattern('/experiences/bear-down')).toBe('/experiences/:code');
+  });
+
+  it('distinguishes nested experience routes from the index', () => {
+    expect(routePattern('/experiences/yay-pie/manage')).toBe('/experiences/:code/manage');
+    expect(routePattern('/experiences/yay-pie/avatar')).toBe('/experiences/:code/avatar');
+    expect(routePattern('/experiences/yay-pie/monitor')).toBe('/experiences/:code/monitor');
+  });
+
+  it('separates the new-block route from a specific block', () => {
+    expect(routePattern('/experiences/yay-pie/manage/blocks/new')).toBe(
+      '/experiences/:code/manage/blocks/new',
+    );
+    expect(routePattern('/experiences/yay-pie/manage/blocks/abc-123')).toBe(
+      '/experiences/:code/manage/blocks/:blockId',
+    );
+  });
+
+  it('collapses slugs on events and performers', () => {
+    expect(routePattern('/events/pie-day')).toBe('/events/:slug');
+    expect(routePattern('/events/new')).toBe('/events/new');
+    expect(routePattern('/performers/some-name/edit')).toBe('/performers/:slug/edit');
+  });
+
+  it('passes through static routes and tolerates trailing slashes', () => {
+    expect(routePattern('/')).toBe('/');
+    expect(routePattern('/join')).toBe('/join');
+    expect(routePattern('/experiences/yay-pie/')).toBe('/experiences/:code');
+  });
+});
+
+describe('apiPathPattern', () => {
+  it('collapses experience and block identifiers', () => {
+    expect(apiPathPattern('/api/experiences/yay-pie/blocks/abc-123/submit_question_response')).toBe(
+      '/api/experiences/:code/blocks/:blockId/submit_question_response',
+    );
+  });
+
+  it('drops query strings and accepts absolute urls', () => {
+    expect(apiPathPattern('/api/experiences/yay-pie?full=true')).toBe('/api/experiences/:code');
+    expect(apiPathPattern('https://example.com/api/performers/jane')).toBe('/api/performers/:slug');
+  });
+});

--- a/app/frontend/Analytics/routes.ts
+++ b/app/frontend/Analytics/routes.ts
@@ -1,0 +1,45 @@
+/**
+ * Maps a concrete pathname to the route pattern that produced it.
+ *
+ * Raw URLs carry experience codes, slugs and block ids, so grouping pageviews by
+ * `$current_url` yields one bucket per show rather than one per page. Every event
+ * carries the pattern as a super property (`route`) so "what pages do users land
+ * on" is a single breakdown.
+ */
+const ROUTE_PATTERNS: Array<[RegExp, string]> = [
+  [/^\/experiences\/[^/]+\/manage\/blocks\/new$/, '/experiences/:code/manage/blocks/new'],
+  [/^\/experiences\/[^/]+\/manage\/blocks\/[^/]+$/, '/experiences/:code/manage/blocks/:blockId'],
+  [/^\/experiences\/[^/]+\/manage$/, '/experiences/:code/manage'],
+  [/^\/experiences\/[^/]+\/register$/, '/experiences/:code/register'],
+  [/^\/experiences\/[^/]+\/monitor$/, '/experiences/:code/monitor'],
+  [/^\/experiences\/[^/]+\/avatar$/, '/experiences/:code/avatar'],
+  [/^\/experiences\/[^/]+\/playbill$/, '/experiences/:code/playbill'],
+  [/^\/experiences\/[^/]+\/timeline$/, '/experiences/:code/timeline'],
+  [/^\/experiences\/[^/]+$/, '/experiences/:code'],
+  [/^\/events\/new$/, '/events/new'],
+  [/^\/events\/[^/]+\/edit$/, '/events/:slug/edit'],
+  [/^\/events\/[^/]+$/, '/events/:slug'],
+  [/^\/performers\/new$/, '/performers/new'],
+  [/^\/performers\/[^/]+\/edit$/, '/performers/:slug/edit'],
+  [/^\/performers\/[^/]+$/, '/performers/:slug'],
+];
+
+export function routePattern(pathname: string): string {
+  const normalized = pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname;
+  const match = ROUTE_PATTERNS.find(([pattern]) => pattern.test(normalized));
+  return match ? match[1] : normalized;
+}
+
+/**
+ * Collapses an API path the same way, so request timing and failures group by
+ * endpoint instead of by experience.
+ */
+export function apiPathPattern(url: string): string {
+  const path = url.startsWith('http') ? new URL(url).pathname : url.split('?')[0];
+  return path
+    .replace(/\/experiences\/[^/]+/, '/experiences/:code')
+    .replace(/\/blocks\/[^/]+/, '/blocks/:blockId')
+    .replace(/\/participants\/[^/]+/, '/participants/:id')
+    .replace(/\/performers\/[^/]+/, '/performers/:slug')
+    .replace(/\/events\/[^/]+/, '/events/:slug');
+}

--- a/app/frontend/App.tsx
+++ b/app/frontend/App.tsx
@@ -4,7 +4,7 @@ import { Outlet, Route, useLocation } from 'react-router-dom';
 
 import { MotionConfig } from 'motion/react';
 
-import { AnalyticsIdentity, ExperienceAnalytics } from '@cctv/analytics';
+import { AnalyticsIdentity, ExperienceAnalytics, RouteAnalytics } from '@cctv/analytics';
 import { RouteWink, TopNav } from '@cctv/components';
 import { ExperienceProvider } from '@cctv/contexts/ExperienceContext';
 import { UserProvider } from '@cctv/contexts/UserContext';
@@ -56,6 +56,7 @@ function App() {
   return (
     <UserProvider>
       <AnalyticsIdentity />
+      <RouteAnalytics />
       <MotionConfig reducedMotion="user">
         <div className={`app${booting ? ' app--booting' : ''}`}>
           {!currentRoute.pathname.includes('/monitor') &&

--- a/app/frontend/App.tsx
+++ b/app/frontend/App.tsx
@@ -4,6 +4,7 @@ import { Outlet, Route, useLocation } from 'react-router-dom';
 
 import { MotionConfig } from 'motion/react';
 
+import { AnalyticsIdentity, ExperienceAnalytics } from '@cctv/analytics';
 import { RouteWink, TopNav } from '@cctv/components';
 import { ExperienceProvider } from '@cctv/contexts/ExperienceContext';
 import { UserProvider } from '@cctv/contexts/UserContext';
@@ -54,6 +55,7 @@ function App() {
 
   return (
     <UserProvider>
+      <AnalyticsIdentity />
       <MotionConfig reducedMotion="user">
         <div className={`app${booting ? ' app--booting' : ''}`}>
           {!currentRoute.pathname.includes('/monitor') &&
@@ -89,6 +91,7 @@ function App() {
                   path="/experiences/:code"
                   element={
                     <ExperienceProvider>
+                      <ExperienceAnalytics />
                       <Outlet />
                     </ExperienceProvider>
                   }

--- a/app/frontend/Contexts/AdminAuthContext.tsx
+++ b/app/frontend/Contexts/AdminAuthContext.tsx
@@ -11,6 +11,7 @@ import {
 
 import { useParams } from 'react-router-dom';
 
+import { instrumentedFetch } from '@cctv/analytics';
 import { useUser } from '@cctv/contexts/UserContext';
 import {
   getStoredAdminJWT,
@@ -115,7 +116,7 @@ export function AdminAuthProvider({ children }: { children: ReactNode }) {
           'Content-Type': 'application/json',
           ...options.headers,
         };
-        return fetch(url, { ...options, headers });
+        return instrumentedFetch(url, { ...options, headers }, { source: 'admin' });
       };
 
       // No JWT client-side - attempt session refresh before giving up,

--- a/app/frontend/Contexts/AuthContext.tsx
+++ b/app/frontend/Contexts/AuthContext.tsx
@@ -2,6 +2,7 @@ import { ReactNode, createContext, useCallback, useContext, useMemo, useState } 
 
 import { useParams } from 'react-router-dom';
 
+import { instrumentedFetch } from '@cctv/analytics';
 import {
   getStoredParticipantJWT,
   removeStoredAdminJWT,
@@ -62,7 +63,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         ...options.headers,
       };
 
-      const response = await fetch(url, { ...options, headers });
+      const response = await instrumentedFetch(
+        url,
+        { ...options, headers },
+        { source: 'participant' },
+      );
 
       if (response.status === 401) {
         qaLogger('401 on participant JWT; clearing');

--- a/app/frontend/Contexts/WebSocketContext.tsx
+++ b/app/frontend/Contexts/WebSocketContext.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from 'react';
 
+import { AnalyticsEvent, capture } from '@cctv/analytics';
 import { useExperienceRoute } from '@cctv/hooks/useExperienceRoute';
 import {
   FamilyFeudAction,
@@ -74,6 +75,15 @@ function createWebSocketConnection(
 
   ws.onopen = () => {
     qaLogger(`[${config.label}] WebSocket connected`);
+    // Only a reconnect is interesting — the first connect is just startup. This
+    // pairs with `websocket disconnected` to show how long participants spent
+    // cut off from live updates during a show.
+    if (attempt > 0) {
+      capture(AnalyticsEvent.WebsocketReconnected, {
+        stream: config.label,
+        attempts: attempt,
+      });
+    }
     onReconnecting?.(false);
     config.onConnect?.();
 
@@ -102,6 +112,11 @@ function createWebSocketConnection(
 
     if (!disposeRef.current && !rejected && event.code !== 1000 && event.code !== 1001) {
       const delay = Math.min(1000 * Math.pow(2, attempt), 30000);
+      capture(AnalyticsEvent.WebsocketDisconnected, {
+        stream: config.label,
+        close_code: event.code,
+        attempt: attempt + 1,
+      });
       qaLogger(`[${config.label}] Reconnecting in ${delay}ms (attempt ${attempt + 1})`);
       onReconnecting?.(true);
       setTimeout(

--- a/app/frontend/Core/Button/Button.test.tsx
+++ b/app/frontend/Core/Button/Button.test.tsx
@@ -1,0 +1,99 @@
+import { MemoryRouter } from 'react-router-dom';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Button } from './Button';
+
+const { analyticsMock } = vi.hoisted(() => ({
+  analyticsMock: {
+    capture: vi.fn(),
+    AnalyticsEvent: { ButtonClicked: 'button clicked' },
+  },
+}));
+vi.mock('@cctv/analytics', () => analyticsMock);
+
+beforeEach(() => {
+  analyticsMock.capture.mockClear();
+});
+
+function renderInRouter(ui: React.ReactNode) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe('Button analytics', () => {
+  it('reports the visible label so flows can be mapped without bespoke events', async () => {
+    renderInRouter(<Button>Start Show</Button>);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Start Show' }));
+
+    expect(analyticsMock.capture).toHaveBeenCalledWith('button clicked', {
+      label: 'Start Show',
+      variant: 'primary',
+    });
+  });
+
+  it('reports the variant so destructive actions are distinguishable', async () => {
+    renderInRouter(<Button variant="destructive">Delete Block</Button>);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete Block' }));
+
+    expect(analyticsMock.capture).toHaveBeenCalledWith('button clicked', {
+      label: 'Delete Block',
+      variant: 'destructive',
+    });
+  });
+
+  it('prefers analyticsLabel when the visible label is dynamic', async () => {
+    renderInRouter(<Button analyticsLabel="Open Playbill">Open Playbill (12)</Button>);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open Playbill (12)' }));
+
+    expect(analyticsMock.capture).toHaveBeenCalledWith('button clicked', {
+      label: 'Open Playbill',
+      variant: 'primary',
+    });
+  });
+
+  it('stays silent when opted out', async () => {
+    renderInRouter(<Button analyticsSilent>Noisy Control</Button>);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Noisy Control' }));
+
+    expect(analyticsMock.capture).not.toHaveBeenCalled();
+  });
+
+  it('still runs the caller onClick', async () => {
+    const onClick = vi.fn();
+    renderInRouter(<Button onClick={onClick}>Save</Button>);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(analyticsMock.capture).toHaveBeenCalledTimes(1);
+  });
+
+  it('tracks link buttons, which are navigation steps in a flow', async () => {
+    renderInRouter(<Button to="/join">Join Show</Button>);
+
+    await userEvent.click(screen.getByRole('link', { name: 'Join Show' }));
+
+    expect(analyticsMock.capture).toHaveBeenCalledWith('button clicked', {
+      label: 'Join Show',
+      variant: 'primary',
+    });
+  });
+
+  it('does not leak analytics props onto the DOM node', () => {
+    renderInRouter(
+      <Button analyticsLabel="X" analyticsSilent>
+        Save
+      </Button>,
+    );
+
+    const button = screen.getByRole('button', { name: 'Save' });
+    expect(button.getAttribute('analyticsLabel')).toBeNull();
+    expect(button.getAttribute('analyticssilent')).toBeNull();
+  });
+});

--- a/app/frontend/Core/Button/Button.tsx
+++ b/app/frontend/Core/Button/Button.tsx
@@ -1,6 +1,8 @@
-import { AnchorHTMLAttributes, ButtonHTMLAttributes, ReactNode, Ref } from 'react';
+import { AnchorHTMLAttributes, ButtonHTMLAttributes, Children, ReactNode, Ref } from 'react';
 
 import { Link, LinkProps } from 'react-router-dom';
+
+import { AnalyticsEvent, capture } from '@cctv/analytics';
 
 import styles from './Button.module.scss';
 
@@ -16,6 +18,14 @@ interface SharedProps {
   icon?: ReactNode;
   /** Visually hide the label (children) but keep it for screen readers. Requires `icon`. */
   hideLabel?: boolean;
+  /**
+   * Overrides the label reported to analytics. Set this when the visible label is
+   * dynamic (a count, a name) and would otherwise split one action across many
+   * high-cardinality values.
+   */
+  analyticsLabel?: string;
+  /** Opts this button out of `button clicked` — use for noisy or trivial controls. */
+  analyticsSilent?: boolean;
 }
 
 type NativeButtonProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof SharedProps>;
@@ -77,6 +87,28 @@ function buildClassName({
     .trim();
 }
 
+/**
+ * Derives a stable analytics label from the button's own content, so mapping a
+ * flow in PostHog needs no bespoke event per button. Only string children are
+ * used — an icon-only button contributes its screen-reader text, and anything
+ * non-textual falls back to undefined rather than serialising a React tree.
+ */
+function deriveLabel(children: ReactNode, override?: string): string | undefined {
+  if (override) return override;
+
+  const text = Children.toArray(children)
+    .filter((child) => typeof child === 'string' || typeof child === 'number')
+    .join(' ')
+    .trim();
+
+  return text.length > 0 ? text.slice(0, 80) : undefined;
+}
+
+function trackClick(label: string | undefined, variant: ButtonVariant, silent: boolean): void {
+  if (silent || !label) return;
+  capture(AnalyticsEvent.ButtonClicked, { label, variant });
+}
+
 function ButtonContent({
   icon,
   hideLabel,
@@ -107,6 +139,8 @@ export function Button(props: ButtonProps) {
     icon,
     hideLabel = false,
     className,
+    analyticsLabel,
+    analyticsSilent = false,
   } = props;
 
   if (hideLabel && !icon) {
@@ -116,6 +150,7 @@ export function Button(props: ButtonProps) {
   }
 
   const classes = buildClassName({ variant, size, loading, hideLabel, className });
+  const label = deriveLabel(children, analyticsLabel);
 
   if (isLinkProps(props)) {
     const {
@@ -127,10 +162,22 @@ export function Button(props: ButtonProps) {
       size: _s,
       icon: _i,
       hideLabel: _h,
+      analyticsLabel: _al,
+      analyticsSilent: _as,
+      onClick,
       ...rest
     } = props;
     return (
-      <Link {...rest} to={to} ref={ref} className={classes}>
+      <Link
+        {...rest}
+        to={to}
+        ref={ref}
+        className={classes}
+        onClick={(event) => {
+          trackClick(label, variant, analyticsSilent);
+          onClick?.(event);
+        }}
+      >
         <ButtonContent icon={icon} hideLabel={hideLabel}>
           {children}
         </ButtonContent>
@@ -148,10 +195,22 @@ export function Button(props: ButtonProps) {
       size: _s,
       icon: _i,
       hideLabel: _h,
+      analyticsLabel: _al,
+      analyticsSilent: _as,
+      onClick,
       ...rest
     } = props;
     return (
-      <a {...rest} href={href} ref={ref} className={classes}>
+      <a
+        {...rest}
+        href={href}
+        ref={ref}
+        className={classes}
+        onClick={(event) => {
+          trackClick(label, variant, analyticsSilent);
+          onClick?.(event);
+        }}
+      >
         <ButtonContent icon={icon} hideLabel={hideLabel}>
           {children}
         </ButtonContent>
@@ -169,12 +228,25 @@ export function Button(props: ButtonProps) {
     size: _s,
     icon: _i,
     hideLabel: _h,
+    analyticsLabel: _al,
+    analyticsSilent: _as,
+    onClick,
     ...rest
   } = props;
   const isDisabled = disabled || loading;
 
   return (
-    <button {...rest} ref={ref} type={type} disabled={isDisabled} className={classes}>
+    <button
+      {...rest}
+      ref={ref}
+      type={type}
+      disabled={isDisabled}
+      className={classes}
+      onClick={(event) => {
+        trackClick(label, variant, analyticsSilent);
+        onClick?.(event);
+      }}
+    >
       {loading ? (
         <>
           <span className={styles.spinner} aria-hidden="true" />

--- a/app/frontend/Experiences/ExperienceBlockContainer/ExperienceBlockContainer.tsx
+++ b/app/frontend/Experiences/ExperienceBlockContainer/ExperienceBlockContainer.tsx
@@ -1,3 +1,6 @@
+import { useEffect } from 'react';
+
+import { trackBlockSeen } from '@cctv/analytics';
 import { Block, BlockKind, ParticipantSummary } from '@cctv/types';
 
 import Announcement from '../Announcement/Announcement';
@@ -24,6 +27,16 @@ export default function ExperienceBlockContainer({
   disabled = false,
   viewContext = 'participant',
 }: ExperienceBlockContainerProps) {
+  // Only a real participant seeing the block counts as an impression. The manage
+  // preview and the projected monitor render the same tree but nobody is being
+  // asked to respond, so counting them would inflate the denominator.
+  const trackImpression = viewContext === 'participant' && Boolean(block.payload);
+
+  useEffect(() => {
+    if (!trackImpression) return;
+    trackBlockSeen({ blockId: block.id, blockKind: block.kind });
+  }, [trackImpression, block.id, block.kind]);
+
   if (!block.payload) {
     return <p>Party's over, everyone go home.</p>;
   }

--- a/app/frontend/Hooks/useJoinExperience.ts
+++ b/app/frontend/Hooks/useJoinExperience.ts
@@ -1,3 +1,4 @@
+import { AnalyticsEvent, capture } from '@cctv/analytics';
 import { JoinExperienceApiResponse } from '@cctv/types';
 import { qaLogger } from '@cctv/utils';
 
@@ -35,6 +36,10 @@ export function useJoinExperience() {
       case 'success':
         qaLogger(`User already registrated, redirecting to: ${response.url}`);
         sessionStorage.setItem('cctv_last_join_code', code.trim());
+        capture(AnalyticsEvent.ExperienceJoined, {
+          status: 'registered',
+          experience_name: response.experience_name,
+        });
         return {
           url: response.url,
           status: 'registered',
@@ -43,6 +48,10 @@ export function useJoinExperience() {
       case 'needs_registration':
         qaLogger(`User needs registration, redirecting to: ${response.url}`);
         sessionStorage.setItem('cctv_last_join_code', code.trim());
+        capture(AnalyticsEvent.ExperienceJoined, {
+          status: 'needs_registration',
+          experience_name: response.experience_name,
+        });
         return {
           url: response.url,
           status: 'needs_registration',

--- a/app/frontend/Hooks/useQuery.ts
+++ b/app/frontend/Hooks/useQuery.ts
@@ -1,5 +1,7 @@
 import { useCallback, useRef, useState } from 'react';
 
+import { instrumentedFetch } from '@cctv/analytics';
+
 export function useQuery<T>({ url }: { url: string }) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string>();
@@ -14,7 +16,11 @@ export function useQuery<T>({ url }: { url: string }) {
       setIsLoading(true);
       setError(undefined);
       try {
-        const response = await fetch(url, { ...options, signal: controller.signal });
+        const response = await instrumentedFetch(
+          url,
+          { ...options, signal: controller.signal },
+          { source: 'public' },
+        );
         const data = (await response.json()) as T;
         if (!response.ok) {
           const msg =

--- a/app/frontend/Hooks/useSubmitBuzzerResponse.ts
+++ b/app/frontend/Hooks/useSubmitBuzzerResponse.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 
+import { trackSubmissionFailed, trackSubmissionSucceeded } from '@cctv/analytics';
 import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { useExperienceState } from '@cctv/contexts/ExperienceStateContext';
 
@@ -30,6 +31,7 @@ export function useSubmitBuzzerResponse() {
         if (!data?.success) {
           const msg = data?.error || 'Buzzer submission failed';
           setError(msg);
+          trackSubmissionFailed(blockId, 'buzzer', 'rejected', msg);
           return { success: false, error: msg };
         }
 
@@ -40,6 +42,8 @@ export function useSubmitBuzzerResponse() {
           }));
         }
 
+        trackSubmissionSucceeded(blockId, 'buzzer');
+
         return { success: true };
       } catch (e: unknown) {
         const msg =
@@ -47,6 +51,12 @@ export function useSubmitBuzzerResponse() {
             ? 'Authentication expired'
             : 'Connection error. Please try again.';
         setError(msg);
+        trackSubmissionFailed(
+          blockId,
+          'buzzer',
+          e instanceof Error && e.message === 'Authentication expired' ? 'auth_expired' : 'network',
+          msg,
+        );
         return { success: false, error: msg };
       } finally {
         setIsLoading(false);

--- a/app/frontend/Hooks/useSubmitPhotoUploadResponse.ts
+++ b/app/frontend/Hooks/useSubmitPhotoUploadResponse.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 
+import { trackSubmissionFailed, trackSubmissionSucceeded } from '@cctv/analytics';
 import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { useExperienceState } from '@cctv/contexts/ExperienceStateContext';
 
@@ -47,6 +48,7 @@ export function useSubmitPhotoUploadResponse() {
         if (!data?.success) {
           const msg = data?.error || 'Photo upload submission failed';
           setError(msg);
+          trackSubmissionFailed(blockId, 'photo_upload', 'rejected', msg);
           return { success: false, error: msg };
         }
 
@@ -61,10 +63,13 @@ export function useSubmitPhotoUploadResponse() {
           }));
         }
 
+        trackSubmissionSucceeded(blockId, 'photo_upload');
+
         return data;
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : 'Connection error. Please try again.';
         setError(msg);
+        trackSubmissionFailed(blockId, 'photo_upload', 'network', msg);
         return { success: false, error: msg };
       } finally {
         setIsLoading(false);

--- a/app/frontend/Hooks/useSubmitPollResponse.ts
+++ b/app/frontend/Hooks/useSubmitPollResponse.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 
+import { trackSubmissionFailed, trackSubmissionSucceeded } from '@cctv/analytics';
 import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { useExperienceState } from '@cctv/contexts/ExperienceStateContext';
 import { qaLogger } from '@cctv/utils';
@@ -52,6 +53,7 @@ export function useSubmitPollResponse() {
         if (!data?.success) {
           const msg = data?.error || 'Poll submission failed';
           setError(msg);
+          trackSubmissionFailed(blockId, 'poll', 'rejected', msg);
           return { success: false, error: msg };
         }
 
@@ -62,6 +64,8 @@ export function useSubmitPollResponse() {
           }));
         }
 
+        trackSubmissionSucceeded(blockId, 'poll');
+
         qaLogger('Successfully submitted poll response');
         return { success: true };
       } catch (e: any) {
@@ -70,6 +74,12 @@ export function useSubmitPollResponse() {
             ? 'Authentication expired'
             : 'Connection error. Please try again.';
         setError(msg);
+        trackSubmissionFailed(
+          blockId,
+          'poll',
+          e?.message === 'Authentication expired' ? 'auth_expired' : 'network',
+          msg,
+        );
         return { success: false, error: msg };
       }
     },

--- a/app/frontend/Hooks/useSubmitQuestionResponse.ts
+++ b/app/frontend/Hooks/useSubmitQuestionResponse.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 
+import { trackSubmissionFailed, trackSubmissionSucceeded } from '@cctv/analytics';
 import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { useExperienceState } from '@cctv/contexts/ExperienceStateContext';
 import { qaLogger } from '@cctv/utils';
@@ -55,6 +56,7 @@ export function useSubmitQuestionResponse() {
         if (!data?.success) {
           const msg = data?.error || 'Question submission failed';
           setError(msg);
+          trackSubmissionFailed(blockId, 'question', 'rejected', msg);
           return { success: false, error: msg };
         }
 
@@ -65,6 +67,8 @@ export function useSubmitQuestionResponse() {
           }));
         }
 
+        trackSubmissionSucceeded(blockId, 'question');
+
         qaLogger('Successfully submitted question response');
         return { success: true };
       } catch (e: any) {
@@ -73,6 +77,12 @@ export function useSubmitQuestionResponse() {
             ? 'Authentication expired'
             : 'Connection error. Please try again.';
         setError(msg);
+        trackSubmissionFailed(
+          blockId,
+          'question',
+          e?.message === 'Authentication expired' ? 'auth_expired' : 'network',
+          msg,
+        );
         return { success: false, error: msg };
       }
     },

--- a/app/frontend/Pages/Manage/Viewer/ManageViewer.tsx
+++ b/app/frontend/Pages/Manage/Viewer/ManageViewer.tsx
@@ -2,6 +2,7 @@ import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { BookOpen, Bug, Columns3, Pause, Play, X } from 'lucide-react';
 
+import { trackManageAction } from '@cctv/analytics';
 import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { Button, Drawer, DrawerBody, DrawerContent } from '@cctv/core';
 import { Pill } from '@cctv/core/Pill/Pill';
@@ -131,6 +132,7 @@ export default function ManageViewer() {
 
   const handleDetachBlock = useCallback(
     async (block: Block) => {
+      trackManageAction('detach_block', { block_id: block.id, block_kind: block.kind });
       setDetachingBlockId(block.id);
       await detachFromParent(block.id);
       setDetachingBlockId(undefined);
@@ -143,6 +145,7 @@ export default function ManageViewer() {
 
   const handleDeleteBlock = useCallback(
     async (block: Block) => {
+      trackManageAction('delete_block', { block_id: block.id, block_kind: block.kind });
       setDeletingBlockId(block.id);
       const result = await deleteBlock(block.id);
       setDeletingBlockId(undefined);
@@ -155,6 +158,7 @@ export default function ManageViewer() {
 
   const handleReorderBlock = useCallback(
     (blockId: string, newIndex: number) => {
+      trackManageAction('reorder_block', { block_id: blockId, new_index: newIndex });
       reorderBlock(blockId, newIndex);
     },
     [reorderBlock],
@@ -189,6 +193,10 @@ export default function ManageViewer() {
 
   const onPlayNext = useCallback(async () => {
     if (!selectedBlock) return;
+    trackManageAction('play_next', {
+      from_block_id: selectedBlock.id,
+      from_block_kind: selectedBlock.kind,
+    });
     const nextBlock = await handlePlayNext(selectedBlock, flattenedBlocks);
     if (nextBlock) setSelectedBlockId(nextBlock.id);
   }, [selectedBlock, flattenedBlocks, handlePlayNext]);

--- a/app/frontend/entrypoints/application.tsx
+++ b/app/frontend/entrypoints/application.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter } from 'react-router-dom';
 
 import { createRoot } from 'react-dom/client';
 
+import { AnalyticsErrorBoundary, initAnalytics } from '@cctv/analytics';
 import { ThemeProvider } from '@cctv/contexts/ThemeContext';
 
 import App from '../App';
@@ -10,12 +11,16 @@ import '../static.css';
 import '../styles.css';
 import '../tailwind.css';
 
+initAnalytics();
+
 const root = document.getElementById('root');
 if (root) {
   createRoot(root).render(
     <BrowserRouter>
       <ThemeProvider>
-        <App />
+        <AnalyticsErrorBoundary>
+          <App />
+        </AnalyticsErrorBoundary>
       </ThemeProvider>
     </BrowserRouter>,
   );

--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -1,0 +1,16 @@
+module AnalyticsHelper
+  # Embeds the browser analytics config as a non-executable JSON data block.
+  # The frontend reads it on boot to decide whether to initialize PostHog.
+  # Renders nothing when analytics is disabled, so the SDK never starts in
+  # development, test, or any environment without POSTHOG_KEY set.
+  def analytics_config_tag
+    return unless Analytics::Config.enabled?
+
+    content_tag(
+      :script,
+      raw(ERB::Util.json_escape(Analytics::Config.client_config.to_json)),
+      type: "application/json",
+      id: "analytics-config",
+    )
+  end
+end

--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -1,8 +1,4 @@
 module AnalyticsHelper
-  # Embeds the browser analytics config as a non-executable JSON data block.
-  # The frontend reads it on boot to decide whether to initialize PostHog.
-  # Renders nothing when analytics is disabled, so the SDK never starts in
-  # development, test, or any environment without POSTHOG_KEY set.
   def analytics_config_tag
     return unless Analytics::Config.enabled?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,11 @@ class User < ApplicationRecord
 
   before_save { self.email = email.downcase.strip }
 
+  # Used by posthog-rails to associate automatically captured errors with this user.
+  def posthog_distinct_id
+    id.to_s
+  end
+
   def most_recent_participant_name
     experience_participants.order(created_at: :desc).first&.name
   end

--- a/app/services/analytics/config.rb
+++ b/app/services/analytics/config.rb
@@ -1,29 +1,28 @@
 module Analytics
-  # Single source of truth for whether analytics is active and what config the
-  # browser client needs. Read at request time (never cached) so a deploy can
-  # flip analytics on/off purely via environment variables.
   module Config
-    module_function
-
     DEFAULT_HOST = "https://us.i.posthog.com".freeze
 
+    module_function
+
     def enabled?
-      ENV["POSTHOG_KEY"].present? && !Rails.env.test?
+      ENV["POSTHOG_API_KEY"].present? && !Rails.env.test?
     end
 
     def key
-      ENV["POSTHOG_KEY"].presence
+      ENV["POSTHOG_API_KEY"].presence
     end
 
+    # Always resolves to a host. The browser config block is rejected client-side
+    # when `host` is missing, so returning nil here would silently disable all
+    # frontend analytics in any environment that sets a key but not a host.
     def host
-      ENV.fetch("POSTHOG_HOST", DEFAULT_HOST)
+      ENV.fetch("POSTHOG_HOST", DEFAULT_HOST).presence || DEFAULT_HOST
     end
 
     def session_replay?
       ActiveModel::Type::Boolean.new.cast(ENV["POSTHOG_SESSION_REPLAY"]) == true
     end
 
-    # Serialized into the page for the browser SDK to read on boot.
     def client_config
       {
         enabled: enabled?,

--- a/app/services/analytics/config.rb
+++ b/app/services/analytics/config.rb
@@ -1,0 +1,37 @@
+module Analytics
+  # Single source of truth for whether analytics is active and what config the
+  # browser client needs. Read at request time (never cached) so a deploy can
+  # flip analytics on/off purely via environment variables.
+  module Config
+    module_function
+
+    DEFAULT_HOST = "https://us.i.posthog.com".freeze
+
+    def enabled?
+      ENV["POSTHOG_KEY"].present? && !Rails.env.test?
+    end
+
+    def key
+      ENV["POSTHOG_KEY"].presence
+    end
+
+    def host
+      ENV.fetch("POSTHOG_HOST", DEFAULT_HOST)
+    end
+
+    def session_replay?
+      ActiveModel::Type::Boolean.new.cast(ENV["POSTHOG_SESSION_REPLAY"]) == true
+    end
+
+    # Serialized into the page for the browser SDK to read on boot.
+    def client_config
+      {
+        enabled: enabled?,
+        key: key,
+        host: host,
+        environment: Rails.env.to_s,
+        sessionReplay: session_replay?,
+      }
+    end
+  end
+end

--- a/app/services/analytics/events.rb
+++ b/app/services/analytics/events.rb
@@ -13,5 +13,13 @@ module Analytics
     BLOCK_CLOSED = "block closed".freeze
     RESPONSE_SUBMITTED = "response submitted".freeze
     AVATAR_SAVED = "avatar saved".freeze
+    EVENT_CREATED = "event_created".freeze
+    EVENT_UPDATED = "event_updated".freeze
+    EVENT_DELETED = "event_deleted".freeze
+    PERFORMER_PROFILE_CREATED = "performer_profile_created".freeze
+    PERFORMER_FOLLOWED = "performer_followed".freeze
+    PERFORMER_UNFOLLOWED = "performer_unfollowed".freeze
+    BLOCK_CREATED = "block_created".freeze
+    PARTICIPANT_KICKED = "participant_kicked".freeze
   end
 end

--- a/app/services/analytics/events.rb
+++ b/app/services/analytics/events.rb
@@ -1,0 +1,17 @@
+module Analytics
+  # Canonical event names. Keep these strings identical to the frontend
+  # taxonomy in app/frontend/Analytics/events.ts so a single PostHog event
+  # represents the same action regardless of which side emitted it.
+  module Events
+    EXPERIENCE_CREATED = "experience created".freeze
+    PARTICIPANT_REGISTERED = "participant registered".freeze
+    LOBBY_OPENED = "experience lobby opened".freeze
+    EXPERIENCE_STARTED = "experience started".freeze
+    EXPERIENCE_PAUSED = "experience paused".freeze
+    EXPERIENCE_RESUMED = "experience resumed".freeze
+    BLOCK_OPENED = "block opened".freeze
+    BLOCK_CLOSED = "block closed".freeze
+    RESPONSE_SUBMITTED = "response submitted".freeze
+    AVATAR_SAVED = "avatar saved".freeze
+  end
+end

--- a/app/services/analytics/tracker.rb
+++ b/app/services/analytics/tracker.rb
@@ -1,0 +1,74 @@
+module Analytics
+  # Thin, failure-tolerant wrapper around the PostHog client. Analytics must
+  # never break a request: every call is guarded and any error is logged and
+  # swallowed. When PostHog is not configured the underlying client is disabled
+  # and these calls are no-ops.
+  module Tracker
+    EXPERIENCE_GROUP = "experience".freeze
+
+    module_function
+
+    # distinct_id should be the User#id so backend events stitch to the
+    # frontend, which identifies with the same id. Pass `experience` to attach
+    # the event to that experience's PostHog group.
+    def capture(distinct_id:, event:, properties: {}, experience: nil)
+      return if distinct_id.blank?
+
+      attrs = {
+        distinct_id: distinct_id,
+        event: event,
+        properties: event_properties(properties, experience),
+      }
+      attrs[:groups] = { EXPERIENCE_GROUP => experience.id } if experience
+
+      POSTHOG.capture(attrs)
+    rescue StandardError => e
+      warn_failure("capture", e)
+    end
+
+    def identify(distinct_id:, properties: {})
+      return if distinct_id.blank?
+
+      POSTHOG.identify(distinct_id: distinct_id, properties: properties)
+    rescue StandardError => e
+      warn_failure("identify", e)
+    end
+
+    def identify_experience(experience)
+      return if experience.blank?
+
+      POSTHOG.group_identify(
+        group_type: EXPERIENCE_GROUP,
+        group_key: experience.id,
+        properties: {
+          name: experience.name,
+          code: experience.code,
+        },
+      )
+    rescue StandardError => e
+      warn_failure("identify_experience", e)
+    end
+
+    def capture_exception(exception, distinct_id: nil, properties: {})
+      POSTHOG.capture_exception(exception, distinct_id, properties)
+    rescue StandardError => e
+      warn_failure("capture_exception", e)
+    end
+
+    def event_properties(properties, experience)
+      return properties unless experience
+
+      properties.merge(
+        experience_code: experience.code,
+        experience_name: experience.name,
+      )
+    end
+    private_class_method :event_properties
+
+    def warn_failure(operation, error)
+      Rails.logger.warn("[PostHog] #{operation} failed: #{error.class} #{error.message}")
+      nil
+    end
+    private_class_method :warn_failure
+  end
+end

--- a/app/services/analytics/tracker.rb
+++ b/app/services/analytics/tracker.rb
@@ -21,7 +21,7 @@ module Analytics
       }
       attrs[:groups] = { EXPERIENCE_GROUP => experience.id } if experience
 
-      POSTHOG.capture(attrs)
+      PostHog.capture(attrs)
     rescue StandardError => e
       warn_failure("capture", e)
     end
@@ -29,7 +29,7 @@ module Analytics
     def identify(distinct_id:, properties: {})
       return if distinct_id.blank?
 
-      POSTHOG.identify(distinct_id: distinct_id, properties: properties)
+      PostHog.identify(distinct_id: distinct_id, properties: properties)
     rescue StandardError => e
       warn_failure("identify", e)
     end
@@ -37,7 +37,7 @@ module Analytics
     def identify_experience(experience)
       return if experience.blank?
 
-      POSTHOG.group_identify(
+      PostHog.group_identify(
         group_type: EXPERIENCE_GROUP,
         group_key: experience.id,
         properties: {
@@ -50,7 +50,7 @@ module Analytics
     end
 
     def capture_exception(exception, distinct_id: nil, properties: {})
-      POSTHOG.capture_exception(exception, distinct_id, properties)
+      PostHog.capture_exception(exception, distinct_id, properties)
     rescue StandardError => e
       warn_failure("capture_exception", e)
     end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <%= analytics_config_tag %>
+
     <%= yield :head %>
 
     <script>

--- a/config/initializers/posthog.rb
+++ b/config/initializers/posthog.rb
@@ -1,19 +1,22 @@
 require "posthog"
+require "posthog/rails"
 
-# Singleton PostHog client, reused for the life of the process (multiple
-# clients can drop events). When POSTHOG_KEY is absent the client is created in
-# a disabled state and every call becomes a no-op, so analytics is effectively
-# off in development and test without any branching at the call sites.
-POSTHOG = PostHog::Client.new(
-  api_key: ENV["POSTHOG_KEY"].to_s,
-  host: ENV.fetch("POSTHOG_HOST", "https://us.i.posthog.com"),
-  test_mode: Rails.env.test?,
-  silence_disabled_client_error: true,
-  on_error: ->(status, message) { Rails.logger.warn("[PostHog] #{status} - #{message}") },
-)
+posthog_api_key = ENV["POSTHOG_API_KEY"].presence
 
-at_exit do
-  POSTHOG.shutdown
-rescue StandardError
-  nil
+if posthog_api_key.present?
+  PostHog.init do |config|
+    config.api_key = posthog_api_key
+    config.host = ENV["POSTHOG_HOST"].presence
+  end
+
+  PostHog::Rails.configure do |config|
+    config.auto_capture_exceptions = true
+    config.report_rescued_exceptions = true
+    config.auto_instrument_active_job = true
+    config.capture_user_context = true
+    config.current_user_method = :current_user
+    config.user_id_method = :posthog_distinct_id
+  end
+elsif Rails.env.development?
+  raise "POSTHOG_API_KEY variable required by PostHog is missing or un-configured, this causes events to be silently missed. This error stops appearing once POSTHOG_API_KEY is configured"
 end

--- a/config/initializers/posthog.rb
+++ b/config/initializers/posthog.rb
@@ -1,0 +1,19 @@
+require "posthog"
+
+# Singleton PostHog client, reused for the life of the process (multiple
+# clients can drop events). When POSTHOG_KEY is absent the client is created in
+# a disabled state and every call becomes a no-op, so analytics is effectively
+# off in development and test without any branching at the call sites.
+POSTHOG = PostHog::Client.new(
+  api_key: ENV["POSTHOG_KEY"].to_s,
+  host: ENV.fetch("POSTHOG_HOST", "https://us.i.posthog.com"),
+  test_mode: Rails.env.test?,
+  silence_disabled_client_error: true,
+  on_error: ->(status, message) { Rails.logger.warn("[PostHog] #{status} - #{message}") },
+)
+
+at_exit do
+  POSTHOG.shutdown
+rescue StandardError
+  nil
+end

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "leaflet": "^1.9.4",
     "lucide-react": "^0.554.0",
     "motion": "^12.40.0",
+    "posthog-js": "^1.386.6",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.3",
     "react-day-picker": "^9.11.3",

--- a/spec/controllers/api/analytics_instrumentation_spec.rb
+++ b/spec/controllers/api/analytics_instrumentation_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+# Guards that the controllers actually emit the analytics events. The Tracker
+# itself is unit-tested in spec/services/analytics; here we confirm the wiring
+# at representative call sites (the direct-capture path via #create and the
+# track_event path via the lifecycle actions).
+RSpec.describe Api::ExperiencesController, type: :controller do
+  include Passwordless::ControllerHelpers
+
+  let!(:experience) { create(:experience, status: :draft) }
+  let(:admin) { create(:user, :admin) }
+
+  # Capture the keyword args of every Tracker.capture call so assertions don't
+  # depend on RSpec's keyword-vs-positional argument matching.
+  let(:captured) { [] }
+
+  before do
+    sign_in(create_passwordless_session(admin))
+    allow(Analytics::Tracker).to receive(:capture) { |**kwargs| captured << kwargs }
+    allow(Analytics::Tracker).to receive(:identify_experience)
+  end
+
+  it "tracks experience creation and identifies the experience group" do
+    post(:create, params: { experience: { name: "Show", code: "SHOW#{rand(100_000)}" } }, format: :json)
+
+    expect(captured).to include(
+      hash_including(event: Analytics::Events::EXPERIENCE_CREATED, distinct_id: admin.id),
+    )
+    expect(Analytics::Tracker).to have_received(:identify_experience).with(an_instance_of(Experience))
+  end
+
+  it "tracks lobby opening with the acting user as distinct_id" do
+    post(:open_lobby, params: { id: experience.code_slug }, format: :json)
+
+    expect(captured).to include(
+      hash_including(event: Analytics::Events::LOBBY_OPENED, distinct_id: admin.id),
+    )
+  end
+
+  it "tracks experience start" do
+    post(:start, params: { id: experience.code_slug }, format: :json)
+
+    expect(captured).to include(hash_including(event: Analytics::Events::EXPERIENCE_STARTED))
+  end
+
+  it "tracks experience pause" do
+    experience.update!(status: :live)
+
+    post(:pause, params: { id: experience.code_slug }, format: :json)
+
+    expect(captured).to include(hash_including(event: Analytics::Events::EXPERIENCE_PAUSED))
+  end
+
+  it "tracks experience resume" do
+    experience.update!(status: :paused)
+
+    post(:resume, params: { id: experience.code_slug }, format: :json)
+
+    expect(captured).to include(hash_including(event: Analytics::Events::EXPERIENCE_RESUMED))
+  end
+end

--- a/spec/controllers/api/base_controller_spec.rb
+++ b/spec/controllers/api/base_controller_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe Api::BaseController, type: :controller do
+  controller(described_class) do
+    def trigger
+      if params[:expected] == "true"
+        raise Api::BaseController::NotFoundError, "expected control flow"
+      else
+        raise RuntimeError, "kaboom"
+      end
+    end
+  end
+
+  before do
+    routes.draw { get "trigger" => "api/base#trigger" }
+    allow(Analytics::Tracker).to receive(:capture_exception)
+  end
+
+  it "reports unexpected errors to PostHog and re-raises them unchanged" do
+    expect { get :trigger }.to raise_error(RuntimeError, "kaboom")
+
+    expect(Analytics::Tracker).to have_received(:capture_exception).with(
+      an_instance_of(RuntimeError),
+      hash_including(
+        distinct_id: nil,
+        properties: hash_including(action: "trigger", path: "/trigger", method: "GET"),
+      ),
+    )
+  end
+
+  it "does not report expected control-flow errors, but still re-raises them" do
+    expect { get :trigger, params: { expected: "true" } }
+      .to raise_error(Api::BaseController::NotFoundError)
+
+    expect(Analytics::Tracker).not_to have_received(:capture_exception)
+  end
+end

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe AnalyticsHelper, type: :helper do
+  describe "#analytics_config_tag" do
+    context "when analytics is disabled (the default in test)" do
+      it "renders nothing" do
+        allow(Analytics::Config).to receive(:enabled?).and_return(false)
+
+        expect(helper.analytics_config_tag).to be_nil
+      end
+    end
+
+    context "when analytics is enabled" do
+      before do
+        allow(Analytics::Config).to receive(:enabled?).and_return(true)
+        allow(Analytics::Config).to receive(:client_config).and_return(
+          enabled: true,
+          key: "phc_test",
+          host: "https://us.i.posthog.com",
+          environment: "production",
+          sessionReplay: false,
+        )
+      end
+
+      it "renders a non-executable JSON config data block with the resolved config" do
+        html = helper.analytics_config_tag.to_s
+
+        expect(html).to include('id="analytics-config"')
+        expect(html).to include('type="application/json"')
+        expect(html).to include('"key":"phc_test"')
+        expect(html).to include('"host":"https://us.i.posthog.com"')
+        expect(html).to include('"enabled":true')
+      end
+    end
+  end
+end

--- a/spec/services/analytics/config_spec.rb
+++ b/spec/services/analytics/config_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe Analytics::Config do
   describe ".enabled?" do
-    it "is false in the test environment regardless of POSTHOG_KEY" do
+    it "is false in the test environment regardless of POSTHOG_API_KEY" do
       allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with("POSTHOG_KEY").and_return("phc_present")
+      allow(ENV).to receive(:[]).with("POSTHOG_API_KEY").and_return("phc_present")
 
       expect(described_class.enabled?).to be(false)
     end

--- a/spec/services/analytics/config_spec.rb
+++ b/spec/services/analytics/config_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe Analytics::Config do
+  describe ".enabled?" do
+    it "is false in the test environment regardless of POSTHOG_KEY" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("POSTHOG_KEY").and_return("phc_present")
+
+      expect(described_class.enabled?).to be(false)
+    end
+  end
+
+  describe ".host" do
+    it "defaults to the US cloud ingestion host" do
+      expect(described_class.host).to eq("https://us.i.posthog.com")
+    end
+
+    it "honors a POSTHOG_HOST override (e.g. EU cloud)" do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("POSTHOG_HOST", anything).and_return("https://eu.i.posthog.com")
+
+      expect(described_class.host).to eq("https://eu.i.posthog.com")
+    end
+  end
+
+  describe ".session_replay?" do
+    it "parses truthy strings" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("POSTHOG_SESSION_REPLAY").and_return("true")
+
+      expect(described_class.session_replay?).to be(true)
+    end
+
+    it "defaults to false when unset" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("POSTHOG_SESSION_REPLAY").and_return(nil)
+
+      expect(described_class.session_replay?).to be(false)
+    end
+  end
+
+  describe ".client_config" do
+    it "reports analytics off in test with the resolved host and environment" do
+      expect(described_class.client_config).to include(
+        enabled: false,
+        host: "https://us.i.posthog.com",
+        environment: "test",
+        sessionReplay: false,
+      )
+    end
+  end
+end

--- a/spec/services/analytics/tracker_spec.rb
+++ b/spec/services/analytics/tracker_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.describe Analytics::Tracker do
+  let(:experience) { double("Experience", id: "exp-1", code: "ABC", name: "My Show") }
+
+  describe ".capture" do
+    it "no-ops when distinct_id is blank" do
+      expect(POSTHOG).not_to receive(:capture)
+
+      described_class.capture(distinct_id: nil, event: "experience started")
+    end
+
+    it "forwards id, event, merged experience properties, and the experience group" do
+      allow(POSTHOG).to receive(:capture)
+
+      described_class.capture(
+        distinct_id: "user-1",
+        event: "experience started",
+        properties: { foo: "bar" },
+        experience: experience,
+      )
+
+      expect(POSTHOG).to have_received(:capture).with(
+        distinct_id: "user-1",
+        event: "experience started",
+        properties: { foo: "bar", experience_code: "ABC", experience_name: "My Show" },
+        groups: { "experience" => "exp-1" },
+      )
+    end
+
+    it "omits the group and experience properties when no experience is given" do
+      allow(POSTHOG).to receive(:capture)
+
+      described_class.capture(distinct_id: "user-1", event: "ping", properties: { a: 1 })
+
+      expect(POSTHOG).to have_received(:capture).with(
+        distinct_id: "user-1",
+        event: "ping",
+        properties: { a: 1 },
+      )
+    end
+
+    it "swallows client errors so analytics never breaks a request" do
+      allow(POSTHOG).to receive(:capture).and_raise(StandardError, "boom")
+
+      expect { described_class.capture(distinct_id: "u", event: "e") }.not_to raise_error
+    end
+  end
+
+  describe ".identify_experience" do
+    it "identifies the experience group with its name and code" do
+      allow(POSTHOG).to receive(:group_identify)
+
+      described_class.identify_experience(experience)
+
+      expect(POSTHOG).to have_received(:group_identify).with(
+        group_type: "experience",
+        group_key: "exp-1",
+        properties: { name: "My Show", code: "ABC" },
+      )
+    end
+
+    it "no-ops when experience is blank" do
+      expect(POSTHOG).not_to receive(:group_identify)
+
+      described_class.identify_experience(nil)
+    end
+  end
+
+  describe ".capture_exception" do
+    it "forwards the exception, distinct_id, and properties to the client" do
+      allow(POSTHOG).to receive(:capture_exception)
+      error = RuntimeError.new("nope")
+
+      described_class.capture_exception(error, distinct_id: "u", properties: { a: 1 })
+
+      expect(POSTHOG).to have_received(:capture_exception).with(error, "u", { a: 1 })
+    end
+  end
+end

--- a/spec/services/analytics/tracker_spec.rb
+++ b/spec/services/analytics/tracker_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe Analytics::Tracker do
 
   describe ".capture" do
     it "no-ops when distinct_id is blank" do
-      expect(POSTHOG).not_to receive(:capture)
+      expect(PostHog).not_to receive(:capture)
 
       described_class.capture(distinct_id: nil, event: "experience started")
     end
 
     it "forwards id, event, merged experience properties, and the experience group" do
-      allow(POSTHOG).to receive(:capture)
+      allow(PostHog).to receive(:capture)
 
       described_class.capture(
         distinct_id: "user-1",
@@ -20,7 +20,7 @@ RSpec.describe Analytics::Tracker do
         experience: experience,
       )
 
-      expect(POSTHOG).to have_received(:capture).with(
+      expect(PostHog).to have_received(:capture).with(
         distinct_id: "user-1",
         event: "experience started",
         properties: { foo: "bar", experience_code: "ABC", experience_name: "My Show" },
@@ -29,11 +29,11 @@ RSpec.describe Analytics::Tracker do
     end
 
     it "omits the group and experience properties when no experience is given" do
-      allow(POSTHOG).to receive(:capture)
+      allow(PostHog).to receive(:capture)
 
       described_class.capture(distinct_id: "user-1", event: "ping", properties: { a: 1 })
 
-      expect(POSTHOG).to have_received(:capture).with(
+      expect(PostHog).to have_received(:capture).with(
         distinct_id: "user-1",
         event: "ping",
         properties: { a: 1 },
@@ -41,7 +41,7 @@ RSpec.describe Analytics::Tracker do
     end
 
     it "swallows client errors so analytics never breaks a request" do
-      allow(POSTHOG).to receive(:capture).and_raise(StandardError, "boom")
+      allow(PostHog).to receive(:capture).and_raise(StandardError, "boom")
 
       expect { described_class.capture(distinct_id: "u", event: "e") }.not_to raise_error
     end
@@ -49,11 +49,11 @@ RSpec.describe Analytics::Tracker do
 
   describe ".identify_experience" do
     it "identifies the experience group with its name and code" do
-      allow(POSTHOG).to receive(:group_identify)
+      allow(PostHog).to receive(:group_identify)
 
       described_class.identify_experience(experience)
 
-      expect(POSTHOG).to have_received(:group_identify).with(
+      expect(PostHog).to have_received(:group_identify).with(
         group_type: "experience",
         group_key: "exp-1",
         properties: { name: "My Show", code: "ABC" },
@@ -61,7 +61,7 @@ RSpec.describe Analytics::Tracker do
     end
 
     it "no-ops when experience is blank" do
-      expect(POSTHOG).not_to receive(:group_identify)
+      expect(PostHog).not_to receive(:group_identify)
 
       described_class.identify_experience(nil)
     end
@@ -69,12 +69,12 @@ RSpec.describe Analytics::Tracker do
 
   describe ".capture_exception" do
     it "forwards the exception, distinct_id, and properties to the client" do
-      allow(POSTHOG).to receive(:capture_exception)
+      allow(PostHog).to receive(:capture_exception)
       error = RuntimeError.new("nope")
 
       described_class.capture_exception(error, distinct_id: "u", properties: { a: 1 })
 
-      expect(POSTHOG).to have_received(:capture_exception).with(error, "u", { a: 1 })
+      expect(PostHog).to have_received(:capture_exception).with(error, "u", { a: 1 })
     end
   end
 end

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,9 @@
       "@cctv/utils": ["./app/frontend/utils"],
       "@cctv/utils/*": ["./app/frontend/utils/*"],
       "@cctv/types": ["./app/frontend/types"],
-      "@cctv/sounds": ["./app/frontend/sounds"]
+      "@cctv/sounds": ["./app/frontend/sounds"],
+      "@cctv/analytics": ["./app/frontend/Analytics"],
+      "@cctv/analytics/*": ["./app/frontend/Analytics/*"]
     }
   },
   "include": ["app/frontend/**/*"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -62,6 +62,10 @@ export default defineConfig({
         fileURLToPath(new URL('.', import.meta.url)),
         'app/frontend/sounds',
       ),
+      '@cctv/analytics': path.resolve(
+        fileURLToPath(new URL('.', import.meta.url)),
+        'app/frontend/Analytics',
+      ),
     },
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1074,6 +1074,18 @@
     "@parcel/watcher-win32-ia32" "2.5.1"
     "@parcel/watcher-win32-x64" "2.5.1"
 
+"@posthog/core@^1.32.3":
+  version "1.32.3"
+  resolved "https://registry.yarnpkg.com/@posthog/core/-/core-1.32.3.tgz#4ea8177e007c17ffee74def62e41e0f6951ad343"
+  integrity sha512-vwOEMfZvGv5XxNWV7p9I52NSmvFNMhyW2IHpIoUHW5jLkgUrknzJW1H/qxVGSIrNNVQkfsoaDFzDhJdg10pgrA==
+  dependencies:
+    "@posthog/types" "1.386.3"
+
+"@posthog/types@1.386.3", "@posthog/types@^1.386.3":
+  version "1.386.3"
+  resolved "https://registry.yarnpkg.com/@posthog/types/-/types-1.386.3.tgz#2703a3b83a80c24524283c515334bdf407be9f9b"
+  integrity sha512-LqJoiQi2eyWn7rCUgnn+D+F3Efp6+04o72bjSX6kWHx0nFaYNC/nJuAIRliDTY/X7GPIUAaHAcSjbMI/9wfX1Q==
+
 "@radix-ui/primitive@1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.3.tgz#e2dbc13bdc5e4168f4334f75832d7bdd3e2de5ba"
@@ -2122,6 +2134,11 @@
     fflate "~0.8.2"
     meshoptimizer "~1.1.1"
 
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
 "@types/use-sync-external-store@^0.0.6":
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz#60be8d21baab8c305132eb9cb912ed497852aadc"
@@ -2683,6 +2700,11 @@ cookie@^1.0.2:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.0.2.tgz#27360701532116bd3f1f9416929d176afe1e4610"
   integrity sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==
 
+core-js@^3.38.1:
+  version "3.49.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.49.0.tgz#8b4d520ac034311fa21aa616f017ada0e0dbbddd"
+  integrity sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==
+
 cors@^2.8.5:
   version "2.8.5"
   resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
@@ -2859,6 +2881,13 @@ dom-accessibility-api@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz#993e925cc1d73f2c662e7d75dd5a5445259a8fd8"
   integrity sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==
+
+dompurify@^3.3.2:
+  version "3.4.9"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.9.tgz#b036637b2df8997126b58837bc90f85dbcad6b2f"
+  integrity sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 dotenv@^17.2.1:
   version "17.2.3"
@@ -3200,6 +3229,11 @@ fetch-blob@^3.1.2, fetch-blob@^3.1.4:
   dependencies:
     node-domexception "^1.0.0"
     web-streams-polyfill "^3.0.3"
+
+fflate@^0.4.8:
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.4.8.tgz#f90b82aefbd8ac174213abb338bd7ef848f0f5ae"
+  integrity sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==
 
 fflate@~0.8.2:
   version "0.8.2"
@@ -4358,6 +4392,25 @@ postcss@^8.5.3, postcss@^8.5.6:
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
+posthog-js@^1.386.6:
+  version "1.386.6"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.386.6.tgz#9d2ef8de3f2eba9c237b8f71cb47911d7ab6339c"
+  integrity sha512-xRcbToRtU07Ojk+VaCCos6I/zD60sNKfWxdeZih0xbncgegIqLZJmBzi4HdkSkXrf14b6HhwMI/s2GxWha5ADQ==
+  dependencies:
+    "@posthog/core" "^1.32.3"
+    "@posthog/types" "^1.386.3"
+    core-js "^3.38.1"
+    dompurify "^3.3.2"
+    fflate "^0.4.8"
+    preact "^10.28.2"
+    query-selector-shadow-dom "^1.0.1"
+    web-vitals "^5.1.0"
+
+preact@^10.28.2:
+  version "10.29.2"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.29.2.tgz#3e6069c471718b8d124d1cd67565114532e88d70"
+  integrity sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==
+
 prettier@^3.3.3:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.2.tgz#ccda02a1003ebbb2bfda6f83a074978f608b9393"
@@ -4411,6 +4464,11 @@ qs@^6.14.0:
   integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
   dependencies:
     side-channel "^1.1.0"
+
+query-selector-shadow-dom@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz#1c7b0058eff4881ac44f45d8f84ede32e9a2f349"
+  integrity sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -5430,6 +5488,11 @@ web-streams-polyfill@^3.0.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
   integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
+
+web-vitals@^5.1.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-5.3.0.tgz#a67f57f229fdf68be99eb99d3725946def284ff3"
+  integrity sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==
 
 webidl-conversions@^8.0.1:
   version "8.0.1"


### PR DESCRIPTION
Adds PostHog product analytics + error tracking across the Rails API and React SPA, gated entirely on `POSTHOG_KEY` (off in dev without a key, always off in test). The backend adds a singleton client and an `Analytics::{Config,Events,Tracker}` service layer that emits authoritative domain events (experience create/lifecycle, registration, block open/close, response submitted, avatar saved) plus an `around_action` that reports unexpected controller exceptions. The frontend uses a server-injected JSON config block to drive a guarded posthog-js module that captures SPA pageviews/exceptions, identifies users by `User#id`, groups events per experience, and wraps the app in an error boundary — configured via `POSTHOG_KEY`/`POSTHOG_HOST`/`POSTHOG_SESSION_REPLAY` (US cloud default, documented in `.env.example`). Includes backend specs (config, tracker, helper, error reporting, event emission) and a frontend vitest suite (config, client, identity, error boundary).