### PR TITLE
Add Focus Mode to the manage page

### DIFF
--- a/app/frontend/App.tsx
+++ b/app/frontend/App.tsx
@@ -41,6 +41,12 @@ const BlockPage = lazy(() =>
 );
 const ManageCreateBlock = lazy(() => import('@cctv/pages/ManageCreateBlock/ManageCreateBlock'));
 const ManageViewer = lazy(() => import('@cctv/pages/Manage/Viewer/ManageViewer'));
+const FocusMode = lazy(() => import('@cctv/pages/Manage/Focus/FocusMode'));
+const ManageParticipantsPage = lazy(
+  () => import('@cctv/pages/Manage/Subpages/ManageParticipantsPage'),
+);
+const ManagePlaybillPage = lazy(() => import('@cctv/pages/Manage/Subpages/ManagePlaybillPage'));
+const ManageDebugPage = lazy(() => import('@cctv/pages/Manage/Subpages/ManageDebugPage'));
 const Timeline = lazy(() => import('@cctv/pages/Timeline/Timeline'));
 
 function App() {
@@ -107,6 +113,10 @@ function App() {
 
                     <Route element={<RequireExperienceHostOrAdmin />}>
                       <Route path="manage" element={<ManageViewer />} />
+                      <Route path="manage/focus" element={<FocusMode />} />
+                      <Route path="manage/participants" element={<ManageParticipantsPage />} />
+                      <Route path="manage/playbill" element={<ManagePlaybillPage />} />
+                      <Route path="manage/debug" element={<ManageDebugPage />} />
                       <Route path="manage/blocks/new" element={<ManageCreateBlock />} />
                       <Route path="manage/blocks/:blockId" element={<BlockPage />} />
                       <Route path="timeline" element={<Timeline />} />

--- a/app/frontend/Pages/Manage/CreateBlock/CreateBlock.tsx
+++ b/app/frontend/Pages/Manage/CreateBlock/CreateBlock.tsx
@@ -59,9 +59,7 @@ function CreateBlockForm({ onClose }: CreateBlockFormProps) {
         required
       />
 
-      <BlockEditor />
-      <SegmentSelector />
-      <PlaybillToggles />
+      <CreateBlockFields />
 
       <div className={styles.actions}>
         <Button variant="secondary" onClick={onClose}>
@@ -79,6 +77,16 @@ function CreateBlockForm({ onClose }: CreateBlockFormProps) {
         <Button onClick={() => submit('open')}>Play now</Button>
       </div>
     </div>
+  );
+}
+
+export function CreateBlockFields() {
+  return (
+    <>
+      <BlockEditor />
+      <SegmentSelector />
+      <PlaybillToggles />
+    </>
   );
 }
 

--- a/app/frontend/Pages/Manage/CreateBlock/CreateBlockContext.tsx
+++ b/app/frontend/Pages/Manage/CreateBlock/CreateBlockContext.tsx
@@ -98,6 +98,7 @@ interface CreateBlockProviderProps {
   participants: ParticipantSummary[];
   onClose: () => void;
   onEndCurrentBlock: () => Promise<void>;
+  initialKind?: BlockKind;
 }
 
 // NOTE: There are N number of branches for each block type. This is a good
@@ -108,6 +109,7 @@ export function CreateBlockProvider({
   participants,
   onClose,
   onEndCurrentBlock,
+  initialKind = BlockKind.POLL,
 }: CreateBlockProviderProps) {
   const getDefaultFormData = useCallback((blockKind: BlockKind): FormBlockData => {
     switch (blockKind) {
@@ -141,9 +143,7 @@ export function CreateBlockProvider({
     }
   }, []);
 
-  const [blockData, setBlockData] = useState<FormBlockData>(() =>
-    getDefaultFormData(BlockKind.POLL),
-  );
+  const [blockData, setBlockData] = useState<FormBlockData>(() => getDefaultFormData(initialKind));
 
   const { experience } = useExperience();
 

--- a/app/frontend/Pages/Manage/EditBlock/EditBlock.tsx
+++ b/app/frontend/Pages/Manage/EditBlock/EditBlock.tsx
@@ -83,8 +83,7 @@ function EditBlockForm({ onClose, block }: EditBlockFormProps) {
         </div>
       )}
 
-      <BlockEditor />
-      {viewAdditionalDetails && <AdditionalDetails />}
+      <EditBlockFields />
 
       <div className={styles.actions}>
         <Button variant="secondary" onClick={onClose}>
@@ -101,6 +100,17 @@ function EditBlockForm({ onClose, block }: EditBlockFormProps) {
         </Button>
       </div>
     </div>
+  );
+}
+
+export function EditBlockFields() {
+  const { viewAdditionalDetails } = useEditBlockContext();
+
+  return (
+    <>
+      <BlockEditor />
+      {viewAdditionalDetails && <AdditionalDetails />}
+    </>
   );
 }
 

--- a/app/frontend/Pages/Manage/ExperienceActionButton.test.tsx
+++ b/app/frontend/Pages/Manage/ExperienceActionButton.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ExperienceActionButton from './ExperienceActionButton';
+
+const { startExperience, pauseExperience, resumeExperience, useExperienceMock } = vi.hoisted(
+  () => ({
+    startExperience: vi.fn(),
+    pauseExperience: vi.fn(),
+    resumeExperience: vi.fn(),
+    useExperienceMock: vi.fn(),
+  }),
+);
+
+vi.mock('@cctv/contexts/ExperienceContext', () => ({
+  useExperience: () => useExperienceMock(),
+}));
+
+vi.mock('@cctv/hooks/useExperienceStart', () => ({
+  useExperienceStart: () => ({ startExperience, error: null }),
+}));
+
+vi.mock('@cctv/hooks/useExperiencePause', () => ({
+  useExperiencePause: () => ({ pauseExperience, error: null }),
+}));
+
+vi.mock('@cctv/hooks/useExperienceResume', () => ({
+  useExperienceResume: () => ({ resumeExperience, error: null }),
+}));
+
+function renderWithStatus(status: string | undefined) {
+  useExperienceMock.mockReturnValue({
+    experience: status ? { id: 'exp-1', status } : null,
+  });
+  return render(<ExperienceActionButton />);
+}
+
+describe('ExperienceActionButton', () => {
+  beforeEach(() => {
+    startExperience.mockReset();
+    pauseExperience.mockReset();
+    resumeExperience.mockReset();
+    useExperienceMock.mockReset();
+  });
+
+  it.each(['draft', 'lobby'])('starts the experience from %s', async (status) => {
+    const user = userEvent.setup();
+    renderWithStatus(status);
+
+    await user.click(screen.getByRole('button', { name: /start/i }));
+
+    expect(startExperience).toHaveBeenCalledTimes(1);
+  });
+
+  it('pauses a live experience', async () => {
+    const user = userEvent.setup();
+    renderWithStatus('live');
+
+    await user.click(screen.getByRole('button', { name: /pause/i }));
+
+    expect(pauseExperience).toHaveBeenCalledTimes(1);
+    expect(startExperience).not.toHaveBeenCalled();
+  });
+
+  it('resumes a paused experience', async () => {
+    const user = userEvent.setup();
+    renderWithStatus('paused');
+
+    await user.click(screen.getByRole('button', { name: /resume/i }));
+
+    expect(resumeExperience).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders nothing for a status with no action', () => {
+    const { container } = renderWithStatus('ended');
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing before the experience loads', () => {
+    const { container } = renderWithStatus(undefined);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/app/frontend/Pages/Manage/ExperienceActionButton.tsx
+++ b/app/frontend/Pages/Manage/ExperienceActionButton.tsx
@@ -1,0 +1,61 @@
+import { ReactNode, useMemo } from 'react';
+
+import { Pause, Play } from 'lucide-react';
+
+import { useExperience } from '@cctv/contexts/ExperienceContext';
+import { Button } from '@cctv/core';
+import { useExperiencePause } from '@cctv/hooks/useExperiencePause';
+import { useExperienceResume } from '@cctv/hooks/useExperienceResume';
+import { useExperienceStart } from '@cctv/hooks/useExperienceStart';
+
+interface ActionConfig {
+  onClick: () => void;
+  icon: ReactNode;
+  label: string;
+  variant?: 'primary' | 'secondary' | 'ghost';
+}
+
+export default function ExperienceActionButton() {
+  const { experience } = useExperience();
+  const { startExperience } = useExperienceStart();
+  const { pauseExperience } = useExperiencePause();
+  const { resumeExperience } = useExperienceResume();
+
+  const config = useMemo<ActionConfig | null>(() => {
+    switch (experience?.status) {
+      case 'draft':
+      case 'lobby':
+        return {
+          onClick: startExperience,
+          icon: <Play size={16} />,
+          label: 'Start',
+          variant: 'primary',
+        };
+      case 'live':
+        return {
+          onClick: pauseExperience,
+          icon: <Pause size={16} />,
+          label: 'Pause',
+          variant: 'secondary',
+        };
+      case 'paused':
+        return {
+          onClick: resumeExperience,
+          icon: <Play size={16} />,
+          label: 'Resume',
+          variant: 'primary',
+        };
+      default:
+        return null;
+    }
+  }, [startExperience, pauseExperience, resumeExperience, experience?.status]);
+
+  if (!config) return null;
+
+  return (
+    <Button title={config.label} variant={config.variant} onClick={config.onClick}>
+      {config.icon}
+      <span>{config.label}</span>
+    </Button>
+  );
+}

--- a/app/frontend/Pages/Manage/Focus/ActivityTile.module.scss
+++ b/app/frontend/Pages/Manage/Focus/ActivityTile.module.scss
@@ -1,0 +1,84 @@
+.root {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  padding: 0.75rem;
+  border-radius: var(--radius);
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--card));
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 120ms ease,
+    transform 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.root:hover {
+  border-color: var(--phosphor);
+  transform: translateY(-2px);
+  box-shadow: 0 0 0 1px var(--phosphor-glow-medium);
+}
+
+.root:focus-visible {
+  outline: 2px solid var(--phosphor);
+  outline-offset: 2px;
+}
+
+.draft {
+  border-color: var(--amber);
+}
+
+.draft:hover {
+  border-color: var(--amber);
+  box-shadow: 0 0 0 1px var(--amber-glow);
+}
+
+.label {
+  font-family: var(--font-ui);
+  font-size: 1.05rem;
+  line-height: 1.2;
+  letter-spacing: 0.02em;
+  color: var(--hot-white);
+}
+
+.summary {
+  font-size: 0.75rem;
+  line-height: 1.3;
+  color: hsl(var(--muted-foreground));
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.badge {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  font-family: var(--font-ui);
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: var(--amber);
+  color: var(--black);
+}
+
+.footer {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.kind {
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+  white-space: nowrap;
+}

--- a/app/frontend/Pages/Manage/Focus/ActivityTile.stories.tsx
+++ b/app/frontend/Pages/Manage/Focus/ActivityTile.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from '@storybook/test';
+
+import { BLOCK_KIND_LABELS, BlockKind } from '@cctv/types';
+
+import { ActivityTile } from './ActivityTile';
+
+const meta: Meta<typeof ActivityTile> = {
+  title: 'Manage/Focus/ActivityTile',
+  component: ActivityTile,
+  tags: ['autodocs'],
+  args: {
+    onClick: fn(),
+    kind: BlockKind.POLL,
+    label: 'Poll',
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ActivityTile>;
+
+export const Kind: Story = {};
+
+export const Draft: Story = {
+  args: {
+    isDraft: true,
+    label: 'Which sketch should close the show?',
+  },
+};
+
+export const DraftWithSummary: Story = {
+  args: {
+    isDraft: true,
+    kind: BlockKind.QUESTION,
+    label: 'Audience warm-up',
+    summary: 'What is the worst advice you have ever been given?',
+  },
+};
+
+export const EveryKind: Story = {
+  render: (args) => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(13rem, 1fr))',
+        gap: '0.875rem',
+      }}
+    >
+      {Object.values(BlockKind).map((kind) => (
+        <ActivityTile
+          key={kind}
+          kind={kind}
+          label={BLOCK_KIND_LABELS[kind]}
+          onClick={args.onClick}
+        />
+      ))}
+    </div>
+  ),
+};

--- a/app/frontend/Pages/Manage/Focus/ActivityTile.test.tsx
+++ b/app/frontend/Pages/Manage/Focus/ActivityTile.test.tsx
@@ -3,8 +3,16 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import { BlockKind } from '@cctv/types';
-import type { Block } from '@cctv/types';
 
+import {
+  announcementBlock,
+  blockOfKind,
+  buzzerBlock,
+  familyFeudBlock,
+  minigameArithmeticBlock,
+  pollBlock,
+  questionBlock,
+} from '../testFactories';
 import { ActivityTile, blockSummary } from './ActivityTile';
 
 describe('ActivityTile', () => {
@@ -48,44 +56,55 @@ describe('ActivityTile', () => {
 });
 
 describe('blockSummary', () => {
-  function withPayload(payload: Record<string, unknown>): Block {
-    return {
-      id: 'b1',
-      kind: BlockKind.POLL,
-      status: 'hidden',
-      position: 0,
-      payload,
-    } as unknown as Block;
-  }
-
-  it('prefers the question field', () => {
-    expect(blockSummary(withPayload({ question: 'Best opener?', title: 'Ignored' }))).toBe(
+  it('reads a poll question', () => {
+    expect(blockSummary(pollBlock({ payload: { question: 'Best opener?', options: [] } }))).toBe(
       'Best opener?',
     );
   });
 
-  it.each([
-    ['title', 'A Title'],
-    ['prompt', 'A Prompt'],
-    ['message', 'A Message'],
-    ['headline', 'A Headline'],
-  ])('falls back to %s', (key, value) => {
-    expect(blockSummary(withPayload({ [key]: value }))).toBe(value);
+  it('reads a question prompt', () => {
+    expect(
+      blockSummary(questionBlock({ payload: { question: 'Worst advice?', formKey: 'advice' } })),
+    ).toBe('Worst advice?');
   });
 
-  it('reads the first nested question when there is no top-level text', () => {
-    expect(blockSummary(withPayload({ questions: [{ prompt: 'Name something' }] }))).toBe(
-      'Name something',
+  it('falls back to a Family Feud title', () => {
+    expect(blockSummary(familyFeudBlock({ payload: { title: 'Green room things' } }))).toBe(
+      'Green room things',
     );
   });
 
-  it('trims whitespace and ignores blank values', () => {
-    expect(blockSummary(withPayload({ question: '   ', title: '  Real Title  ' }))).toBe(
-      'Real Title',
+  it('falls back to a buzzer prompt', () => {
+    expect(blockSummary(buzzerBlock({ payload: { prompt: 'Buzz to answer' } }))).toBe(
+      'Buzz to answer',
     );
   });
 
-  it('returns an empty string when nothing is usable', () => {
-    expect(blockSummary(withPayload({ duration_seconds: 30 }))).toBe('');
+  it('falls back to an announcement message', () => {
+    expect(blockSummary(announcementBlock({ payload: { message: 'Phones out.' } }))).toBe(
+      'Phones out.',
+    );
+  });
+
+  it('prefers a buzzer prompt over its label', () => {
+    expect(blockSummary(buzzerBlock({ payload: { label: 'Buzz', prompt: 'Name a city' } }))).toBe(
+      'Name a city',
+    );
+    expect(blockSummary(buzzerBlock({ payload: { label: 'Buzz' } }))).toBe('Buzz');
+  });
+
+  it('trims what it returns and treats blank text as absent', () => {
+    expect(
+      blockSummary(pollBlock({ payload: { question: '  Best opener?  ', options: [] } })),
+    ).toBe('Best opener?');
+    expect(blockSummary(familyFeudBlock({ payload: { title: '   ' } }))).toBe('');
+  });
+
+  it('returns an empty string for kinds with no natural title', () => {
+    expect(blockSummary(minigameArithmeticBlock())).toBe('');
+  });
+
+  it.each(Object.values(BlockKind))('returns a string for %s', (kind) => {
+    expect(typeof blockSummary(blockOfKind(kind))).toBe('string');
   });
 });

--- a/app/frontend/Pages/Manage/Focus/ActivityTile.test.tsx
+++ b/app/frontend/Pages/Manage/Focus/ActivityTile.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { BlockKind } from '@cctv/types';
+import type { Block } from '@cctv/types';
+
+import { ActivityTile, blockSummary } from './ActivityTile';
+
+describe('ActivityTile', () => {
+  it('fires onClick when chosen', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<ActivityTile kind={BlockKind.POLL} label="Poll" onClick={onClick} />);
+
+    await user.click(screen.getByRole('button', { name: /poll/i }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows no draft badge for a plain kind tile', () => {
+    render(<ActivityTile kind={BlockKind.POLL} label="Poll" onClick={vi.fn()} />);
+
+    expect(screen.queryByText('Draft')).not.toBeInTheDocument();
+  });
+
+  it('badges drafts and names their kind', () => {
+    render(
+      <ActivityTile kind={BlockKind.QUESTION} label="Closing sketch?" isDraft onClick={vi.fn()} />,
+    );
+
+    expect(screen.getByText('Draft')).toBeInTheDocument();
+    expect(screen.getByText('Question')).toBeInTheDocument();
+  });
+
+  it('renders a summary when given one', () => {
+    render(
+      <ActivityTile
+        kind={BlockKind.POLL}
+        label="Warm-up"
+        summary="Which sketch should close?"
+        onClick={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Which sketch should close?')).toBeInTheDocument();
+  });
+});
+
+describe('blockSummary', () => {
+  function withPayload(payload: Record<string, unknown>): Block {
+    return {
+      id: 'b1',
+      kind: BlockKind.POLL,
+      status: 'hidden',
+      position: 0,
+      payload,
+    } as unknown as Block;
+  }
+
+  it('prefers the question field', () => {
+    expect(blockSummary(withPayload({ question: 'Best opener?', title: 'Ignored' }))).toBe(
+      'Best opener?',
+    );
+  });
+
+  it.each([
+    ['title', 'A Title'],
+    ['prompt', 'A Prompt'],
+    ['message', 'A Message'],
+    ['headline', 'A Headline'],
+  ])('falls back to %s', (key, value) => {
+    expect(blockSummary(withPayload({ [key]: value }))).toBe(value);
+  });
+
+  it('reads the first nested question when there is no top-level text', () => {
+    expect(blockSummary(withPayload({ questions: [{ prompt: 'Name something' }] }))).toBe(
+      'Name something',
+    );
+  });
+
+  it('trims whitespace and ignores blank values', () => {
+    expect(blockSummary(withPayload({ question: '   ', title: '  Real Title  ' }))).toBe(
+      'Real Title',
+    );
+  });
+
+  it('returns an empty string when nothing is usable', () => {
+    expect(blockSummary(withPayload({ duration_seconds: 30 }))).toBe('');
+  });
+});

--- a/app/frontend/Pages/Manage/Focus/ActivityTile.tsx
+++ b/app/frontend/Pages/Manage/Focus/ActivityTile.tsx
@@ -1,0 +1,52 @@
+import classNames from 'classnames';
+
+import { BLOCK_KIND_LABELS, Block, BlockKind } from '@cctv/types';
+
+import KindPreview from './KindPreview';
+
+import styles from './ActivityTile.module.scss';
+
+interface ActivityTileProps {
+  kind: BlockKind;
+  label: string;
+  summary?: string;
+  isDraft?: boolean;
+  onClick: () => void;
+}
+
+export function ActivityTile({ kind, label, summary, isDraft, onClick }: ActivityTileProps) {
+  return (
+    <button
+      type="button"
+      className={classNames(styles.root, isDraft && styles.draft)}
+      onClick={onClick}
+    >
+      {isDraft && <span className={styles.badge}>Draft</span>}
+      <KindPreview kind={kind} />
+      <div className={styles.footer}>
+        <span className={styles.label}>{label}</span>
+        {isDraft && <span className={styles.kind}>{BLOCK_KIND_LABELS[kind]}</span>}
+      </div>
+      {summary && <span className={styles.summary}>{summary}</span>}
+    </button>
+  );
+}
+
+export function blockSummary(block: Block): string {
+  const payload = block.payload as Record<string, unknown>;
+  const candidates = ['question', 'title', 'prompt', 'message', 'headline'];
+
+  for (const key of candidates) {
+    const value = payload[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+
+  const questions = payload.questions;
+  if (Array.isArray(questions) && questions.length > 0) {
+    const first = questions[0] as Record<string, unknown>;
+    if (typeof first?.prompt === 'string') return first.prompt;
+    if (typeof first?.question === 'string') return first.question;
+  }
+
+  return '';
+}

--- a/app/frontend/Pages/Manage/Focus/ActivityTile.tsx
+++ b/app/frontend/Pages/Manage/Focus/ActivityTile.tsx
@@ -33,20 +33,26 @@ export function ActivityTile({ kind, label, summary, isDraft, onClick }: Activit
 }
 
 export function blockSummary(block: Block): string {
-  const payload = block.payload as Record<string, unknown>;
-  const candidates = ['question', 'title', 'prompt', 'message', 'headline'];
-
-  for (const key of candidates) {
-    const value = payload[key];
-    if (typeof value === 'string' && value.trim()) return value.trim();
+  switch (block.kind) {
+    case BlockKind.POLL:
+    case BlockKind.QUESTION:
+      return block.payload.question.trim();
+    case BlockKind.ANNOUNCEMENT:
+      return block.payload.message.trim();
+    case BlockKind.FAMILY_FEUD:
+      return block.payload.title.trim();
+    case BlockKind.PHOTO_UPLOAD:
+      return block.payload.prompt.trim();
+    case BlockKind.BUZZER:
+      return (block.payload.prompt ?? block.payload.label ?? '').trim();
+    case BlockKind.GUESS_WHO:
+    case BlockKind.MINIGAME_ARITHMETIC:
+    case BlockKind.MINIGAME_BALLOON_PUMP:
+    case BlockKind.THE_SCENE:
+      return '';
+    default: {
+      const exhaustiveCheck: never = block;
+      return exhaustiveCheck;
+    }
   }
-
-  const questions = payload.questions;
-  if (Array.isArray(questions) && questions.length > 0) {
-    const first = questions[0] as Record<string, unknown>;
-    if (typeof first?.prompt === 'string') return first.prompt;
-    if (typeof first?.question === 'string') return first.question;
-  }
-
-  return '';
 }

--- a/app/frontend/Pages/Manage/Focus/FocusEditor.module.scss
+++ b/app/frontend/Pages/Manage/Focus/FocusEditor.module.scss
@@ -1,0 +1,56 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  width: 100%;
+  max-width: 46rem;
+  margin: 0 auto;
+  padding-bottom: var(--space-md);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  line-height: 1;
+  letter-spacing: 0.04em;
+  color: var(--hot-white);
+}
+
+.fields {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  align-items: center;
+  width: 100%;
+  padding: var(--space-sm);
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  background: hsl(var(--card));
+}
+
+.actions {
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 0.75rem 0;
+  background: linear-gradient(to top, hsl(var(--background)) 70%, transparent);
+}
+
+.spacer {
+  flex: 1;
+}
+
+.error {
+  color: hsl(var(--destructive));
+  font-size: 0.95rem;
+  text-shadow: none;
+}

--- a/app/frontend/Pages/Manage/Focus/FocusEditor.test.tsx
+++ b/app/frontend/Pages/Manage/Focus/FocusEditor.test.tsx
@@ -3,8 +3,9 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { BlockKind } from '@cctv/types';
-import type { Block, ParticipantSummary } from '@cctv/types';
+import type { Block, ParticipantSummary, PollBlock } from '@cctv/types';
 
+import { pollBlock } from '../testFactories';
 import FocusEditor from './FocusEditor';
 
 const { createExperienceBlock, updateExperienceBlock } = vi.hoisted(() => ({
@@ -72,15 +73,12 @@ async function fillPoll(user: ReturnType<typeof userEvent.setup>) {
   await user.type(screen.getByLabelText('Option 2'), 'Stand-up');
 }
 
-function draftPoll(): Block {
-  return {
+function draftPoll(): PollBlock {
+  return pollBlock({
     id: 'draft-1',
-    kind: BlockKind.POLL,
-    status: 'hidden',
-    position: 0,
     payload: { question: 'Closing sketch?', options: ['The Bit', 'Cold Open'] },
     responses: { total: 0 },
-  } as Block;
+  });
 }
 
 describe('FocusEditor — creating', () => {

--- a/app/frontend/Pages/Manage/Focus/FocusEditor.test.tsx
+++ b/app/frontend/Pages/Manage/Focus/FocusEditor.test.tsx
@@ -1,0 +1,215 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { BlockKind } from '@cctv/types';
+import type { Block, ParticipantSummary } from '@cctv/types';
+
+import FocusEditor from './FocusEditor';
+
+const { createExperienceBlock, updateExperienceBlock } = vi.hoisted(() => ({
+  createExperienceBlock: vi.fn(),
+  updateExperienceBlock: vi.fn(),
+}));
+
+vi.mock('@cctv/contexts/ExperienceContext', () => ({
+  useExperience: () => ({
+    experience: { id: 'exp-1', code: 'FOCUSTEST', segments: [], blocks: [] },
+    code: 'FOCUSTEST',
+    isLoading: false,
+    wsReady: true,
+  }),
+}));
+
+vi.mock('@cctv/contexts/AdminAuthContext', () => ({
+  useAdminAuth: () => ({ adminJWT: 'jwt', adminFetch: vi.fn(), isAdminLoading: false }),
+}));
+
+vi.mock('@cctv/hooks/useCreateExperienceBlock', async () => {
+  const { useState } = await import('react');
+  return {
+    useCreateExperienceBlock: () => {
+      const [error, setError] = useState<string | null>(null);
+      return { createExperienceBlock, isLoading: false, error, setError };
+    },
+  };
+});
+
+vi.mock('@cctv/hooks/useUpdateExperienceBlock', async () => {
+  const { useState } = await import('react');
+  return {
+    useUpdateExperienceBlock: () => {
+      const [error, setError] = useState<string | null>(null);
+      return { updateExperienceBlock, isLoading: false, error, setError };
+    },
+  };
+});
+
+const participants: ParticipantSummary[] = [];
+
+function renderEditor(block?: Block) {
+  const onBack = vi.fn();
+  const onDone = vi.fn();
+  const onEndCurrentBlock = vi.fn().mockResolvedValue(undefined);
+
+  render(
+    <FocusEditor
+      kind={block?.kind ?? BlockKind.POLL}
+      block={block}
+      participants={participants}
+      onBack={onBack}
+      onDone={onDone}
+      onEndCurrentBlock={onEndCurrentBlock}
+    />,
+  );
+
+  return { onBack, onDone, onEndCurrentBlock };
+}
+
+async function fillPoll(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText('Poll Question'), 'Best opener?');
+  await user.type(screen.getByLabelText('Option 1'), 'Improv set');
+  await user.type(screen.getByLabelText('Option 2'), 'Stand-up');
+}
+
+function draftPoll(): Block {
+  return {
+    id: 'draft-1',
+    kind: BlockKind.POLL,
+    status: 'hidden',
+    position: 0,
+    payload: { question: 'Closing sketch?', options: ['The Bit', 'Cold Open'] },
+    responses: { total: 0 },
+  } as Block;
+}
+
+describe('FocusEditor — creating', () => {
+  beforeEach(() => {
+    createExperienceBlock.mockReset().mockResolvedValue({ success: true });
+    updateExperienceBlock.mockReset().mockResolvedValue({ success: true });
+  });
+
+  it('opens on the chosen kind', () => {
+    renderEditor();
+
+    expect(screen.getByRole('heading', { name: 'New Poll' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Poll Question')).toBeInTheDocument();
+  });
+
+  it('creates an open block when Play is pressed', async () => {
+    const user = userEvent.setup();
+    const { onDone } = renderEditor();
+
+    await fillPoll(user);
+    await user.click(screen.getByRole('button', { name: /play/i }));
+
+    expect(createExperienceBlock).toHaveBeenCalledTimes(1);
+    expect(createExperienceBlock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: BlockKind.POLL,
+        status: 'open',
+        open_immediately: true,
+        payload: expect.objectContaining({
+          question: 'Best opener?',
+          options: ['Improv set', 'Stand-up'],
+        }),
+      }),
+    );
+    expect(onDone).toHaveBeenCalledWith('play');
+  });
+
+  it('closes whatever was already playing after starting a new one', async () => {
+    const user = userEvent.setup();
+    const { onEndCurrentBlock } = renderEditor();
+
+    await fillPoll(user);
+    await user.click(screen.getByRole('button', { name: /play/i }));
+
+    expect(onEndCurrentBlock).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates a hidden block when Save as draft is pressed', async () => {
+    const user = userEvent.setup();
+    const { onDone, onEndCurrentBlock } = renderEditor();
+
+    await fillPoll(user);
+    await user.click(screen.getByRole('button', { name: /save as draft/i }));
+
+    expect(createExperienceBlock).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'hidden', open_immediately: false }),
+    );
+    expect(onDone).toHaveBeenCalledWith('draft');
+    expect(onEndCurrentBlock).not.toHaveBeenCalled();
+  });
+
+  it('does not fire a call when the form is invalid', async () => {
+    const user = userEvent.setup();
+    const { onDone } = renderEditor();
+
+    await user.click(screen.getByRole('button', { name: /play/i }));
+
+    expect(createExperienceBlock).not.toHaveBeenCalled();
+    expect(onDone).not.toHaveBeenCalled();
+    expect(screen.getByText('Poll question is required')).toBeInTheDocument();
+  });
+
+  it('leaves without creating anything when Back is pressed', async () => {
+    const user = userEvent.setup();
+    const { onBack, onDone } = renderEditor();
+
+    await user.click(screen.getByRole('button', { name: /back/i }));
+
+    expect(onBack).toHaveBeenCalledTimes(1);
+    expect(createExperienceBlock).not.toHaveBeenCalled();
+    expect(onDone).not.toHaveBeenCalled();
+  });
+});
+
+describe('FocusEditor — editing a draft', () => {
+  beforeEach(() => {
+    createExperienceBlock.mockReset().mockResolvedValue({ success: true });
+    updateExperienceBlock.mockReset().mockResolvedValue({ success: true });
+  });
+
+  it('loads the draft into the form', () => {
+    renderEditor(draftPoll());
+
+    expect(screen.getByRole('heading', { name: 'Poll' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Poll Question')).toHaveValue('Closing sketch?');
+    expect(screen.getByLabelText('Option 1')).toHaveValue('The Bit');
+  });
+
+  it('saves edits and reports the play intent', async () => {
+    const user = userEvent.setup();
+    const { onDone } = renderEditor(draftPoll());
+
+    await user.click(screen.getByRole('button', { name: /play/i }));
+
+    expect(updateExperienceBlock).toHaveBeenCalledTimes(1);
+    expect(updateExperienceBlock.mock.calls[0][0]).toBe('draft-1');
+    expect(createExperienceBlock).not.toHaveBeenCalled();
+    expect(onDone).toHaveBeenCalledWith('play');
+  });
+
+  it('saves edits and stays a draft when Save as draft is pressed', async () => {
+    const user = userEvent.setup();
+    const { onDone } = renderEditor(draftPoll());
+
+    await user.type(screen.getByLabelText('Poll Question'), ' Updated');
+    await user.click(screen.getByRole('button', { name: /save as draft/i }));
+
+    expect(updateExperienceBlock).toHaveBeenCalledTimes(1);
+    expect(onDone).toHaveBeenCalledWith('draft');
+  });
+
+  it('does not save an invalid edit', async () => {
+    const user = userEvent.setup();
+    const { onDone } = renderEditor(draftPoll());
+
+    await user.clear(screen.getByLabelText('Poll Question'));
+    await user.click(screen.getByRole('button', { name: /play/i }));
+
+    expect(updateExperienceBlock).not.toHaveBeenCalled();
+    expect(onDone).not.toHaveBeenCalled();
+  });
+});

--- a/app/frontend/Pages/Manage/Focus/FocusEditor.tsx
+++ b/app/frontend/Pages/Manage/Focus/FocusEditor.tsx
@@ -1,0 +1,148 @@
+import { useRef } from 'react';
+
+import { ArrowLeft, Play, Save } from 'lucide-react';
+
+import { Button } from '@cctv/core';
+import { BLOCK_KIND_LABELS, Block, BlockKind, ParticipantSummary } from '@cctv/types';
+
+import { CreateBlockFields } from '../CreateBlock/CreateBlock';
+import { CreateBlockProvider, useCreateBlockContext } from '../CreateBlock/CreateBlockContext';
+import { EditBlockFields } from '../EditBlock/EditBlock';
+import { EditBlockProvider, useEditBlockContext } from '../EditBlock/EditBlockContext';
+
+import styles from './FocusEditor.module.scss';
+
+export type EditorIntent = 'draft' | 'play';
+
+interface FocusEditorProps {
+  kind: BlockKind;
+  block?: Block;
+  participants: ParticipantSummary[];
+  onBack: () => void;
+  onDone: (intent: EditorIntent) => void;
+  onEndCurrentBlock: () => Promise<void>;
+}
+
+export default function FocusEditor({
+  kind,
+  block,
+  participants,
+  onBack,
+  onDone,
+  onEndCurrentBlock,
+}: FocusEditorProps) {
+  const intent = useRef<EditorIntent>('draft');
+
+  if (block) {
+    return (
+      <EditBlockProvider
+        block={block}
+        participants={participants}
+        onClose={() => onDone(intent.current)}
+      >
+        <EditDraftForm kind={kind} intent={intent} onBack={onBack} />
+      </EditBlockProvider>
+    );
+  }
+
+  return (
+    <CreateBlockProvider
+      participants={participants}
+      initialKind={kind}
+      onClose={() => onDone(intent.current)}
+      onEndCurrentBlock={onEndCurrentBlock}
+    >
+      <CreateForm kind={kind} intent={intent} onBack={onBack} />
+    </CreateBlockProvider>
+  );
+}
+
+interface FormProps {
+  kind: BlockKind;
+  intent: React.MutableRefObject<EditorIntent>;
+  onBack: () => void;
+}
+
+function CreateForm({ kind, intent, onBack }: FormProps) {
+  const { submit, isSubmitting, error } = useCreateBlockContext();
+
+  const run = (next: EditorIntent) => {
+    intent.current = next;
+    submit(next === 'play' ? 'open' : 'hidden');
+  };
+
+  return (
+    <Shell
+      title={`New ${BLOCK_KIND_LABELS[kind]}`}
+      error={error}
+      isSubmitting={isSubmitting}
+      onBack={onBack}
+      onDraft={() => run('draft')}
+      onPlay={() => run('play')}
+    >
+      <CreateBlockFields />
+    </Shell>
+  );
+}
+
+function EditDraftForm({ kind, intent, onBack }: FormProps) {
+  const { submit, isSubmitting, error } = useEditBlockContext();
+
+  const run = (next: EditorIntent) => {
+    intent.current = next;
+    submit();
+  };
+
+  return (
+    <Shell
+      title={BLOCK_KIND_LABELS[kind]}
+      error={error}
+      isSubmitting={isSubmitting}
+      onBack={onBack}
+      onDraft={() => run('draft')}
+      onPlay={() => run('play')}
+    >
+      <EditBlockFields />
+    </Shell>
+  );
+}
+
+interface ShellProps {
+  title: string;
+  error: string | null;
+  isSubmitting: boolean;
+  children: React.ReactNode;
+  onBack: () => void;
+  onDraft: () => void;
+  onPlay: () => void;
+}
+
+function Shell({ title, error, isSubmitting, children, onBack, onDraft, onPlay }: ShellProps) {
+  return (
+    <div className={styles.root}>
+      <div className={styles.header}>
+        <Button variant="ghost" onClick={onBack} title="Back to activities">
+          <ArrowLeft size={18} />
+          <span>Back</span>
+        </Button>
+        <h1 className={styles.title}>{title}</h1>
+      </div>
+
+      {error && <div className={styles.error}>{error}</div>}
+
+      <div className={styles.fields}>{children}</div>
+
+      <div className={styles.actions}>
+        <div className={styles.spacer} />
+        <Button variant="secondary" onClick={onDraft} disabled={isSubmitting}>
+          <Save size={16} />
+          <span>Save as draft</span>
+        </Button>
+        <Button onClick={onPlay} loading={isSubmitting} loadingText="Starting...">
+          <Play size={16} />
+          <span>Play</span>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/Pages/Manage/Focus/FocusHistory.module.scss
+++ b/app/frontend/Pages/Manage/Focus/FocusHistory.module.scss
@@ -1,0 +1,80 @@
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  width: 100%;
+  padding: 0.75rem 0.875rem;
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  background: hsl(var(--card));
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease;
+}
+
+.row:hover {
+  border-color: var(--phosphor);
+  background: var(--phosphor-glow-faint);
+}
+
+.row:focus-visible {
+  outline: 2px solid var(--phosphor);
+  outline-offset: 2px;
+}
+
+.thumb {
+  width: 5.5rem;
+  flex-shrink: 0;
+}
+
+.text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.summary {
+  font-family: var(--font-ui);
+  font-size: 1.05rem;
+  line-height: 1.25;
+  color: var(--hot-white);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kind {
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+}
+
+.count {
+  flex-shrink: 0;
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  color: var(--phosphor);
+  white-space: nowrap;
+}
+
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: var(--space-lg) var(--space-sm);
+  color: hsl(var(--muted-foreground));
+  text-align: center;
+}

--- a/app/frontend/Pages/Manage/Focus/FocusHistory.stories.tsx
+++ b/app/frontend/Pages/Manage/Focus/FocusHistory.stories.tsx
@@ -1,20 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { fn } from '@storybook/test';
 
-import { Block, BlockKind } from '@cctv/types';
-
+import { buzzerBlock, familyFeudBlock, pollBlock, questionBlock } from '../testFactories';
 import FocusHistory from './FocusHistory';
-
-function past(id: string, kind: BlockKind, question: string, total: number): Block {
-  return {
-    id,
-    kind,
-    status: 'closed',
-    position: 0,
-    payload: { question },
-    responses: { total },
-  } as Block;
-}
 
 const meta: Meta<typeof FocusHistory> = {
   title: 'Manage/Focus/FocusHistory',
@@ -23,9 +11,24 @@ const meta: Meta<typeof FocusHistory> = {
   args: {
     onSelect: fn(),
     blocks: [
-      past('b3', BlockKind.FAMILY_FEUD, 'Name something you find in a green room', 41),
-      past('b2', BlockKind.POLL, 'Which sketch should close the show?', 24),
-      past('b1', BlockKind.QUESTION, 'What is the worst advice you have been given?', 8),
+      familyFeudBlock({
+        id: 'b3',
+        status: 'closed',
+        payload: { title: 'Name something you find in a green room' },
+        responses: { total: 41 },
+      }),
+      pollBlock({
+        id: 'b2',
+        status: 'closed',
+        payload: { question: 'Which sketch should close the show?', options: [] },
+        responses: { total: 24 },
+      }),
+      questionBlock({
+        id: 'b1',
+        status: 'closed',
+        payload: { question: 'What is the worst advice you have been given?', formKey: 'advice' },
+        responses: { total: 8 },
+      }),
     ],
   },
 };
@@ -37,7 +40,14 @@ export const WithPastActivities: Story = {};
 
 export const SingleResponse: Story = {
   args: {
-    blocks: [past('b1', BlockKind.BUZZER, 'First to buzz wins', 1)],
+    blocks: [
+      buzzerBlock({
+        id: 'b1',
+        status: 'closed',
+        payload: { prompt: 'First to buzz wins' },
+        responses: { total: 1 },
+      }),
+    ],
   },
 };
 

--- a/app/frontend/Pages/Manage/Focus/FocusHistory.stories.tsx
+++ b/app/frontend/Pages/Manage/Focus/FocusHistory.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from '@storybook/test';
+
+import { Block, BlockKind } from '@cctv/types';
+
+import FocusHistory from './FocusHistory';
+
+function past(id: string, kind: BlockKind, question: string, total: number): Block {
+  return {
+    id,
+    kind,
+    status: 'closed',
+    position: 0,
+    payload: { question },
+    responses: { total },
+  } as Block;
+}
+
+const meta: Meta<typeof FocusHistory> = {
+  title: 'Manage/Focus/FocusHistory',
+  component: FocusHistory,
+  tags: ['autodocs'],
+  args: {
+    onSelect: fn(),
+    blocks: [
+      past('b3', BlockKind.FAMILY_FEUD, 'Name something you find in a green room', 41),
+      past('b2', BlockKind.POLL, 'Which sketch should close the show?', 24),
+      past('b1', BlockKind.QUESTION, 'What is the worst advice you have been given?', 8),
+    ],
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof FocusHistory>;
+
+export const WithPastActivities: Story = {};
+
+export const SingleResponse: Story = {
+  args: {
+    blocks: [past('b1', BlockKind.BUZZER, 'First to buzz wins', 1)],
+  },
+};
+
+export const Empty: Story = {
+  args: { blocks: [] },
+};

--- a/app/frontend/Pages/Manage/Focus/FocusHistory.test.tsx
+++ b/app/frontend/Pages/Manage/Focus/FocusHistory.test.tsx
@@ -2,20 +2,18 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
-import { BlockKind } from '@cctv/types';
 import type { Block } from '@cctv/types';
 
+import { buzzerBlock, pollBlock, questionBlock } from '../testFactories';
 import FocusHistory from './FocusHistory';
 
-function past(id: string, kind: BlockKind, question: string, total: number): Block {
-  return {
+function pastPoll(id: string, question: string, total: number): Block {
+  return pollBlock({
     id,
-    kind,
     status: 'closed',
-    position: 0,
-    payload: { question },
+    payload: { question, options: [] },
     responses: { total },
-  } as Block;
+  });
 }
 
 describe('FocusHistory', () => {
@@ -23,8 +21,12 @@ describe('FocusHistory', () => {
     render(
       <FocusHistory
         blocks={[
-          past('b1', BlockKind.POLL, 'Best opener?', 4),
-          past('b2', BlockKind.QUESTION, 'Worst advice?', 0),
+          pastPoll('b1', 'Best opener?', 4),
+          questionBlock({
+            id: 'b2',
+            status: 'closed',
+            payload: { question: 'Worst advice?', formKey: 'advice' },
+          }),
         ]}
         onSelect={vi.fn()}
       />,
@@ -38,11 +40,7 @@ describe('FocusHistory', () => {
   it('pluralises the response count', () => {
     render(
       <FocusHistory
-        blocks={[
-          past('b1', BlockKind.POLL, 'Many', 4),
-          past('b2', BlockKind.POLL, 'One', 1),
-          past('b3', BlockKind.POLL, 'None', 0),
-        ]}
+        blocks={[pastPoll('b1', 'Many', 4), pastPoll('b2', 'One', 1), pastPoll('b3', 'None', 0)]}
         onSelect={vi.fn()}
       />,
     );
@@ -53,14 +51,7 @@ describe('FocusHistory', () => {
   });
 
   it('falls back to the kind label when a block has no text', () => {
-    const block = {
-      id: 'b1',
-      kind: BlockKind.BUZZER,
-      status: 'closed',
-      position: 0,
-      payload: {},
-      responses: { total: 0 },
-    } as Block;
+    const block = buzzerBlock({ status: 'closed', payload: {}, responses: { total: 0 } });
 
     render(<FocusHistory blocks={[block]} onSelect={vi.fn()} />);
 
@@ -70,7 +61,7 @@ describe('FocusHistory', () => {
   it('passes the chosen block to onSelect', async () => {
     const user = userEvent.setup();
     const onSelect = vi.fn();
-    const block = past('b1', BlockKind.POLL, 'Best opener?', 4);
+    const block = pastPoll('b1', 'Best opener?', 4);
 
     render(<FocusHistory blocks={[block]} onSelect={onSelect} />);
     await user.click(screen.getByText('Best opener?'));

--- a/app/frontend/Pages/Manage/Focus/FocusHistory.test.tsx
+++ b/app/frontend/Pages/Manage/Focus/FocusHistory.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { BlockKind } from '@cctv/types';
+import type { Block } from '@cctv/types';
+
+import FocusHistory from './FocusHistory';
+
+function past(id: string, kind: BlockKind, question: string, total: number): Block {
+  return {
+    id,
+    kind,
+    status: 'closed',
+    position: 0,
+    payload: { question },
+    responses: { total },
+  } as Block;
+}
+
+describe('FocusHistory', () => {
+  it('renders one row per finished activity', () => {
+    render(
+      <FocusHistory
+        blocks={[
+          past('b1', BlockKind.POLL, 'Best opener?', 4),
+          past('b2', BlockKind.QUESTION, 'Worst advice?', 0),
+        ]}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByRole('button')).toHaveLength(2);
+    expect(screen.getByText('Best opener?')).toBeInTheDocument();
+    expect(screen.getByText('Worst advice?')).toBeInTheDocument();
+  });
+
+  it('pluralises the response count', () => {
+    render(
+      <FocusHistory
+        blocks={[
+          past('b1', BlockKind.POLL, 'Many', 4),
+          past('b2', BlockKind.POLL, 'One', 1),
+          past('b3', BlockKind.POLL, 'None', 0),
+        ]}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('4 responses')).toBeInTheDocument();
+    expect(screen.getByText('1 response')).toBeInTheDocument();
+    expect(screen.getByText('0 responses')).toBeInTheDocument();
+  });
+
+  it('falls back to the kind label when a block has no text', () => {
+    const block = {
+      id: 'b1',
+      kind: BlockKind.BUZZER,
+      status: 'closed',
+      position: 0,
+      payload: {},
+      responses: { total: 0 },
+    } as Block;
+
+    render(<FocusHistory blocks={[block]} onSelect={vi.fn()} />);
+
+    expect(screen.getAllByText('Buzzer').length).toBeGreaterThan(0);
+  });
+
+  it('passes the chosen block to onSelect', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const block = past('b1', BlockKind.POLL, 'Best opener?', 4);
+
+    render(<FocusHistory blocks={[block]} onSelect={onSelect} />);
+    await user.click(screen.getByText('Best opener?'));
+
+    expect(onSelect).toHaveBeenCalledWith(block);
+  });
+
+  it('shows an empty state with nothing to list', () => {
+    render(<FocusHistory blocks={[]} onSelect={vi.fn()} />);
+
+    expect(screen.getByText('Nothing has run yet.')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/app/frontend/Pages/Manage/Focus/FocusHistory.tsx
+++ b/app/frontend/Pages/Manage/Focus/FocusHistory.tsx
@@ -1,0 +1,49 @@
+import { BLOCK_KIND_LABELS, Block } from '@cctv/types';
+
+import { blockSummary } from './ActivityTile';
+import KindPreview from './KindPreview';
+
+import styles from './FocusHistory.module.scss';
+
+interface FocusHistoryProps {
+  blocks: Block[];
+  onSelect: (block: Block) => void;
+}
+
+export default function FocusHistory({ blocks, onSelect }: FocusHistoryProps) {
+  if (blocks.length === 0) {
+    return (
+      <div className={styles.empty}>
+        <p>Nothing has run yet.</p>
+        <p>Activities show up here once you finish them.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.list}>
+      {blocks.map((block) => {
+        const count = block.responses?.total ?? 0;
+        return (
+          <button
+            key={block.id}
+            type="button"
+            className={styles.row}
+            onClick={() => onSelect(block)}
+          >
+            <KindPreview kind={block.kind} className={styles.thumb} />
+            <span className={styles.text}>
+              <span className={styles.summary}>
+                {blockSummary(block) || BLOCK_KIND_LABELS[block.kind]}
+              </span>
+              <span className={styles.kind}>{BLOCK_KIND_LABELS[block.kind]}</span>
+            </span>
+            <span className={styles.count}>
+              {count} {count === 1 ? 'response' : 'responses'}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/frontend/Pages/Manage/Focus/FocusMode.module.scss
+++ b/app/frontend/Pages/Manage/Focus/FocusMode.module.scss
@@ -1,0 +1,136 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-height: calc(100dvh - var(--nav-h));
+  background: hsl(var(--background));
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding: 0.75rem var(--space-sm);
+  border-bottom: 1px solid hsl(var(--border));
+}
+
+.name {
+  font-family: var(--font-ui);
+  font-size: 1.15rem;
+  letter-spacing: 0.03em;
+  color: var(--hot-white);
+}
+
+.spacer {
+  flex: 1;
+}
+
+.body {
+  flex: 1;
+  padding: var(--space-sm);
+}
+
+.select {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  width: 100%;
+  max-width: 76rem;
+  margin: 0 auto;
+}
+
+.tabs {
+  display: flex;
+  gap: 0.25rem;
+  border-bottom: 1px solid hsl(var(--border));
+}
+
+.tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.875rem;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+  font-family: var(--font-ui);
+  font-size: 1rem;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition:
+    color 120ms ease,
+    border-color 120ms ease;
+}
+
+.tab:hover {
+  color: var(--hot-white);
+}
+
+.tab:focus-visible {
+  outline: 2px solid var(--phosphor);
+  outline-offset: -2px;
+}
+
+.tabActive {
+  color: var(--phosphor);
+  border-bottom-color: var(--phosphor);
+  text-shadow: var(--tv-glow);
+}
+
+.tabCount {
+  padding: 0.05rem 0.4rem;
+  border-radius: 999px;
+  background: hsl(var(--secondary));
+  color: hsl(var(--secondary-foreground));
+  font-family: var(--font-body);
+  font-size: 0.72rem;
+  text-shadow: none;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.sectionTitle {
+  font-family: var(--font-display);
+  font-size: 1.6rem;
+  line-height: 1;
+  letter-spacing: 0.06em;
+  color: var(--hot-white);
+}
+
+.sectionHint {
+  font-size: 0.85rem;
+  color: hsl(var(--muted-foreground));
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(13rem, 1fr));
+  gap: 0.875rem;
+}
+
+.placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: var(--space-lg) var(--space-sm);
+  color: hsl(var(--muted-foreground));
+}
+
+.error {
+  margin: 0 auto var(--space-sm);
+  max-width: 76rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid hsl(var(--destructive));
+  border-radius: var(--radius);
+  background: hsl(var(--destructive) / 0.1);
+  color: hsl(var(--destructive));
+  text-shadow: none;
+}

--- a/app/frontend/Pages/Manage/Focus/FocusMode.test.tsx
+++ b/app/frontend/Pages/Manage/Focus/FocusMode.test.tsx
@@ -6,8 +6,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ExperienceStateProvider } from '@cctv/contexts/ExperienceStateContext';
 import { BlockKind } from '@cctv/types';
-import type { Block, Experience } from '@cctv/types';
+import type { Block } from '@cctv/types';
 
+import { announcementBlock, experience, pollBlock, questionBlock } from '../testFactories';
 import FocusMode from './FocusMode';
 
 const { useExperienceMock, handlePresent, handleStopPresenting, closeBlock, navigate } = vi.hoisted(
@@ -60,26 +61,9 @@ vi.mock('@cctv/hooks/useBlockPresentation', () => ({
   }),
 }));
 
-function block(id: string, kind: BlockKind, status: Block['status'], payload = {}): Block {
-  return { id, kind, status, position: 0, payload } as Block;
-}
-
-function experienceWith(blocks: Block[]): Experience {
-  return {
-    id: 'exp-1',
-    name: 'Focus Mode Test',
-    code: 'FOCUSTEST',
-    status: 'lobby',
-    blocks,
-    hosts: [],
-    participants: [],
-    segments: [],
-  } as unknown as Experience;
-}
-
 function setExperience(blocks: Block[]) {
   useExperienceMock.mockReturnValue({
-    experience: experienceWith(blocks),
+    experience: experience({ blocks }),
     code: 'FOCUSTEST',
     isLoading: false,
     wsReady: true,
@@ -119,8 +103,8 @@ describe('FocusMode', () => {
 
   it('lists hidden blocks as drafts and excludes child blocks', () => {
     setExperience([
-      block('draft-1', BlockKind.POLL, 'hidden', { question: 'Closing sketch?' }),
-      { ...block('child-1', BlockKind.QUESTION, 'hidden'), parent_block_id: 'draft-1' } as Block,
+      pollBlock({ id: 'draft-1', payload: { question: 'Closing sketch?', options: [] } }),
+      questionBlock({ id: 'child-1', parent_block_id: 'draft-1' }),
     ]);
     renderFocusMode();
 
@@ -158,14 +142,20 @@ describe('FocusMode', () => {
   it('lists finished activities under History, newest first', async () => {
     const user = userEvent.setup();
     setExperience([
-      { ...block('past-1', BlockKind.POLL, 'closed', { question: 'First bit' }), position: 0 },
-      { ...block('past-2', BlockKind.QUESTION, 'closed', { question: 'Second bit' }), position: 1 },
-      { ...block('draft-1', BlockKind.BUZZER, 'hidden', { question: 'Draft bit' }), position: 2 },
-      {
-        ...block('child-1', BlockKind.QUESTION, 'closed'),
-        parent_block_id: 'past-1',
-        position: 3,
-      } as Block,
+      pollBlock({
+        id: 'past-1',
+        status: 'closed',
+        position: 0,
+        payload: { question: 'First bit', options: [] },
+      }),
+      questionBlock({
+        id: 'past-2',
+        status: 'closed',
+        position: 1,
+        payload: { question: 'Second bit', formKey: 'second' },
+      }),
+      announcementBlock({ id: 'draft-1', position: 2, payload: { message: 'Draft bit' } }),
+      questionBlock({ id: 'child-1', status: 'closed', position: 3, parent_block_id: 'past-1' }),
     ]);
     renderFocusMode();
 
@@ -179,7 +169,7 @@ describe('FocusMode', () => {
 
   it('shows an empty state when nothing has run', async () => {
     const user = userEvent.setup();
-    setExperience([block('draft-1', BlockKind.POLL, 'hidden')]);
+    setExperience([pollBlock({ id: 'draft-1' })]);
     renderFocusMode();
 
     await user.click(screen.getByRole('tab', { name: /history/i }));
@@ -190,10 +180,12 @@ describe('FocusMode', () => {
   it('opens a read-only review for a finished activity', async () => {
     const user = userEvent.setup();
     setExperience([
-      {
-        ...block('past-1', BlockKind.POLL, 'closed', { question: 'Closing sketch?', options: [] }),
+      pollBlock({
+        id: 'past-1',
+        status: 'closed',
+        payload: { question: 'Closing sketch?', options: [] },
         responses: { total: 12 },
-      } as Block,
+      }),
     ]);
     renderFocusMode();
 
@@ -208,7 +200,13 @@ describe('FocusMode', () => {
 
   it('returns to the History tab from a review', async () => {
     const user = userEvent.setup();
-    setExperience([block('past-1', BlockKind.POLL, 'closed', { question: 'Closing sketch?' })]);
+    setExperience([
+      pollBlock({
+        id: 'past-1',
+        status: 'closed',
+        payload: { question: 'Closing sketch?', options: [] },
+      }),
+    ]);
     renderFocusMode();
 
     await user.click(screen.getByRole('tab', { name: /history/i }));
@@ -221,7 +219,7 @@ describe('FocusMode', () => {
 
   it('starts on the live stage when a block is already open', () => {
     setExperience([
-      block('open-1', BlockKind.POLL, 'open', { question: 'Live poll', options: [] }),
+      pollBlock({ id: 'open-1', status: 'open', payload: { question: 'Live poll', options: [] } }),
     ]);
     renderFocusMode();
 
@@ -231,7 +229,11 @@ describe('FocusMode', () => {
 
   it('closes the open block and returns to the activity list on Finish', async () => {
     const user = userEvent.setup();
-    const open = block('open-1', BlockKind.POLL, 'open', { question: 'Live poll', options: [] });
+    const open = pollBlock({
+      id: 'open-1',
+      status: 'open',
+      payload: { question: 'Live poll', options: [] },
+    });
     setExperience([open]);
     renderFocusMode();
 
@@ -244,15 +246,12 @@ describe('FocusMode', () => {
 
   it('puts a draft on the monitor when it is played from the editor', async () => {
     const user = userEvent.setup();
-    const draft = block('draft-1', BlockKind.ANNOUNCEMENT, 'hidden', {
-      title: 'Welcome',
-      message: 'Phones out.',
-    });
+    const draft = announcementBlock({ id: 'draft-1', payload: { message: 'Phones out.' } });
     setExperience([draft]);
     renderFocusMode();
 
     const draftSection = screen.getByRole('heading', { name: 'Drafts' }).parentElement!;
-    await user.click(within(draftSection).getByText('Welcome'));
+    await user.click(within(draftSection).getByText('Phones out.'));
     await user.click(screen.getByRole('button', { name: /^play$/i }));
 
     expect(handlePresent).toHaveBeenCalledTimes(1);
@@ -261,16 +260,11 @@ describe('FocusMode', () => {
 
   it('does not present anything when a draft is saved rather than played', async () => {
     const user = userEvent.setup();
-    setExperience([
-      block('draft-1', BlockKind.ANNOUNCEMENT, 'hidden', {
-        title: 'Welcome',
-        message: 'Phones out.',
-      }),
-    ]);
+    setExperience([announcementBlock({ id: 'draft-1', payload: { message: 'Phones out.' } })]);
     renderFocusMode();
 
     const draftSection = screen.getByRole('heading', { name: 'Drafts' }).parentElement!;
-    await user.click(within(draftSection).getByText('Welcome'));
+    await user.click(within(draftSection).getByText('Phones out.'));
     await user.click(screen.getByRole('button', { name: /save as draft/i }));
 
     expect(handlePresent).not.toHaveBeenCalled();

--- a/app/frontend/Pages/Manage/Focus/FocusMode.test.tsx
+++ b/app/frontend/Pages/Manage/Focus/FocusMode.test.tsx
@@ -1,0 +1,205 @@
+import { MemoryRouter } from 'react-router-dom';
+
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ExperienceStateProvider } from '@cctv/contexts/ExperienceStateContext';
+import { BlockKind } from '@cctv/types';
+import type { Block, Experience } from '@cctv/types';
+
+import FocusMode from './FocusMode';
+
+const useExperienceMock = vi.fn();
+
+vi.mock('@cctv/contexts/ExperienceContext', () => ({
+  useExperience: () => useExperienceMock(),
+  ExperienceProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@cctv/contexts/AdminAuthContext', () => ({
+  useAdminAuth: () => ({
+    adminJWT: 'test-admin-jwt',
+    adminFetch: vi.fn(),
+    isAdminLoading: false,
+  }),
+  AdminAuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@cctv/hooks/useBlockPresentation', () => ({
+  useBlockPresentation: () => ({
+    handlePresent: vi.fn(),
+    handleStopPresenting: vi.fn(),
+    handlePlayNext: vi.fn(),
+    closeBlock: vi.fn(),
+    busyBlockId: undefined,
+    statusError: null,
+    setStatusError: vi.fn(),
+  }),
+}));
+
+function block(id: string, kind: BlockKind, status: Block['status'], payload = {}): Block {
+  return { id, kind, status, position: 0, payload } as Block;
+}
+
+function experienceWith(blocks: Block[]): Experience {
+  return {
+    id: 'exp-1',
+    name: 'Focus Mode Test',
+    code: 'FOCUSTEST',
+    status: 'lobby',
+    blocks,
+    hosts: [],
+    participants: [],
+    segments: [],
+  } as unknown as Experience;
+}
+
+function setExperience(blocks: Block[]) {
+  useExperienceMock.mockReturnValue({
+    experience: experienceWith(blocks),
+    code: 'FOCUSTEST',
+    isLoading: false,
+    wsReady: true,
+  });
+}
+
+function renderFocusMode() {
+  return render(
+    <MemoryRouter initialEntries={['/experiences/FOCUSTEST/manage/focus']}>
+      <ExperienceStateProvider>
+        <FocusMode />
+      </ExperienceStateProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('FocusMode', () => {
+  beforeEach(() => {
+    useExperienceMock.mockReset();
+    localStorage.clear();
+  });
+
+  it('shows a tile for every activity kind', () => {
+    setExperience([]);
+    renderFocusMode();
+
+    const newSection = screen.getByRole('heading', { name: 'Choose an activity' }).parentElement!;
+    const tiles = within(newSection).getAllByRole('button');
+
+    expect(tiles).toHaveLength(Object.values(BlockKind).length);
+    expect(within(newSection).getByText('Family Feud')).toBeInTheDocument();
+  });
+
+  it('lists hidden blocks as drafts and excludes child blocks', () => {
+    setExperience([
+      block('draft-1', BlockKind.POLL, 'hidden', { question: 'Closing sketch?' }),
+      { ...block('child-1', BlockKind.QUESTION, 'hidden'), parent_block_id: 'draft-1' } as Block,
+    ]);
+    renderFocusMode();
+
+    const draftSection = screen.getByRole('heading', { name: 'Drafts' }).parentElement!;
+    expect(within(draftSection).getAllByRole('button')).toHaveLength(1);
+    expect(within(draftSection).getByText('Closing sketch?')).toBeInTheDocument();
+  });
+
+  it('opens the editor with Play and draft actions when a kind is chosen', async () => {
+    const user = userEvent.setup();
+    setExperience([]);
+    renderFocusMode();
+
+    const newSection = screen.getByRole('heading', { name: 'Choose an activity' }).parentElement!;
+    await user.click(within(newSection).getByText('Poll'));
+
+    expect(screen.getByRole('heading', { name: 'New Poll' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /play/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /save as draft/i })).toBeInTheDocument();
+  });
+
+  it('returns to the activity list from the editor', async () => {
+    const user = userEvent.setup();
+    setExperience([]);
+    renderFocusMode();
+
+    const newSection = screen.getByRole('heading', { name: 'Choose an activity' }).parentElement!;
+    await user.click(within(newSection).getByText('Announcement'));
+    expect(screen.getByRole('heading', { name: 'New Announcement' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /back/i }));
+    expect(screen.getByRole('heading', { name: 'Choose an activity' })).toBeInTheDocument();
+  });
+
+  it('lists finished activities under History, newest first', async () => {
+    const user = userEvent.setup();
+    setExperience([
+      { ...block('past-1', BlockKind.POLL, 'closed', { question: 'First bit' }), position: 0 },
+      { ...block('past-2', BlockKind.QUESTION, 'closed', { question: 'Second bit' }), position: 1 },
+      { ...block('draft-1', BlockKind.BUZZER, 'hidden', { question: 'Draft bit' }), position: 2 },
+      {
+        ...block('child-1', BlockKind.QUESTION, 'closed'),
+        parent_block_id: 'past-1',
+        position: 3,
+      } as Block,
+    ]);
+    renderFocusMode();
+
+    await user.click(screen.getByRole('tab', { name: /history/i }));
+
+    const rows = screen.getAllByRole('button').filter((el) => el.textContent?.includes('bit'));
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveTextContent('Second bit');
+    expect(rows[1]).toHaveTextContent('First bit');
+  });
+
+  it('shows an empty state when nothing has run', async () => {
+    const user = userEvent.setup();
+    setExperience([block('draft-1', BlockKind.POLL, 'hidden')]);
+    renderFocusMode();
+
+    await user.click(screen.getByRole('tab', { name: /history/i }));
+
+    expect(screen.getByText('Nothing has run yet.')).toBeInTheDocument();
+  });
+
+  it('opens a read-only review for a finished activity', async () => {
+    const user = userEvent.setup();
+    setExperience([
+      {
+        ...block('past-1', BlockKind.POLL, 'closed', { question: 'Closing sketch?', options: [] }),
+        responses: { total: 12 },
+      } as Block,
+    ]);
+    renderFocusMode();
+
+    await user.click(screen.getByRole('tab', { name: /history/i }));
+    await user.click(screen.getByText('Closing sketch?'));
+
+    expect(screen.getByRole('heading', { name: 'Poll' })).toBeInTheDocument();
+    expect(screen.getByText('Finished')).toBeInTheDocument();
+    expect(screen.getByText('12 responses')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /finish/i })).not.toBeInTheDocument();
+  });
+
+  it('returns to the History tab from a review', async () => {
+    const user = userEvent.setup();
+    setExperience([block('past-1', BlockKind.POLL, 'closed', { question: 'Closing sketch?' })]);
+    renderFocusMode();
+
+    await user.click(screen.getByRole('tab', { name: /history/i }));
+    await user.click(screen.getByText('Closing sketch?'));
+    await user.click(screen.getByRole('button', { name: /back/i }));
+
+    expect(screen.getByRole('tab', { name: /history/i })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText('Closing sketch?')).toBeInTheDocument();
+  });
+
+  it('starts on the live stage when a block is already open', () => {
+    setExperience([
+      block('open-1', BlockKind.POLL, 'open', { question: 'Live poll', options: [] }),
+    ]);
+    renderFocusMode();
+
+    expect(screen.getByRole('button', { name: /finish/i })).toBeInTheDocument();
+    expect(screen.getByText('Live')).toBeInTheDocument();
+  });
+});

--- a/app/frontend/Pages/Manage/Focus/FocusMode.test.tsx
+++ b/app/frontend/Pages/Manage/Focus/FocusMode.test.tsx
@@ -10,7 +10,20 @@ import type { Block, Experience } from '@cctv/types';
 
 import FocusMode from './FocusMode';
 
-const useExperienceMock = vi.fn();
+const { useExperienceMock, handlePresent, handleStopPresenting, closeBlock, navigate } = vi.hoisted(
+  () => ({
+    useExperienceMock: vi.fn(),
+    handlePresent: vi.fn(),
+    handleStopPresenting: vi.fn(),
+    closeBlock: vi.fn(),
+    navigate: vi.fn(),
+  }),
+);
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => navigate };
+});
 
 vi.mock('@cctv/contexts/ExperienceContext', () => ({
   useExperience: () => useExperienceMock(),
@@ -26,12 +39,21 @@ vi.mock('@cctv/contexts/AdminAuthContext', () => ({
   AdminAuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+vi.mock('@cctv/hooks/useUpdateExperienceBlock', () => ({
+  useUpdateExperienceBlock: () => ({
+    updateExperienceBlock: vi.fn().mockResolvedValue({ success: true }),
+    isLoading: false,
+    error: null,
+    setError: vi.fn(),
+  }),
+}));
+
 vi.mock('@cctv/hooks/useBlockPresentation', () => ({
   useBlockPresentation: () => ({
-    handlePresent: vi.fn(),
-    handleStopPresenting: vi.fn(),
+    handlePresent,
+    handleStopPresenting,
     handlePlayNext: vi.fn(),
-    closeBlock: vi.fn(),
+    closeBlock,
     busyBlockId: undefined,
     statusError: null,
     setStatusError: vi.fn(),
@@ -77,6 +99,10 @@ function renderFocusMode() {
 describe('FocusMode', () => {
   beforeEach(() => {
     useExperienceMock.mockReset();
+    handlePresent.mockReset().mockResolvedValue(undefined);
+    handleStopPresenting.mockReset().mockResolvedValue(undefined);
+    closeBlock.mockReset().mockResolvedValue(undefined);
+    navigate.mockReset();
     localStorage.clear();
   });
 
@@ -201,5 +227,60 @@ describe('FocusMode', () => {
 
     expect(screen.getByRole('button', { name: /finish/i })).toBeInTheDocument();
     expect(screen.getByText('Live')).toBeInTheDocument();
+  });
+
+  it('closes the open block and returns to the activity list on Finish', async () => {
+    const user = userEvent.setup();
+    const open = block('open-1', BlockKind.POLL, 'open', { question: 'Live poll', options: [] });
+    setExperience([open]);
+    renderFocusMode();
+
+    await user.click(screen.getByRole('button', { name: /finish/i }));
+
+    expect(handleStopPresenting).toHaveBeenCalledTimes(1);
+    expect(handleStopPresenting).toHaveBeenCalledWith(open);
+    expect(screen.getByRole('heading', { name: 'Choose an activity' })).toBeInTheDocument();
+  });
+
+  it('puts a draft on the monitor when it is played from the editor', async () => {
+    const user = userEvent.setup();
+    const draft = block('draft-1', BlockKind.ANNOUNCEMENT, 'hidden', {
+      title: 'Welcome',
+      message: 'Phones out.',
+    });
+    setExperience([draft]);
+    renderFocusMode();
+
+    const draftSection = screen.getByRole('heading', { name: 'Drafts' }).parentElement!;
+    await user.click(within(draftSection).getByText('Welcome'));
+    await user.click(screen.getByRole('button', { name: /^play$/i }));
+
+    expect(handlePresent).toHaveBeenCalledTimes(1);
+    expect(handlePresent).toHaveBeenCalledWith(draft);
+  });
+
+  it('does not present anything when a draft is saved rather than played', async () => {
+    const user = userEvent.setup();
+    setExperience([
+      block('draft-1', BlockKind.ANNOUNCEMENT, 'hidden', {
+        title: 'Welcome',
+        message: 'Phones out.',
+      }),
+    ]);
+    renderFocusMode();
+
+    const draftSection = screen.getByRole('heading', { name: 'Drafts' }).parentElement!;
+    await user.click(within(draftSection).getByText('Welcome'));
+    await user.click(screen.getByRole('button', { name: /save as draft/i }));
+
+    expect(handlePresent).not.toHaveBeenCalled();
+    expect(screen.getByRole('heading', { name: 'Choose an activity' })).toBeInTheDocument();
+  });
+
+  it('remembers focus mode as the preferred manage view', () => {
+    setExperience([]);
+    renderFocusMode();
+
+    expect(localStorage.getItem('cctv_manage_mode')).toBe('focus');
   });
 });

--- a/app/frontend/Pages/Manage/Focus/FocusMode.tsx
+++ b/app/frontend/Pages/Manage/Focus/FocusMode.tsx
@@ -1,0 +1,285 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useNavigate } from 'react-router-dom';
+
+import classNames from 'classnames';
+import { BookOpen, Bug, LayoutGrid, MonitorPlay, MoreHorizontal, Users } from 'lucide-react';
+
+import { useExperience } from '@cctv/contexts/ExperienceContext';
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Pill,
+} from '@cctv/core';
+import { useBlockPresentation } from '@cctv/hooks/useBlockPresentation';
+import { BLOCK_KIND_LABELS, Block, BlockKind, ParticipantSummary } from '@cctv/types';
+
+import ExperienceActionButton from '../ExperienceActionButton';
+import { ActivityTile, blockSummary } from './ActivityTile';
+import FocusEditor, { EditorIntent } from './FocusEditor';
+import FocusHistory from './FocusHistory';
+import FocusReview from './FocusReview';
+import FocusStage from './FocusStage';
+import { setManageMode } from './useManageMode';
+
+import styles from './FocusMode.module.scss';
+
+type Stage =
+  | { name: 'select' }
+  | { name: 'editor'; kind: BlockKind; block?: Block }
+  | { name: 'live' }
+  | { name: 'review'; blockId: string };
+
+type SelectTab = 'activities' | 'history';
+
+export default function FocusMode() {
+  const navigate = useNavigate();
+  const { experience, code, isLoading, wsReady } = useExperience();
+  const { handlePresent, handleStopPresenting, closeBlock, statusError } = useBlockPresentation();
+
+  const [stage, setStage] = useState<Stage>({ name: 'select' });
+  const [selectTab, setSelectTab] = useState<SelectTab>('activities');
+  const [isFinishing, setIsFinishing] = useState(false);
+  const initializedRef = useRef(false);
+
+  const participants: ParticipantSummary[] = useMemo(
+    () => [...(experience?.hosts || []), ...(experience?.participants || [])],
+    [experience],
+  );
+
+  const openBlock = useMemo(
+    () => experience?.blocks?.find((block) => block.status === 'open'),
+    [experience],
+  );
+
+  const drafts = useMemo(
+    () =>
+      (experience?.blocks || []).filter(
+        (block) => block.status === 'hidden' && !block.parent_block_id,
+      ),
+    [experience],
+  );
+
+  const history = useMemo(
+    () =>
+      (experience?.blocks || [])
+        .filter((block) => block.status === 'closed' && !block.parent_block_id)
+        .sort((a, b) => b.position - a.position),
+    [experience],
+  );
+
+  const reviewBlock = useMemo(
+    () =>
+      stage.name === 'review'
+        ? experience?.blocks?.find((block) => block.id === stage.blockId)
+        : undefined,
+    [experience, stage],
+  );
+
+  useEffect(() => {
+    setManageMode('focus');
+  }, []);
+
+  useEffect(() => {
+    if (initializedRef.current || !experience) return;
+    initializedRef.current = true;
+    if (openBlock) setStage({ name: 'live' });
+  }, [experience, openBlock]);
+
+  const endCurrentBlock = useCallback(async () => {
+    if (!openBlock) return;
+    await closeBlock(openBlock);
+  }, [openBlock, closeBlock]);
+
+  const handleEditorDone = useCallback(
+    async (intent: EditorIntent, draft?: Block) => {
+      if (intent === 'draft') {
+        setStage({ name: 'select' });
+        return;
+      }
+
+      if (draft) await handlePresent(draft);
+      setStage({ name: 'live' });
+    },
+    [handlePresent],
+  );
+
+  const handleFinish = useCallback(async () => {
+    if (!openBlock) {
+      setStage({ name: 'select' });
+      return;
+    }
+
+    setIsFinishing(true);
+    await handleStopPresenting(openBlock);
+    setIsFinishing(false);
+    setStage({ name: 'select' });
+  }, [openBlock, handleStopPresenting]);
+
+  const exitFocusMode = useCallback(() => {
+    setManageMode('manage');
+    navigate(`/experiences/${code}/manage`);
+  }, [navigate, code]);
+
+  if (isLoading || !wsReady) {
+    return <section className="page flex-centered">Loading...</section>;
+  }
+
+  return (
+    <section className={styles.page}>
+      <header className={styles.header}>
+        <span className={styles.name}>{experience?.name || 'Experience'}</span>
+        {experience?.status && (
+          <Pill label={experience.status.charAt(0).toUpperCase() + experience.status.slice(1)} />
+        )}
+        <div className={styles.spacer} />
+        <ExperienceActionButton />
+        <Button
+          to={`/experiences/${code}/monitor`}
+          target="_blank"
+          rel="noreferrer"
+          variant="secondary"
+          title="Open monitor in a new tab"
+        >
+          <MonitorPlay size={16} />
+          <span>Monitor</span>
+        </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="secondary" title="More">
+              <MoreHorizontal size={16} />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => navigate(`/experiences/${code}/manage/participants`)}>
+              <Users size={16} />
+              Participants
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => navigate(`/experiences/${code}/manage/playbill`)}>
+              <BookOpen size={16} />
+              Playbill
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => navigate(`/experiences/${code}/manage/debug`)}>
+              <Bug size={16} />
+              Debug
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={exitFocusMode}>
+              <LayoutGrid size={16} />
+              Full manage view
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </header>
+
+      {statusError && <div className={styles.error}>{statusError}</div>}
+
+      <div className={styles.body}>
+        {stage.name === 'select' && (
+          <div className={styles.select}>
+            <div className={styles.tabs} role="tablist">
+              <button
+                type="button"
+                role="tab"
+                aria-selected={selectTab === 'activities'}
+                className={classNames(styles.tab, selectTab === 'activities' && styles.tabActive)}
+                onClick={() => setSelectTab('activities')}
+              >
+                Activities
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={selectTab === 'history'}
+                className={classNames(styles.tab, selectTab === 'history' && styles.tabActive)}
+                onClick={() => setSelectTab('history')}
+              >
+                History
+                {history.length > 0 && <span className={styles.tabCount}>{history.length}</span>}
+              </button>
+            </div>
+
+            {selectTab === 'history' ? (
+              <FocusHistory
+                blocks={history}
+                onSelect={(block) => setStage({ name: 'review', blockId: block.id })}
+              />
+            ) : (
+              <>
+                {drafts.length > 0 && (
+                  <div className={styles.section}>
+                    <h2 className={styles.sectionTitle}>Drafts</h2>
+                    <p className={styles.sectionHint}>
+                      Prepared earlier — pick one up and play it.
+                    </p>
+                    <div className={styles.grid}>
+                      {drafts.map((draft) => (
+                        <ActivityTile
+                          key={draft.id}
+                          kind={draft.kind}
+                          label={blockSummary(draft) || BLOCK_KIND_LABELS[draft.kind]}
+                          isDraft
+                          onClick={() =>
+                            setStage({ name: 'editor', kind: draft.kind, block: draft })
+                          }
+                        />
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                <div className={styles.section}>
+                  <h2 className={styles.sectionTitle}>Choose an activity</h2>
+                  <div className={styles.grid}>
+                    {Object.values(BlockKind).map((kind) => (
+                      <ActivityTile
+                        key={kind}
+                        kind={kind}
+                        label={BLOCK_KIND_LABELS[kind]}
+                        onClick={() => setStage({ name: 'editor', kind })}
+                      />
+                    ))}
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        {stage.name === 'editor' && (
+          <FocusEditor
+            key={stage.block?.id ?? stage.kind}
+            kind={stage.kind}
+            block={stage.block}
+            participants={participants}
+            onBack={() => setStage({ name: 'select' })}
+            onDone={(intent) => handleEditorDone(intent, stage.block)}
+            onEndCurrentBlock={endCurrentBlock}
+          />
+        )}
+
+        {stage.name === 'live' &&
+          (openBlock ? (
+            <FocusStage block={openBlock} isFinishing={isFinishing} onFinish={handleFinish} />
+          ) : (
+            <div className={styles.placeholder}>
+              <p>Putting it on the monitor…</p>
+              <Button variant="secondary" onClick={() => setStage({ name: 'select' })}>
+                Back to activities
+              </Button>
+            </div>
+          ))}
+
+        {stage.name === 'review' && reviewBlock && (
+          <FocusReview
+            block={reviewBlock}
+            participants={participants}
+            onBack={() => setStage({ name: 'select' })}
+          />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app/frontend/Pages/Manage/Focus/FocusReview.module.scss
+++ b/app/frontend/Pages/Manage/Focus/FocusReview.module.scss
@@ -1,0 +1,85 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  width: 100%;
+  max-width: 76rem;
+  margin: 0 auto;
+  padding-bottom: var(--space-md);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  line-height: 1;
+  letter-spacing: 0.04em;
+  color: var(--hot-white);
+}
+
+.done {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  border: 1px solid hsl(var(--border));
+  color: hsl(var(--muted-foreground));
+  font-family: var(--font-ui);
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.columns {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-sm);
+  align-items: start;
+}
+
+@media (min-width: 60rem) {
+  .columns {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+}
+
+.panel {
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  background: hsl(var(--card));
+  overflow: hidden;
+}
+
+.panelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.6rem 0.85rem;
+  border-bottom: 1px solid hsl(var(--border));
+  font-family: var(--font-ui);
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+}
+
+.panelBody {
+  padding: var(--space-sm);
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.count {
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  color: var(--phosphor);
+  text-transform: none;
+  letter-spacing: 0;
+}

--- a/app/frontend/Pages/Manage/Focus/FocusReview.test.tsx
+++ b/app/frontend/Pages/Manage/Focus/FocusReview.test.tsx
@@ -2,9 +2,9 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
-import { BlockKind } from '@cctv/types';
-import type { Block, ParticipantSummary } from '@cctv/types';
+import type { Block, PollBlock } from '@cctv/types';
 
+import { participant, pollBlock } from '../testFactories';
 import FocusReview from './FocusReview';
 
 vi.mock('../BlockPreview/BlockPreview', () => ({
@@ -12,18 +12,14 @@ vi.mock('../BlockPreview/BlockPreview', () => ({
 }));
 
 const participants = [
-  { id: 'p1', name: 'Nina' },
-  { id: 'p2', name: 'Marcus' },
-] as ParticipantSummary[];
+  participant({ id: 'p1', name: 'Nina' }),
+  participant({ id: 'p2', name: 'Marcus' }),
+];
 
-function closedPoll(overrides: Partial<Block['responses']> = {}): Block {
-  return {
-    id: 'block-1',
-    kind: BlockKind.POLL,
+function closedPoll(responses: PollBlock['responses'] = undefined): PollBlock {
+  return pollBlock({
     status: 'closed',
-    position: 0,
-    payload: { question: 'Best opener?', options: [] },
-    responses: {
+    responses: responses ?? {
       total: 2,
       all_responses: [
         {
@@ -39,9 +35,8 @@ function closedPoll(overrides: Partial<Block['responses']> = {}): Block {
           created_at: '2026-08-07T22:34:25Z',
         },
       ],
-      ...overrides,
     },
-  } as Block;
+  });
 }
 
 function renderReview(block: Block) {

--- a/app/frontend/Pages/Manage/Focus/FocusReview.test.tsx
+++ b/app/frontend/Pages/Manage/Focus/FocusReview.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { BlockKind } from '@cctv/types';
+import type { Block, ParticipantSummary } from '@cctv/types';
+
+import FocusReview from './FocusReview';
+
+vi.mock('../BlockPreview/BlockPreview', () => ({
+  default: ({ block }: { block: Block }) => <div>preview of {block.id}</div>,
+}));
+
+const participants = [
+  { id: 'p1', name: 'Nina' },
+  { id: 'p2', name: 'Marcus' },
+] as ParticipantSummary[];
+
+function closedPoll(overrides: Partial<Block['responses']> = {}): Block {
+  return {
+    id: 'block-1',
+    kind: BlockKind.POLL,
+    status: 'closed',
+    position: 0,
+    payload: { question: 'Best opener?', options: [] },
+    responses: {
+      total: 2,
+      all_responses: [
+        {
+          id: 'r1',
+          experience_participant_id: 'p1',
+          answer: { value: 'Improv set' },
+          created_at: '2026-08-07T22:34:25Z',
+        },
+        {
+          id: 'r2',
+          experience_participant_id: 'p2',
+          answer: { value: 'Stand-up' },
+          created_at: '2026-08-07T22:34:25Z',
+        },
+      ],
+      ...overrides,
+    },
+  } as Block;
+}
+
+function renderReview(block: Block) {
+  const onBack = vi.fn();
+  render(<FocusReview block={block} participants={participants} onBack={onBack} />);
+  return { onBack };
+}
+
+describe('FocusReview', () => {
+  it('marks the activity as finished and names its kind', () => {
+    renderReview(closedPoll());
+
+    expect(screen.getByRole('heading', { name: 'Poll' })).toBeInTheDocument();
+    expect(screen.getByText('Finished')).toBeInTheDocument();
+  });
+
+  it('offers no live controls', () => {
+    renderReview(closedPoll());
+
+    expect(screen.queryByRole('button', { name: /finish/i })).not.toBeInTheDocument();
+    expect(screen.queryByText('Live')).not.toBeInTheDocument();
+  });
+
+  it('lists the responses with who gave them', () => {
+    renderReview(closedPoll());
+
+    expect(screen.getByText('2 responses')).toBeInTheDocument();
+    expect(screen.getByText(/Nina/)).toBeInTheDocument();
+    expect(screen.getByText(/Marcus/)).toBeInTheDocument();
+    expect(screen.getByText('Improv set')).toBeInTheDocument();
+  });
+
+  it('handles an activity that collected nothing', () => {
+    renderReview(closedPoll({ total: 0, all_responses: [] }));
+
+    expect(screen.getByText('0 responses')).toBeInTheDocument();
+    expect(screen.getByText('No responses yet')).toBeInTheDocument();
+  });
+
+  it('calls onBack from the back button', async () => {
+    const user = userEvent.setup();
+    const { onBack } = renderReview(closedPoll());
+
+    await user.click(screen.getByRole('button', { name: /back/i }));
+
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/frontend/Pages/Manage/Focus/FocusReview.tsx
+++ b/app/frontend/Pages/Manage/Focus/FocusReview.tsx
@@ -1,0 +1,55 @@
+import { ArrowLeft } from 'lucide-react';
+
+import { Button } from '@cctv/core';
+import { BLOCK_KIND_LABELS, Block, ParticipantSummary } from '@cctv/types';
+
+import BlockPreview from '../BlockPreview/BlockPreview';
+import BlockResponsesList from '../Viewer/BlockResponsesList';
+
+import styles from './FocusReview.module.scss';
+
+interface FocusReviewProps {
+  block: Block;
+  participants: ParticipantSummary[];
+  onBack: () => void;
+}
+
+export default function FocusReview({ block, participants, onBack }: FocusReviewProps) {
+  const responseCount = block.responses?.total ?? 0;
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.header}>
+        <Button variant="ghost" onClick={onBack} title="Back to history">
+          <ArrowLeft size={18} />
+          <span>Back</span>
+        </Button>
+        <h1 className={styles.title}>{BLOCK_KIND_LABELS[block.kind]}</h1>
+        <span className={styles.done}>Finished</span>
+      </div>
+
+      <div className={styles.columns}>
+        <div className={styles.panel}>
+          <div className={styles.panelHeader}>
+            <span>What the audience saw</span>
+          </div>
+          <div className={styles.panelBody}>
+            <BlockPreview block={block} viewContext="monitor" />
+          </div>
+        </div>
+
+        <div className={styles.panel}>
+          <div className={styles.panelHeader}>
+            <span>Responses</span>
+            <span className={styles.count}>
+              {responseCount} {responseCount === 1 ? 'response' : 'responses'}
+            </span>
+          </div>
+          <div className={styles.panelBody}>
+            <BlockResponsesList block={block} participants={participants} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/Pages/Manage/Focus/FocusStage.module.scss
+++ b/app/frontend/Pages/Manage/Focus/FocusStage.module.scss
@@ -1,0 +1,103 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  width: 100%;
+  max-width: 76rem;
+  margin: 0 auto;
+  padding-bottom: var(--space-md);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  line-height: 1;
+  letter-spacing: 0.04em;
+  color: var(--hot-white);
+}
+
+.live {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  background: var(--red);
+  color: var(--hot-white);
+  font-family: var(--font-ui);
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.dot {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: var(--hot-white);
+}
+
+.spacer {
+  flex: 1;
+}
+
+.columns {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-sm);
+  align-items: start;
+}
+
+@media (min-width: 60rem) {
+  .withControls {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+}
+
+.panel {
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  background: hsl(var(--card));
+  overflow: hidden;
+}
+
+.panelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.6rem 0.85rem;
+  border-bottom: 1px solid hsl(var(--border));
+  font-family: var(--font-ui);
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+}
+
+.panelBody {
+  padding: var(--space-sm);
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.count {
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  color: var(--phosphor);
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.hint {
+  font-size: 0.85rem;
+  color: hsl(var(--muted-foreground));
+  padding-top: 0.5rem;
+}

--- a/app/frontend/Pages/Manage/Focus/FocusStage.stories.tsx
+++ b/app/frontend/Pages/Manage/Focus/FocusStage.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from '@storybook/test';
+
+import { Block, BlockKind } from '@cctv/types';
+
+import FocusStage from './FocusStage';
+
+const pollBlock = {
+  id: 'block-1',
+  kind: BlockKind.POLL,
+  status: 'open',
+  position: 0,
+  payload: {
+    question: 'Which sketch should close the show?',
+    options: ['The Bit', 'Cold Open', 'Musical Number'],
+  },
+  responses: { total: 0 },
+} as Block;
+
+const meta: Meta<typeof FocusStage> = {
+  title: 'Manage/Focus/FocusStage',
+  component: FocusStage,
+  tags: ['autodocs'],
+  args: {
+    onFinish: fn(),
+    isFinishing: false,
+    block: pollBlock,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof FocusStage>;
+
+export const AwaitingResponses: Story = {};
+
+export const WithResponses: Story = {
+  args: {
+    block: { ...pollBlock, responses: { total: 24 } } as Block,
+  },
+};
+
+export const Finishing: Story = {
+  args: { isFinishing: true },
+};

--- a/app/frontend/Pages/Manage/Focus/FocusStage.stories.tsx
+++ b/app/frontend/Pages/Manage/Focus/FocusStage.stories.tsx
@@ -1,21 +1,17 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { fn } from '@storybook/test';
 
-import { Block, BlockKind } from '@cctv/types';
-
+import { pollBlock } from '../testFactories';
 import FocusStage from './FocusStage';
 
-const pollBlock = {
-  id: 'block-1',
-  kind: BlockKind.POLL,
+const livePoll = pollBlock({
   status: 'open',
-  position: 0,
   payload: {
     question: 'Which sketch should close the show?',
     options: ['The Bit', 'Cold Open', 'Musical Number'],
   },
   responses: { total: 0 },
-} as Block;
+});
 
 const meta: Meta<typeof FocusStage> = {
   title: 'Manage/Focus/FocusStage',
@@ -24,7 +20,7 @@ const meta: Meta<typeof FocusStage> = {
   args: {
     onFinish: fn(),
     isFinishing: false,
-    block: pollBlock,
+    block: livePoll,
   },
 };
 export default meta;
@@ -35,7 +31,7 @@ export const AwaitingResponses: Story = {};
 
 export const WithResponses: Story = {
   args: {
-    block: { ...pollBlock, responses: { total: 24 } } as Block,
+    block: { ...livePoll, responses: { total: 24 } },
   },
 };
 

--- a/app/frontend/Pages/Manage/Focus/FocusStage.test.tsx
+++ b/app/frontend/Pages/Manage/Focus/FocusStage.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { BlockKind } from '@cctv/types';
+import type { Block } from '@cctv/types';
+
+import FocusStage from './FocusStage';
+
+vi.mock('../BlockPreview/BlockPreview', () => ({
+  default: ({ block }: { block: Block }) => <div>preview of {block.id}</div>,
+}));
+
+vi.mock('@cctv/pages/Block/FamilyFeudManager/FamilyFeudManager', () => ({
+  default: () => <div>family feud controls</div>,
+}));
+
+vi.mock('@cctv/pages/Block/GuessWhoManager/GuessWhoManager', () => ({
+  default: () => <div>guess who controls</div>,
+}));
+
+function openBlock(kind: BlockKind, total = 0, payload: Record<string, unknown> = {}): Block {
+  return {
+    id: 'block-1',
+    kind,
+    status: 'open',
+    position: 0,
+    payload,
+    responses: { total },
+  } as Block;
+}
+
+function renderStage(block: Block, props: Partial<{ isFinishing: boolean }> = {}) {
+  const onFinish = vi.fn();
+  render(<FocusStage block={block} isFinishing={props.isFinishing ?? false} onFinish={onFinish} />);
+  return { onFinish };
+}
+
+describe('FocusStage', () => {
+  it('marks the activity as live and names its kind', () => {
+    renderStage(openBlock(BlockKind.POLL, 0, { question: 'Best opener?', options: [] }));
+
+    expect(screen.getByRole('heading', { name: 'Poll' })).toBeInTheDocument();
+    expect(screen.getByText('Live')).toBeInTheDocument();
+  });
+
+  it('calls onFinish when Finish is pressed', async () => {
+    const user = userEvent.setup();
+    const { onFinish } = renderStage(
+      openBlock(BlockKind.POLL, 3, { question: 'Best opener?', options: [] }),
+    );
+
+    await user.click(screen.getByRole('button', { name: /finish/i }));
+
+    expect(onFinish).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the running response count', () => {
+    renderStage(openBlock(BlockKind.POLL, 3, { question: 'Best opener?', options: [] }));
+
+    expect(screen.getByText('3 responses')).toBeInTheDocument();
+  });
+
+  it('shows a reveal panel for Family Feud', () => {
+    renderStage(openBlock(BlockKind.FAMILY_FEUD));
+
+    expect(screen.getByText('Reveal')).toBeInTheDocument();
+    expect(screen.getByText('family feud controls')).toBeInTheDocument();
+  });
+
+  it('shows a reveal panel for Guess Who', () => {
+    renderStage(openBlock(BlockKind.GUESS_WHO));
+
+    expect(screen.getByText('Reveal')).toBeInTheDocument();
+    expect(screen.getByText('guess who controls')).toBeInTheDocument();
+  });
+
+  it('shows a waiting hint instead of a reveal panel for kinds without one', () => {
+    renderStage(openBlock(BlockKind.POLL, 0, { question: 'Best opener?', options: [] }));
+
+    expect(screen.queryByText('Reveal')).not.toBeInTheDocument();
+    expect(screen.getByText(/responses are coming in/i)).toBeInTheDocument();
+  });
+
+  it('disables Finish while finishing', () => {
+    renderStage(openBlock(BlockKind.POLL, 0, { question: 'Best opener?', options: [] }), {
+      isFinishing: true,
+    });
+
+    expect(screen.getByRole('button', { name: /finishing/i })).toBeDisabled();
+  });
+});

--- a/app/frontend/Pages/Manage/Focus/FocusStage.test.tsx
+++ b/app/frontend/Pages/Manage/Focus/FocusStage.test.tsx
@@ -2,9 +2,9 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
-import { BlockKind } from '@cctv/types';
 import type { Block } from '@cctv/types';
 
+import { familyFeudBlock, guessWhoBlock, pollBlock } from '../testFactories';
 import FocusStage from './FocusStage';
 
 vi.mock('../BlockPreview/BlockPreview', () => ({
@@ -19,15 +19,8 @@ vi.mock('@cctv/pages/Block/GuessWhoManager/GuessWhoManager', () => ({
   default: () => <div>guess who controls</div>,
 }));
 
-function openBlock(kind: BlockKind, total = 0, payload: Record<string, unknown> = {}): Block {
-  return {
-    id: 'block-1',
-    kind,
-    status: 'open',
-    position: 0,
-    payload,
-    responses: { total },
-  } as Block;
+function openPoll(total = 0): Block {
+  return pollBlock({ status: 'open', responses: { total } });
 }
 
 function renderStage(block: Block, props: Partial<{ isFinishing: boolean }> = {}) {
@@ -38,7 +31,7 @@ function renderStage(block: Block, props: Partial<{ isFinishing: boolean }> = {}
 
 describe('FocusStage', () => {
   it('marks the activity as live and names its kind', () => {
-    renderStage(openBlock(BlockKind.POLL, 0, { question: 'Best opener?', options: [] }));
+    renderStage(openPoll());
 
     expect(screen.getByRole('heading', { name: 'Poll' })).toBeInTheDocument();
     expect(screen.getByText('Live')).toBeInTheDocument();
@@ -46,9 +39,7 @@ describe('FocusStage', () => {
 
   it('calls onFinish when Finish is pressed', async () => {
     const user = userEvent.setup();
-    const { onFinish } = renderStage(
-      openBlock(BlockKind.POLL, 3, { question: 'Best opener?', options: [] }),
-    );
+    const { onFinish } = renderStage(openPoll(3));
 
     await user.click(screen.getByRole('button', { name: /finish/i }));
 
@@ -56,36 +47,34 @@ describe('FocusStage', () => {
   });
 
   it('shows the running response count', () => {
-    renderStage(openBlock(BlockKind.POLL, 3, { question: 'Best opener?', options: [] }));
+    renderStage(openPoll(3));
 
     expect(screen.getByText('3 responses')).toBeInTheDocument();
   });
 
   it('shows a reveal panel for Family Feud', () => {
-    renderStage(openBlock(BlockKind.FAMILY_FEUD));
+    renderStage(familyFeudBlock({ status: 'open' }));
 
     expect(screen.getByText('Reveal')).toBeInTheDocument();
     expect(screen.getByText('family feud controls')).toBeInTheDocument();
   });
 
   it('shows a reveal panel for Guess Who', () => {
-    renderStage(openBlock(BlockKind.GUESS_WHO));
+    renderStage(guessWhoBlock({ status: 'open' }));
 
     expect(screen.getByText('Reveal')).toBeInTheDocument();
     expect(screen.getByText('guess who controls')).toBeInTheDocument();
   });
 
   it('shows a waiting hint instead of a reveal panel for kinds without one', () => {
-    renderStage(openBlock(BlockKind.POLL, 0, { question: 'Best opener?', options: [] }));
+    renderStage(openPoll());
 
     expect(screen.queryByText('Reveal')).not.toBeInTheDocument();
     expect(screen.getByText(/responses are coming in/i)).toBeInTheDocument();
   });
 
   it('disables Finish while finishing', () => {
-    renderStage(openBlock(BlockKind.POLL, 0, { question: 'Best opener?', options: [] }), {
-      isFinishing: true,
-    });
+    renderStage(openPoll(), { isFinishing: true });
 
     expect(screen.getByRole('button', { name: /finishing/i })).toBeDisabled();
   });

--- a/app/frontend/Pages/Manage/Focus/FocusStage.tsx
+++ b/app/frontend/Pages/Manage/Focus/FocusStage.tsx
@@ -1,0 +1,80 @@
+import classNames from 'classnames';
+import { Square } from 'lucide-react';
+
+import { Button } from '@cctv/core';
+import FamilyFeudManager from '@cctv/pages/Block/FamilyFeudManager/FamilyFeudManager';
+import GuessWhoManager from '@cctv/pages/Block/GuessWhoManager/GuessWhoManager';
+import { BLOCK_KIND_LABELS, Block, BlockKind } from '@cctv/types';
+
+import BlockPreview from '../BlockPreview/BlockPreview';
+
+import styles from './FocusStage.module.scss';
+
+interface FocusStageProps {
+  block: Block;
+  isFinishing: boolean;
+  onFinish: () => void;
+}
+
+export default function FocusStage({ block, isFinishing, onFinish }: FocusStageProps) {
+  const controls = renderControls(block);
+  const responseCount = block.responses?.total ?? 0;
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.header}>
+        <h1 className={styles.title}>{BLOCK_KIND_LABELS[block.kind]}</h1>
+        <span className={styles.live}>
+          <span className={styles.dot} />
+          Live
+        </span>
+        <div className={styles.spacer} />
+        <Button onClick={onFinish} loading={isFinishing} loadingText="Finishing...">
+          <Square size={16} />
+          <span>Finish</span>
+        </Button>
+      </div>
+
+      <div className={classNames(styles.columns, controls && styles.withControls)}>
+        <div className={styles.panel}>
+          <div className={styles.panelHeader}>
+            <span>On the monitor</span>
+            <span className={styles.count}>
+              {responseCount} {responseCount === 1 ? 'response' : 'responses'}
+            </span>
+          </div>
+          <div className={styles.panelBody}>
+            <BlockPreview block={block} viewContext="monitor" />
+          </div>
+        </div>
+
+        {controls && (
+          <div className={styles.panel}>
+            <div className={styles.panelHeader}>
+              <span>Reveal</span>
+            </div>
+            <div className={styles.panelBody}>{controls}</div>
+          </div>
+        )}
+      </div>
+
+      {!controls && (
+        <p className={styles.hint}>
+          Responses are coming in. Hit Finish when you&rsquo;re ready to move on.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function renderControls(block: Block) {
+  if (block.kind === BlockKind.FAMILY_FEUD) {
+    return <FamilyFeudManager block={block} />;
+  }
+
+  if (block.kind === BlockKind.GUESS_WHO) {
+    return <GuessWhoManager block={block} />;
+  }
+
+  return null;
+}

--- a/app/frontend/Pages/Manage/Focus/KindPreview.module.scss
+++ b/app/frontend/Pages/Manage/Focus/KindPreview.module.scss
@@ -1,0 +1,151 @@
+.root {
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  padding: 0.75rem;
+  border-radius: calc(var(--radius) - 0.25rem);
+  background: hsl(var(--background));
+  border: 1px solid hsl(var(--border));
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.bar {
+  height: 0.5rem;
+  border-radius: 999px;
+  background: var(--dim);
+}
+
+.barFilled {
+  background: var(--phosphor);
+  box-shadow: var(--tv-glow);
+}
+
+.barRow {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.line {
+  height: 0.375rem;
+  border-radius: 999px;
+  background: var(--dim);
+}
+
+.caret {
+  width: 60%;
+  height: 1.25rem;
+  border-radius: 0.25rem;
+  border: 1px solid var(--phosphor);
+  background: transparent;
+}
+
+.headline {
+  width: 70%;
+  height: 0.75rem;
+  border-radius: 999px;
+  background: var(--phosphor);
+  box-shadow: var(--tv-glow);
+}
+
+.board {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.3rem;
+}
+
+.cell {
+  height: 0.7rem;
+  border-radius: 0.15rem;
+  background: var(--dim);
+}
+
+.cellRevealed {
+  background: var(--phosphor);
+  box-shadow: var(--tv-glow);
+}
+
+.frames {
+  display: flex;
+  gap: 0.35rem;
+  align-items: flex-end;
+}
+
+.frame {
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 0.2rem;
+  border: 1px solid var(--dim);
+  background: linear-gradient(135deg, var(--dim) 0%, transparent 60%);
+}
+
+.buzzer {
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 50%;
+  background: var(--red);
+  box-shadow: 0 0 12px rgba(255, 73, 17, 0.5);
+}
+
+.silhouette {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.head {
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 50%;
+  background: var(--dim);
+}
+
+.headActive {
+  background: var(--phosphor);
+  box-shadow: var(--tv-glow);
+}
+
+.glyph {
+  font-family: var(--font-display);
+  font-size: 1.75rem;
+  line-height: 1;
+  letter-spacing: 0.1em;
+  color: var(--phosphor);
+  text-shadow: var(--tv-glow);
+}
+
+.balloon {
+  width: 1.5rem;
+  height: 1.9rem;
+  border-radius: 50% 50% 45% 45%;
+  background: var(--amber);
+  box-shadow: 0 0 10px var(--amber-glow);
+}
+
+.balloonSmall {
+  width: 1rem;
+  height: 1.3rem;
+  opacity: 0.55;
+}
+
+.spotlight {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  background: radial-gradient(circle, var(--phosphor-glow-strong) 0%, transparent 70%);
+  border: 1px solid var(--phosphor);
+}
+
+.row {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+  justify-content: center;
+}

--- a/app/frontend/Pages/Manage/Focus/KindPreview.test.tsx
+++ b/app/frontend/Pages/Manage/Focus/KindPreview.test.tsx
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { BlockKind } from '@cctv/types';
+
+import KindPreview from './KindPreview';
+
+describe('KindPreview', () => {
+  it.each(Object.values(BlockKind))('renders a preview for %s', (kind) => {
+    const { container } = render(<KindPreview kind={kind} />);
+
+    expect(container.firstChild).toBeInTheDocument();
+    expect(container.firstChild).not.toBeEmptyDOMElement();
+  });
+
+  it('is hidden from assistive technology', () => {
+    const { container } = render(<KindPreview kind={BlockKind.POLL} />);
+
+    expect(container.firstChild).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('applies an extra class name when given one', () => {
+    const { container } = render(<KindPreview kind={BlockKind.POLL} className="thumb" />);
+
+    expect(container.firstChild).toHaveClass('thumb');
+  });
+});

--- a/app/frontend/Pages/Manage/Focus/KindPreview.tsx
+++ b/app/frontend/Pages/Manage/Focus/KindPreview.tsx
@@ -1,0 +1,118 @@
+import classNames from 'classnames';
+
+import { BlockKind } from '@cctv/types';
+
+import styles from './KindPreview.module.scss';
+
+interface KindPreviewProps {
+  kind: BlockKind;
+  className?: string;
+}
+
+function Bars({ widths, filled }: { widths: string[]; filled: number }) {
+  return (
+    <div className={styles.barRow}>
+      {widths.map((width, index) => (
+        <div
+          key={width + index}
+          className={classNames(styles.bar, index === filled && styles.barFilled)}
+          style={{ width }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function Lines({ widths }: { widths: string[] }) {
+  return (
+    <div className={styles.barRow}>
+      {widths.map((width, index) => (
+        <div key={width + index} className={styles.line} style={{ width }} />
+      ))}
+    </div>
+  );
+}
+
+export default function KindPreview({ kind, className }: KindPreviewProps) {
+  return (
+    <div className={classNames(styles.root, className)} aria-hidden="true">
+      {renderPreview(kind)}
+    </div>
+  );
+}
+
+function renderPreview(kind: BlockKind) {
+  switch (kind) {
+    case BlockKind.POLL:
+      return (
+        <>
+          <div className={styles.headline} />
+          <Bars widths={['85%', '60%', '40%']} filled={0} />
+        </>
+      );
+    case BlockKind.QUESTION:
+      return (
+        <>
+          <div className={styles.headline} />
+          <div className={styles.caret} />
+        </>
+      );
+    case BlockKind.ANNOUNCEMENT:
+      return (
+        <>
+          <div className={styles.headline} />
+          <Lines widths={['90%', '70%']} />
+        </>
+      );
+    case BlockKind.FAMILY_FEUD:
+      return (
+        <div className={styles.board}>
+          <div className={classNames(styles.cell, styles.cellRevealed)} />
+          <div className={styles.cell} />
+          <div className={styles.cell} />
+          <div className={classNames(styles.cell, styles.cellRevealed)} />
+          <div className={styles.cell} />
+          <div className={styles.cell} />
+        </div>
+      );
+    case BlockKind.PHOTO_UPLOAD:
+      return (
+        <div className={styles.frames}>
+          <div className={styles.frame} />
+          <div className={styles.frame} />
+          <div className={styles.frame} />
+        </div>
+      );
+    case BlockKind.BUZZER:
+      return <div className={styles.buzzer} />;
+    case BlockKind.GUESS_WHO:
+      return (
+        <div className={styles.silhouette}>
+          <div className={styles.head} />
+          <div className={classNames(styles.head, styles.headActive)} />
+          <div className={styles.head} />
+        </div>
+      );
+    case BlockKind.MINIGAME_ARITHMETIC:
+      return <div className={styles.glyph}>7 + 4</div>;
+    case BlockKind.MINIGAME_BALLOON_PUMP:
+      return (
+        <div className={styles.row}>
+          <div className={classNames(styles.balloon, styles.balloonSmall)} />
+          <div className={styles.balloon} />
+          <div className={classNames(styles.balloon, styles.balloonSmall)} />
+        </div>
+      );
+    case BlockKind.THE_SCENE:
+      return (
+        <>
+          <div className={styles.spotlight} />
+          <Lines widths={['55%']} />
+        </>
+      );
+    default: {
+      const exhaustiveCheck: never = kind;
+      return <div className={styles.glyph}>{exhaustiveCheck}</div>;
+    }
+  }
+}

--- a/app/frontend/Pages/Manage/Focus/useManageMode.test.ts
+++ b/app/frontend/Pages/Manage/Focus/useManageMode.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { getManageMode, setManageMode } from './useManageMode';
+
+describe('useManageMode', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('has no preference until one is set', () => {
+    expect(getManageMode()).toBeNull();
+  });
+
+  it('round-trips a stored preference', () => {
+    setManageMode('focus');
+    expect(getManageMode()).toBe('focus');
+
+    setManageMode('manage');
+    expect(getManageMode()).toBe('manage');
+  });
+
+  it('ignores a value it does not recognise', () => {
+    localStorage.setItem('cctv_manage_mode', 'something-else');
+
+    expect(getManageMode()).toBeNull();
+  });
+});

--- a/app/frontend/Pages/Manage/Focus/useManageMode.ts
+++ b/app/frontend/Pages/Manage/Focus/useManageMode.ts
@@ -1,0 +1,16 @@
+export type ManageMode = 'focus' | 'manage';
+
+const STORAGE_KEY = 'cctv_manage_mode';
+
+export function getManageMode(): ManageMode | null {
+  if (typeof window === 'undefined') return null;
+
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  return stored === 'focus' || stored === 'manage' ? stored : null;
+}
+
+export function setManageMode(mode: ManageMode) {
+  if (typeof window === 'undefined') return;
+
+  window.localStorage.setItem(STORAGE_KEY, mode);
+}

--- a/app/frontend/Pages/Manage/Subpages/ManageDebugPage.tsx
+++ b/app/frontend/Pages/Manage/Subpages/ManageDebugPage.tsx
@@ -1,0 +1,16 @@
+import { useExperience } from '@cctv/contexts/ExperienceContext';
+
+import DebugPanel from '../Viewer/DebugPanel/DebugPanel';
+import ManageSubpage from './ManageSubpage';
+
+export default function ManageDebugPage() {
+  const { experience } = useExperience();
+
+  const openBlock = experience?.blocks?.find((block) => block.status === 'open');
+
+  return (
+    <ManageSubpage title="Debug">
+      <DebugPanel selectedBlock={openBlock} />
+    </ManageSubpage>
+  );
+}

--- a/app/frontend/Pages/Manage/Subpages/ManageParticipantsPage.tsx
+++ b/app/frontend/Pages/Manage/Subpages/ManageParticipantsPage.tsx
@@ -1,0 +1,20 @@
+import { useExperience } from '@cctv/contexts/ExperienceContext';
+
+import ParticipantsTab from '../ParticipantsTab/ParticipantsTab';
+import ManageSubpage from './ManageSubpage';
+
+export default function ManageParticipantsPage() {
+  const { experience } = useExperience();
+
+  const participants = [...(experience?.hosts || []), ...(experience?.participants || [])];
+
+  return (
+    <ManageSubpage title="Participants">
+      <ParticipantsTab
+        participants={participants}
+        segments={experience?.segments || []}
+        defaultSegmentId={experience?.default_segment_id ?? null}
+      />
+    </ManageSubpage>
+  );
+}

--- a/app/frontend/Pages/Manage/Subpages/ManagePlaybillPage.tsx
+++ b/app/frontend/Pages/Manage/Subpages/ManagePlaybillPage.tsx
@@ -1,0 +1,17 @@
+import { useExperience } from '@cctv/contexts/ExperienceContext';
+
+import PlaybillTab from '../PlaybillTab/PlaybillTab';
+import ManageSubpage from './ManageSubpage';
+
+export default function ManagePlaybillPage() {
+  const { experience } = useExperience();
+
+  return (
+    <ManageSubpage title="Playbill">
+      <PlaybillTab
+        playbill={experience?.playbill || []}
+        playbillEnabled={experience?.playbill_enabled !== false}
+      />
+    </ManageSubpage>
+  );
+}

--- a/app/frontend/Pages/Manage/Subpages/ManageSubpage.module.scss
+++ b/app/frontend/Pages/Manage/Subpages/ManageSubpage.module.scss
@@ -1,0 +1,31 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-height: calc(100dvh - var(--nav-h));
+  background: hsl(var(--background));
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem var(--space-sm);
+  border-bottom: 1px solid hsl(var(--border));
+}
+
+.title {
+  font-family: var(--font-display);
+  font-size: 1.6rem;
+  line-height: 1;
+  letter-spacing: 0.06em;
+  color: var(--hot-white);
+}
+
+.body {
+  flex: 1;
+  width: 100%;
+  max-width: 64rem;
+  margin: 0 auto;
+  padding: var(--space-sm);
+}

--- a/app/frontend/Pages/Manage/Subpages/ManageSubpage.tsx
+++ b/app/frontend/Pages/Manage/Subpages/ManageSubpage.tsx
@@ -1,0 +1,41 @@
+import { ReactNode } from 'react';
+
+import { useNavigate } from 'react-router-dom';
+
+import { ArrowLeft } from 'lucide-react';
+
+import { useExperience } from '@cctv/contexts/ExperienceContext';
+import { Button } from '@cctv/core';
+
+import styles from './ManageSubpage.module.scss';
+
+interface ManageSubpageProps {
+  title: string;
+  children: ReactNode;
+}
+
+export default function ManageSubpage({ title, children }: ManageSubpageProps) {
+  const navigate = useNavigate();
+  const { code, isLoading, wsReady } = useExperience();
+
+  if (isLoading || !wsReady) {
+    return <section className="page flex-centered">Loading...</section>;
+  }
+
+  return (
+    <section className={styles.root}>
+      <header className={styles.header}>
+        <Button
+          variant="ghost"
+          onClick={() => navigate(`/experiences/${code}/manage/focus`)}
+          title="Back to focus mode"
+        >
+          <ArrowLeft size={18} />
+          <span>Back</span>
+        </Button>
+        <h1 className={styles.title}>{title}</h1>
+      </header>
+      <div className={styles.body}>{children}</div>
+    </section>
+  );
+}

--- a/app/frontend/Pages/Manage/Subpages/ManageSubpages.test.tsx
+++ b/app/frontend/Pages/Manage/Subpages/ManageSubpages.test.tsx
@@ -1,0 +1,130 @@
+import { MemoryRouter } from 'react-router-dom';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { BlockKind } from '@cctv/types';
+import type { Block } from '@cctv/types';
+
+import ManageDebugPage from './ManageDebugPage';
+import ManageParticipantsPage from './ManageParticipantsPage';
+import ManagePlaybillPage from './ManagePlaybillPage';
+
+const { navigate, useExperienceMock } = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  useExperienceMock: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => navigate };
+});
+
+vi.mock('@cctv/contexts/ExperienceContext', () => ({
+  useExperience: () => useExperienceMock(),
+}));
+
+vi.mock('../ParticipantsTab/ParticipantsTab', () => ({
+  default: ({ participants }: { participants: { id: string }[] }) => (
+    <div>participants: {participants.length}</div>
+  ),
+}));
+
+vi.mock('../PlaybillTab/PlaybillTab', () => ({
+  default: ({ playbillEnabled }: { playbillEnabled: boolean }) => (
+    <div>playbill enabled: {String(playbillEnabled)}</div>
+  ),
+}));
+
+vi.mock('../Viewer/DebugPanel/DebugPanel', () => ({
+  default: ({ selectedBlock }: { selectedBlock?: Block }) => (
+    <div>debug block: {selectedBlock?.id ?? 'none'}</div>
+  ),
+}));
+
+function setExperience(overrides: Record<string, unknown> = {}) {
+  useExperienceMock.mockReturnValue({
+    experience: {
+      id: 'exp-1',
+      code: 'FOCUSTEST',
+      hosts: [{ id: 'h1', name: 'Cam' }],
+      participants: [{ id: 'p1', name: 'Nina' }],
+      segments: [],
+      blocks: [],
+      playbill: [],
+      playbill_enabled: true,
+      ...overrides,
+    },
+    code: 'FOCUSTEST',
+    isLoading: false,
+    wsReady: true,
+  });
+}
+
+function renderPage(ui: React.ReactNode) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe('Manage subpages', () => {
+  beforeEach(() => {
+    navigate.mockReset();
+    useExperienceMock.mockReset();
+    setExperience();
+  });
+
+  it('shows participants with hosts folded in', () => {
+    renderPage(<ManageParticipantsPage />);
+
+    expect(screen.getByRole('heading', { name: 'Participants' })).toBeInTheDocument();
+    expect(screen.getByText('participants: 2')).toBeInTheDocument();
+  });
+
+  it('shows the playbill', () => {
+    renderPage(<ManagePlaybillPage />);
+
+    expect(screen.getByRole('heading', { name: 'Playbill' })).toBeInTheDocument();
+    expect(screen.getByText('playbill enabled: true')).toBeInTheDocument();
+  });
+
+  it('hands the open block to the debug panel', () => {
+    setExperience({
+      blocks: [
+        { id: 'closed-1', kind: BlockKind.POLL, status: 'closed', position: 0, payload: {} },
+        { id: 'open-1', kind: BlockKind.POLL, status: 'open', position: 1, payload: {} },
+      ],
+    });
+    renderPage(<ManageDebugPage />);
+
+    expect(screen.getByRole('heading', { name: 'Debug' })).toBeInTheDocument();
+    expect(screen.getByText('debug block: open-1')).toBeInTheDocument();
+  });
+
+  it('copes with no open block on the debug page', () => {
+    renderPage(<ManageDebugPage />);
+
+    expect(screen.getByText('debug block: none')).toBeInTheDocument();
+  });
+
+  it('routes back to focus mode', async () => {
+    const user = userEvent.setup();
+    renderPage(<ManageParticipantsPage />);
+
+    await user.click(screen.getByRole('button', { name: /back/i }));
+
+    expect(navigate).toHaveBeenCalledWith('/experiences/FOCUSTEST/manage/focus');
+  });
+
+  it('waits for the websocket before rendering', () => {
+    useExperienceMock.mockReturnValue({
+      experience: null,
+      code: 'FOCUSTEST',
+      isLoading: false,
+      wsReady: false,
+    });
+    renderPage(<ManageParticipantsPage />);
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Participants' })).not.toBeInTheDocument();
+  });
+});

--- a/app/frontend/Pages/Manage/Subpages/ManageSubpages.test.tsx
+++ b/app/frontend/Pages/Manage/Subpages/ManageSubpages.test.tsx
@@ -4,9 +4,9 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { BlockKind } from '@cctv/types';
-import type { Block } from '@cctv/types';
+import type { Block, Experience } from '@cctv/types';
 
+import { experience, participant, pollBlock } from '../testFactories';
 import ManageDebugPage from './ManageDebugPage';
 import ManageParticipantsPage from './ManageParticipantsPage';
 import ManagePlaybillPage from './ManagePlaybillPage';
@@ -43,19 +43,15 @@ vi.mock('../Viewer/DebugPanel/DebugPanel', () => ({
   ),
 }));
 
-function setExperience(overrides: Record<string, unknown> = {}) {
+function setExperience(overrides: Partial<Experience> = {}) {
   useExperienceMock.mockReturnValue({
-    experience: {
-      id: 'exp-1',
-      code: 'FOCUSTEST',
-      hosts: [{ id: 'h1', name: 'Cam' }],
-      participants: [{ id: 'p1', name: 'Nina' }],
-      segments: [],
-      blocks: [],
+    experience: experience({
+      hosts: [participant({ id: 'h1', name: 'Cam', role: 'host' })],
+      participants: [participant({ id: 'p1', name: 'Nina' })],
       playbill: [],
       playbill_enabled: true,
       ...overrides,
-    },
+    }),
     code: 'FOCUSTEST',
     isLoading: false,
     wsReady: true,
@@ -90,8 +86,8 @@ describe('Manage subpages', () => {
   it('hands the open block to the debug panel', () => {
     setExperience({
       blocks: [
-        { id: 'closed-1', kind: BlockKind.POLL, status: 'closed', position: 0, payload: {} },
-        { id: 'open-1', kind: BlockKind.POLL, status: 'open', position: 1, payload: {} },
+        pollBlock({ id: 'closed-1', status: 'closed', position: 0 }),
+        pollBlock({ id: 'open-1', status: 'open', position: 1 }),
       ],
     });
     renderPage(<ManageDebugPage />);

--- a/app/frontend/Pages/Manage/Viewer/ManageViewer.tsx
+++ b/app/frontend/Pages/Manage/Viewer/ManageViewer.tsx
@@ -1,6 +1,8 @@
-import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { BookOpen, Bug, Columns3, Pause, Play, X } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+
+import { BookOpen, Bug, Columns3, Focus, X } from 'lucide-react';
 
 import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { Button, Drawer, DrawerBody, DrawerContent } from '@cctv/core';
@@ -16,63 +18,13 @@ import { Block, ParticipantSummary } from '@cctv/types';
 
 import CreateBlock from '../CreateBlock/CreateBlock';
 import EditBlock from '../EditBlock/EditBlock';
+import ExperienceActionButton from '../ExperienceActionButton';
+import { getManageMode, setManageMode } from '../Focus/useManageMode';
 import ParticipantsTab from '../ParticipantsTab/ParticipantsTab';
 import PlaybillTab from '../PlaybillTab/PlaybillTab';
 import BlockDetailPanel from './BlockDetailPanel';
 import BlockSidebar from './BlockSidebar';
 import DebugPanel from './DebugPanel/DebugPanel';
-
-function ExperienceActionButton() {
-  const { experience } = useExperience();
-  const { startExperience } = useExperienceStart();
-  const { pauseExperience } = useExperiencePause();
-  const { resumeExperience } = useExperienceResume();
-
-  if (!experience) return null;
-
-  const config = useMemo<{
-    onClick: () => void;
-    icon: ReactNode;
-    label: string;
-    variant?: 'primary' | 'secondary' | 'ghost';
-  } | null>(() => {
-    switch (experience.status) {
-      case 'draft':
-      case 'lobby':
-        return {
-          onClick: startExperience,
-          icon: <Play size={16} />,
-          label: 'Start',
-          variant: 'primary',
-        };
-      case 'live':
-        return {
-          onClick: pauseExperience,
-          icon: <Pause size={16} />,
-          label: 'Pause',
-          variant: 'secondary',
-        };
-      case 'paused':
-        return {
-          onClick: resumeExperience,
-          icon: <Play size={16} />,
-          label: 'Resume',
-          variant: 'primary',
-        };
-      default:
-        return null;
-    }
-  }, [startExperience, pauseExperience, resumeExperience, experience?.status]);
-
-  if (!config) return null;
-
-  return (
-    <Button title={config.label} variant={config.variant} onClick={config.onClick}>
-      {config.icon}
-      <span>{config.label}</span>
-    </Button>
-  );
-}
 
 export default function ManageViewer() {
   const [selectedBlockId, setSelectedBlockId] = useState<string | null>(null);
@@ -101,8 +53,12 @@ export default function ManageViewer() {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
+  const navigate = useNavigate();
+  const redirectedRef = useRef(false);
+
   const {
     experience,
+    code,
     error: experienceError,
     isLoading,
     wsReady,
@@ -124,6 +80,14 @@ export default function ManageViewer() {
     busyBlockId,
     statusError,
   } = useBlockPresentation();
+
+  useEffect(() => {
+    if (redirectedRef.current || !code) return;
+    redirectedRef.current = true;
+    if (getManageMode() === 'focus') {
+      navigate(`/experiences/${code}/manage/focus`, { replace: true });
+    }
+  }, [code, navigate]);
 
   const { reorder: reorderBlock } = useReorderBlock();
   const { detach: detachFromParent, error: detachError } = useDetachBlockFromParent();
@@ -243,6 +207,17 @@ export default function ManageViewer() {
             </div>
             <div className="flex items-center gap-2">
               <ExperienceActionButton />
+              <Button
+                onClick={() => {
+                  setManageMode('focus');
+                  navigate(`/experiences/${code}/manage/focus`);
+                }}
+                variant="secondary"
+                title="Focus mode"
+              >
+                <Focus size={16} />
+                <span>Focus</span>
+              </Button>
               <Button
                 to={`/experiences/${experience?.code}/timeline`}
                 variant="secondary"

--- a/app/frontend/Pages/Manage/testFactories.ts
+++ b/app/frontend/Pages/Manage/testFactories.ts
@@ -1,0 +1,215 @@
+import {
+  AnnouncementBlock,
+  Block,
+  BlockKind,
+  BuzzerBlock,
+  Experience,
+  ExperienceParticipant,
+  FamilyFeudBlock,
+  GuessWhoBlock,
+  MinigameArithmeticBlock,
+  MinigameBalloonPumpBlock,
+  PhotoUploadBlock,
+  PollBlock,
+  QuestionBlock,
+  TheSceneBlock,
+} from '@cctv/types';
+
+type BlockDefaults = Pick<Block, 'status' | 'position'>;
+
+const blockDefaults: BlockDefaults = { status: 'hidden', position: 0 };
+
+export function pollBlock(overrides: Partial<PollBlock> = {}): PollBlock {
+  return {
+    ...blockDefaults,
+    id: 'block-poll',
+    kind: BlockKind.POLL,
+    payload: { question: 'Best opener?', options: ['Improv set', 'Stand-up'] },
+    ...overrides,
+  };
+}
+
+export function questionBlock(overrides: Partial<QuestionBlock> = {}): QuestionBlock {
+  return {
+    ...blockDefaults,
+    id: 'block-question',
+    kind: BlockKind.QUESTION,
+    payload: { question: 'Worst advice you have been given?', formKey: 'worst_advice' },
+    ...overrides,
+  };
+}
+
+export function announcementBlock(overrides: Partial<AnnouncementBlock> = {}): AnnouncementBlock {
+  return {
+    ...blockDefaults,
+    id: 'block-announcement',
+    kind: BlockKind.ANNOUNCEMENT,
+    payload: { message: 'Phones out.' },
+    ...overrides,
+  };
+}
+
+export function familyFeudBlock(overrides: Partial<FamilyFeudBlock> = {}): FamilyFeudBlock {
+  return {
+    ...blockDefaults,
+    id: 'block-family-feud',
+    kind: BlockKind.FAMILY_FEUD,
+    payload: { title: 'Name something in a green room' },
+    ...overrides,
+  };
+}
+
+export function photoUploadBlock(overrides: Partial<PhotoUploadBlock> = {}): PhotoUploadBlock {
+  return {
+    ...blockDefaults,
+    id: 'block-photo-upload',
+    kind: BlockKind.PHOTO_UPLOAD,
+    payload: { prompt: 'Show us your worst headshot' },
+    ...overrides,
+  };
+}
+
+export function buzzerBlock(overrides: Partial<BuzzerBlock> = {}): BuzzerBlock {
+  return {
+    ...blockDefaults,
+    id: 'block-buzzer',
+    kind: BlockKind.BUZZER,
+    payload: { label: 'Buzz in' },
+    ...overrides,
+  };
+}
+
+export function guessWhoBlock(overrides: Partial<GuessWhoBlock> = {}): GuessWhoBlock {
+  return {
+    ...blockDefaults,
+    id: 'block-guess-who',
+    kind: BlockKind.GUESS_WHO,
+    payload: { contestants: [], monitor_view: 'idle' },
+    ...overrides,
+  };
+}
+
+export function minigameArithmeticBlock(
+  overrides: Partial<MinigameArithmeticBlock> = {},
+): MinigameArithmeticBlock {
+  return {
+    ...blockDefaults,
+    id: 'block-minigame-arithmetic',
+    kind: BlockKind.MINIGAME_ARITHMETIC,
+    payload: {
+      variant: 'arithmetic',
+      duration_seconds: 60,
+      question_count: 10,
+      leaderboard_size: 5,
+      started_at: null,
+      ended_at: null,
+    },
+    ...overrides,
+  };
+}
+
+export function minigameBalloonPumpBlock(
+  overrides: Partial<MinigameBalloonPumpBlock> = {},
+): MinigameBalloonPumpBlock {
+  return {
+    ...blockDefaults,
+    id: 'block-minigame-balloon-pump',
+    kind: BlockKind.MINIGAME_BALLOON_PUMP,
+    payload: {
+      variant: 'balloon_pump',
+      target_units: 100,
+      started_at: null,
+      ended_at: null,
+      leader_fill: 0,
+      leader_participant_id: null,
+      winner_participant_ids: [],
+    },
+    ...overrides,
+  };
+}
+
+export function theSceneBlock(overrides: Partial<TheSceneBlock> = {}): TheSceneBlock {
+  return {
+    ...blockDefaults,
+    id: 'block-the-scene',
+    kind: BlockKind.THE_SCENE,
+    payload: {
+      phase: 'collecting',
+      scene_started_at: null,
+      winner_revealed_at: null,
+      leaderboard_size: 5,
+      prompt_input_count: 3,
+      performer_participant_ids: [],
+      prompt_participant_ids: [],
+      buzzer_participant_id: null,
+      leaderboard: [],
+      performers: [],
+    },
+    ...overrides,
+  };
+}
+
+export function blockOfKind(kind: BlockKind): Block {
+  switch (kind) {
+    case BlockKind.POLL:
+      return pollBlock();
+    case BlockKind.QUESTION:
+      return questionBlock();
+    case BlockKind.ANNOUNCEMENT:
+      return announcementBlock();
+    case BlockKind.FAMILY_FEUD:
+      return familyFeudBlock();
+    case BlockKind.PHOTO_UPLOAD:
+      return photoUploadBlock();
+    case BlockKind.BUZZER:
+      return buzzerBlock();
+    case BlockKind.GUESS_WHO:
+      return guessWhoBlock();
+    case BlockKind.MINIGAME_ARITHMETIC:
+      return minigameArithmeticBlock();
+    case BlockKind.MINIGAME_BALLOON_PUMP:
+      return minigameBalloonPumpBlock();
+    case BlockKind.THE_SCENE:
+      return theSceneBlock();
+    default: {
+      const exhaustiveCheck: never = kind;
+      throw new Error(`Unhandled block kind: ${exhaustiveCheck}`);
+    }
+  }
+}
+
+export function participant(overrides: Partial<ExperienceParticipant> = {}): ExperienceParticipant {
+  return {
+    id: 'participant-1',
+    user_id: 'user-1',
+    experience_id: 'experience-1',
+    name: 'Nina',
+    email: 'nina@example.test',
+    status: 'registered',
+    role: 'audience',
+    joined_at: null,
+    fingerprint: null,
+    created_at: '2026-08-07T00:00:00Z',
+    updated_at: '2026-08-07T00:00:00Z',
+    ...overrides,
+  };
+}
+
+export function experience(overrides: Partial<Experience> = {}): Experience {
+  return {
+    id: 'experience-1',
+    name: 'Focus Mode Test',
+    code: 'FOCUSTEST',
+    code_slug: 'focustest',
+    url: 'http://localhost:3000/experiences/focustest',
+    status: 'lobby',
+    creator_id: 'user-1',
+    hosts: [],
+    participants: [],
+    blocks: [],
+    segments: [],
+    created_at: '2026-08-07T00:00:00Z',
+    updated_at: '2026-08-07T00:00:00Z',
+    ...overrides,
+  };
+}


### PR DESCRIPTION
The manage page presents everything at once — a block sidebar, a detail panel, and a participants drawer — which is more than a host needs while running a show. Focus Mode is an experiment in narrowing that to one decision at a time: Select, Create/Edit, Play, Finish.

Adds /manage/focus alongside the existing manage page rather than replacing it, so the two can be compared during a real show. A Focus button on the manage page and a Full manage view item in Focus Mode switch between them, and the choice is remembered in localStorage.

The select screen shows one tile per activity kind, each with a small preview of the shape it takes on screen. Drafts (blocks with status hidden) appear alongside them, labelled with their own question text. A History tab lists finished activities newest first and opens a read-only review with the monitor view and the full response list.

Choosing a tile opens the kind's editor full screen with two actions: Play puts it on the monitor immediately, Save as draft returns it to the select screen for later. Once live, the stage shows the monitor preview and a response count, with the existing Family Feud and Guess Who managers embedded for their reveal steps. Finish closes the block, which returns the monitor to its idle state on its own.

Participants, Playbill, and Debug move out of the main surface onto their own routes, reachable from a single overflow menu.

To avoid duplicating the per-kind form switches, CreateBlock and EditBlock now export their field groups, and CreateBlockProvider takes an initialKind so a tile click seeds the right form. ExperienceActionButton moves out of ManageViewer into a shared component; its useMemo sat after an early return, which is a conditional hook call, so that is fixed in the move.

History is ordered by block position because serialize_block does not emit timestamps. Positions increment as blocks are created, so this matches creation order but would diverge if blocks were reordered.

Reveal is wired only for Family Feud and Guess Who, which already have the mechanic. Poll has none: serialize_response_data sends its aggregate to hosts and moderators only, so revealing results on the monitor needs a backend change and is left for follow-up.
