### PR TITLE
Reduce redundant DB loads in broadcast update

### DIFF
--- a/app/services/experiences/broadcaster.rb
+++ b/app/services/experiences/broadcaster.rb
@@ -49,20 +49,23 @@ class Experiences::Broadcaster
       .where("target_user_ids IS NOT NULL AND cardinality(target_user_ids) > 0")
       .pluck(:id, :target_user_ids)
 
+    visibility = Experiences::Visibility.new(experience)
+
     experience.experience_participants.includes(:user, :experience_segments)
       .group_by { |p| self.class.visibility_fingerprint(experience, p, targeted_block_data: targeted_block_data) }
       .each do |fingerprint, participants|
         rep = participants.first
         broadcast_to_profile(
           self.class.profile_stream_key(experience, fingerprint),
-          role:     rep.role,
-          segments: rep.experience_segments.map(&:name),
-          user_id:  rep.user_id
+          role:       rep.role,
+          segments:   rep.experience_segments.map(&:name),
+          user_id:    rep.user_id,
+          visibility: visibility
         )
       end
 
-    broadcast_monitor_view
-    broadcast_admin_view
+    broadcast_monitor_view(visibility: visibility)
+    broadcast_admin_view(visibility: visibility)
   end
 
   def broadcast_family_feud_update(block_id:, operation:, data:)
@@ -101,9 +104,9 @@ class Experiences::Broadcaster
     )
   end
 
-  def broadcast_monitor_view
+  def broadcast_monitor_view(visibility:)
     begin
-      payload = Experiences::Visibility.for_monitor(experience)
+      payload = visibility.for_monitor
 
       send_broadcast(
         self.class.monitor_stream_key(experience),
@@ -125,9 +128,9 @@ class Experiences::Broadcaster
     end
   end
 
-  def broadcast_admin_view
+  def broadcast_admin_view(visibility:)
     begin
-      payload = Experiences::Visibility.for_admin(experience)
+      payload = visibility.for_admin
 
       send_broadcast(
         self.class.admin_stream_key(experience),
@@ -152,9 +155,9 @@ class Experiences::Broadcaster
     end
   end
 
-  def broadcast_to_profile(stream_key, role:, segments:, user_id: nil)
+  def broadcast_to_profile(stream_key, role:, segments:, user_id: nil, visibility:)
     begin
-      payload = Experiences::Visibility.for_profile(experience, role: role, segments: segments, user_id: user_id)
+      payload = visibility.for_profile(role: role, segments: segments, user_id: user_id)
 
       send_broadcast(
         stream_key,

--- a/app/services/experiences/visibility.rb
+++ b/app/services/experiences/visibility.rb
@@ -127,7 +127,7 @@ module Experiences
     end
 
     def monitor_visible_blocks
-      all      = @experience.experience_blocks.includes(:experience_segments).order(position: :asc).to_a
+      all      = all_blocks_with_segments
       parents  = all.select(&:parent_block?)
       children = all.reject(&:parent_block?)
       children_by_parent = children.group_by(&:parent_block_id)
@@ -160,7 +160,7 @@ module Experiences
     end
 
     def participant_visible_blocks(participant)
-      all     = @experience.experience_blocks.includes(:experience_segments).order(position: :asc).to_a
+      all     = all_blocks_with_segments
       parents = all.select(&:parent_block?)
 
       return parents if host_or_moderator?(participant.role)
@@ -175,7 +175,7 @@ module Experiences
     end
 
     def profile_visible_blocks(role:, segments:, user_id: nil)
-      all     = @experience.experience_blocks.includes(:experience_segments).order(position: :asc).to_a
+      all     = all_blocks_with_segments
       parents = all.select(&:parent_block?)
 
       return parents if host_or_moderator?(role)
@@ -739,7 +739,7 @@ module Experiences
 
     def experience_payload(blocks:, **extra)
       base_url     = Rails.application.config.app_base_url
-      participants = @experience.experience_participants.includes(:user, :experience_segments).to_a
+      participants = loaded_participants
 
       result = {
         id:               @experience.id,
@@ -786,15 +786,14 @@ module Experiences
     end
 
     def serialize_segments
-      @experience.experience_segments.order(position: :asc).map do |s|
+      loaded_segments.map do |s|
         { id: s.id, name: s.name, color: s.color, position: s.position }
       end
     end
 
     def serialize_playbill_running_order
-      @experience.experience_blocks
-        .where(parent_block_id: nil, add_to_playbill: true)
-        .order(position: :asc)
+      all_blocks_with_segments
+        .select { |b| b.parent_block_id.nil? && b.add_to_playbill }
         .map do |block|
           {
             id:                  block.id,
@@ -871,6 +870,23 @@ module Experiences
 
     def attachment_url(attachment)
       attachment.attached? ? ActiveStorageUrlService.blob_url(attachment.blob) : nil
+    end
+
+    def all_blocks_with_segments
+      @all_blocks_with_segments ||= @experience.experience_blocks
+        .includes(:experience_segments)
+        .order(position: :asc)
+        .to_a
+    end
+
+    def loaded_participants
+      @loaded_participants ||= @experience.experience_participants
+        .includes(:user, :experience_segments)
+        .to_a
+    end
+
+    def loaded_segments
+      @loaded_segments ||= @experience.experience_segments.order(position: :asc).to_a
     end
 
     def host_or_moderator?(role)


### PR DESCRIPTION
Replace per-broadcast Visibility instantiation with a single shared instance per broadcast cycle. Memoize block, participant, and segment loads within the instance so they are executed once regardless of how many unique visibility profiles exist.

Previously, each unique profile group triggered a full ExperienceBlock load, and participants and segments were reloaded for every stream (profile × N, monitor, admin). With N segments producing N profiles, block loads scaled as N+2 per broadcast job.