### PR TITLE
Add avatar cosmetics: inventory, decorate/background modes, frames

### DIFF
--- a/app/channels/experience_subscription_channel.rb
+++ b/app/channels/experience_subscription_channel.rb
@@ -195,13 +195,21 @@ class ExperienceSubscriptionChannel < ApplicationCable::Channel
       # doesn't scale, so this should be de-coupled from the initial fetch in
       # the future
       @experience.experience_participants.includes(:user).each do |p|
-        next unless p.avatar.present? && p.avatar['strokes'].present?
+        next unless p.avatar.present?
+
+        data =
+          if p.avatar['image'].present?
+            { image: p.avatar['image'], cosmetics: p.avatar['cosmetics'] || [] }
+          elsif p.avatar['strokes'].present?
+            { strokes: p.avatar['strokes'] }
+          end
+        next unless data
 
         transmit({
           type: 'drawing_update',
           participant_id: p.id,
           operation: 'avatar_committed',
-          data: { strokes: p.avatar['strokes'] }
+          data: data
         })
       end
     when 'impersonation'

--- a/app/controllers/api/experience_avatar_controller.rb
+++ b/app/controllers/api/experience_avatar_controller.rb
@@ -9,7 +9,11 @@ class Api::ExperienceAvatarController < Api::BaseController
   def create
     with_experience_orchestration do
       participant = Experiences::Orchestrator.new(experience: @experience, actor: @user)
-        .update_participant_avatar!(participant: @participant, strokes: params.dig(:avatar, :strokes))
+        .update_participant_avatar!(
+          participant: @participant,
+          image: params.dig(:avatar, :image),
+          cosmetics: params.dig(:avatar, :cosmetics)
+        )
 
       Experiences::Broadcaster.enqueue_update(@experience)
 
@@ -19,7 +23,10 @@ class Api::ExperienceAvatarController < Api::BaseController
           type: 'drawing_update',
           participant_id: participant.id,
           operation: 'avatar_committed',
-          data: { strokes: participant.avatar['strokes'] || [] }
+          data: {
+            image: participant.avatar['image'],
+            cosmetics: participant.avatar['cosmetics'] || []
+          }
         }
       )
 

--- a/app/controllers/api/experience_cosmetics_controller.rb
+++ b/app/controllers/api/experience_cosmetics_controller.rb
@@ -1,0 +1,23 @@
+class Api::ExperienceCosmeticsController < Api::BaseController
+  before_action :authenticate_and_set_user_and_experience
+  before_action :set_participant!
+  before_action -> { authorize! @participant, to: :show? }
+
+  after_action :verify_authorized
+
+  # GET /api/experiences/:id/cosmetics
+  def index
+    cosmetics = @user.cosmetics.merge(Cosmetic.active).order(:name)
+    render json: { cosmetics: cosmetics.map { |c| CosmeticSerializer.serialize(c) } }
+  end
+
+  private
+
+  def set_participant!
+    @participant = @experience.experience_participants.find_by(user: @user)
+    unless @participant
+      skip_verify_authorized!
+      render json: { success: false, error: 'participant not found' }, status: :not_found
+    end
+  end
+end

--- a/app/frontend/Components/Avatar/LobbyAvatarEditor.module.scss
+++ b/app/frontend/Components/Avatar/LobbyAvatarEditor.module.scss
@@ -6,6 +6,13 @@
   align-items: center;
 }
 
+.modeToggle {
+  display: flex;
+  gap: var(--space-xs);
+  align-items: center;
+  justify-content: center;
+}
+
 .stageWrap {
   width: 100%;
   max-width: 480px;

--- a/app/frontend/Components/Avatar/LobbyAvatarEditor.tsx
+++ b/app/frontend/Components/Avatar/LobbyAvatarEditor.tsx
@@ -1,11 +1,19 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
+import { CosmeticInventory, DRAW_SIZE, applyCosmetic } from '@cctv/components/Cosmetics';
 import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { useUser } from '@cctv/contexts/UserContext';
+import { Button } from '@cctv/core';
+import { useCosmetics } from '@cctv/hooks/useCosmetics';
 import { useSaveAvatar } from '@cctv/hooks/useSaveAvatar';
-import { AvatarStroke } from '@cctv/types';
+import { Cosmetic, CosmeticPlacement } from '@cctv/types';
 
-import DrawingCanvas from '../DrawingCanvas/DrawingCanvas';
+import DrawingCanvas, {
+  DrawingCanvasMode,
+  DrawingCanvasSubmission,
+} from '../DrawingCanvas/DrawingCanvas';
+
+import styles from './LobbyAvatarEditor.module.scss';
 
 export default function LobbyAvatarEditor({
   onFinalize,
@@ -17,21 +25,79 @@ export default function LobbyAvatarEditor({
   const { participant, experiencePerform } = useExperience();
   const { user } = useUser();
   const { saveAvatar } = useSaveAvatar();
+  const { cosmetics: ownedCosmetics, isLoading, error } = useCosmetics();
+
+  const [mode, setMode] = useState<DrawingCanvasMode>('draw');
 
   const initialStrokes = useMemo(
     () => participant?.avatar?.strokes ?? user?.most_recent_avatar?.strokes ?? [],
     [participant?.avatar, user?.most_recent_avatar],
   );
 
+  // A finalized avatar is a flattened image; reload it so re-editing keeps the
+  // prior drawing and background (strokes are not preserved by design).
+  const initialImage = participant?.avatar?.image ?? user?.most_recent_avatar?.image ?? null;
+
+  const [placements, setPlacements] = useState<CosmeticPlacement[]>(
+    () => participant?.avatar?.cosmetics ?? user?.most_recent_avatar?.cosmetics ?? [],
+  );
+
+  const handleApplyCosmetic = (cosmetic: Cosmetic) => {
+    setPlacements((prev) => applyCosmetic(prev, cosmetic, DRAW_SIZE / 2, DRAW_SIZE / 4));
+  };
+
   return (
-    <DrawingCanvas
-      initialStrokes={initialStrokes}
-      onStrokeEvent={(event) => experiencePerform?.('drawing_event', event)}
-      onSubmit={async (strokes: AvatarStroke[]) => {
-        await saveAvatar({ strokes });
-        if (!onBack) onFinalize?.();
-      }}
-      onBack={onBack}
-    />
+    <div className={styles.root}>
+      <div className={styles.modeToggle}>
+        <Button
+          variant="outline"
+          size="sm"
+          aria-pressed={mode === 'draw'}
+          onClick={() => setMode('draw')}
+        >
+          Draw
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          aria-pressed={mode === 'decorate'}
+          onClick={() => setMode('decorate')}
+        >
+          Decorate
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          aria-pressed={mode === 'background'}
+          onClick={() => setMode('background')}
+        >
+          Background
+        </Button>
+      </div>
+
+      <DrawingCanvas
+        initialStrokes={initialStrokes}
+        initialImage={initialImage}
+        cosmetics={placements}
+        onCosmeticsChange={setPlacements}
+        mode={mode}
+        onStrokeEvent={(event) => experiencePerform?.('drawing_event', event)}
+        onSubmit={async ({ image, cosmetics }: DrawingCanvasSubmission) => {
+          await saveAvatar({ image, cosmetics });
+          if (!onBack) onFinalize?.();
+        }}
+        onBack={onBack}
+      />
+
+      {mode === 'decorate' ? (
+        <CosmeticInventory
+          cosmetics={ownedCosmetics}
+          isLoading={isLoading}
+          error={error}
+          onApply={handleApplyCosmetic}
+          onClearFrame={() => setPlacements((prev) => prev.filter((p) => p.category !== 'frame'))}
+        />
+      ) : null}
+    </div>
   );
 }

--- a/app/frontend/Components/Cosmetics/CosmeticInventory.module.scss
+++ b/app/frontend/Components/Cosmetics/CosmeticInventory.module.scss
@@ -1,0 +1,97 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  width: 100%;
+}
+
+.barSelect {
+  width: 100%;
+  padding: var(--space-xs) var(--space-sm);
+  background: hsl(var(--muted));
+  border: 1px solid hsl(var(--border));
+  border-radius: 8px;
+  cursor: pointer;
+  font-family: var(--font-ui);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.85rem;
+  color: hsl(var(--foreground));
+
+  &:hover {
+    border-color: hsl(var(--ring));
+  }
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  min-width: 0;
+}
+
+.row {
+  display: flex;
+  gap: var(--space-xs);
+  overflow-x: auto;
+  padding: 4px 2px;
+  scrollbar-width: thin;
+  -webkit-overflow-scrolling: touch;
+}
+
+.item {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  width: 72px;
+  padding: var(--space-xs);
+  background: hsl(var(--muted));
+  border: 1px solid hsl(var(--border));
+  border-radius: 8px;
+  cursor: grab;
+  color: hsl(var(--foreground));
+
+  &:active {
+    cursor: grabbing;
+  }
+
+  &:hover {
+    border-color: hsl(var(--ring));
+  }
+}
+
+.thumb {
+  width: 48px;
+  height: 48px;
+  object-fit: contain;
+  pointer-events: none;
+}
+
+.noneItem {
+  cursor: pointer;
+}
+
+.noneThumb {
+  width: 48px;
+  height: 48px;
+  border-radius: 8px;
+  border: 1px dashed hsl(var(--border));
+  background:
+    linear-gradient(45deg, transparent 46%, var(--red) 46%, var(--red) 54%, transparent 54%),
+    hsl(var(--muted));
+}
+
+.label {
+  font-size: 0.7rem;
+  line-height: 1;
+  text-align: center;
+  color: hsl(var(--muted-foreground));
+}
+
+.empty {
+  font-size: 0.8rem;
+  color: hsl(var(--muted-foreground));
+  padding: 0.25rem 0;
+}

--- a/app/frontend/Components/Cosmetics/CosmeticInventory.stories.tsx
+++ b/app/frontend/Components/Cosmetics/CosmeticInventory.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Cosmetic } from '@cctv/types';
+
+import CosmeticInventory from './CosmeticInventory';
+
+const hat: Cosmetic = {
+  id: 'hat-1',
+  name: 'Top Hat',
+  slug: 'top-hat',
+  kind: 'hat',
+  category: 'clothing',
+  asset_key: 'hat',
+  default_placement: { x: 100, y: 24, width: 120, height: 96, rotation: 0 },
+};
+
+const frame: Cosmetic = {
+  id: 'frame-1',
+  name: 'Beta Tester',
+  slug: 'beta-tester-frame',
+  kind: 'frame',
+  category: 'frame',
+  asset_key: 'beta_tester_frame',
+  default_placement: { x: 0, y: 0, width: 320, height: 320, rotation: 0 },
+};
+
+const meta: Meta<typeof CosmeticInventory> = {
+  title: 'Components/CosmeticInventory',
+  component: CosmeticInventory,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Shows the cosmetics a participant owns; each can be dragged onto the avatar canvas or clicked/tapped to apply.\n\n' +
+          '**Manual testing:** admin and superadmin accounts bypass the avatar drawing screen, so use the seeded non-admin user `cosmetics_test_user@gmail.com` (role `user`) to reach it. That account owns every active cosmetic. Run `bin/rails db:seed` to (re)create it.',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof CosmeticInventory>;
+
+export const WithCosmetics: Story = {
+  args: {
+    cosmetics: [hat, frame],
+    onApply: (c) => console.log('apply', c.slug),
+    onClearFrame: () => console.log('clear frame'),
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    cosmetics: [],
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    cosmetics: [],
+    isLoading: true,
+  },
+};
+
+export const Error: Story = {
+  args: {
+    cosmetics: [],
+    error: 'Failed to load cosmetics',
+  },
+};

--- a/app/frontend/Components/Cosmetics/CosmeticInventory.tsx
+++ b/app/frontend/Components/Cosmetics/CosmeticInventory.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+
+import { Cosmetic, CosmeticCategory } from '@cctv/types';
+
+import { cosmeticAssetUrl } from './cosmeticAssets';
+import { setCosmeticDragData } from './cosmeticDrag';
+
+import styles from './CosmeticInventory.module.scss';
+
+// '' is the default, closed "Inventory" state (no category chosen).
+type Selection = '' | CosmeticCategory;
+
+export interface CosmeticInventoryProps {
+  cosmetics: Cosmetic[];
+  isLoading?: boolean;
+  error?: string | null;
+  // Fired on click/tap so cosmetics can be applied without a drag (touch).
+  onApply?: (cosmetic: Cosmetic) => void;
+  // Removes the currently applied frame (frames are one-at-a-time).
+  onClearFrame?: () => void;
+}
+
+export default function CosmeticInventory({
+  cosmetics,
+  isLoading = false,
+  error = null,
+  onApply,
+  onClearFrame,
+}: CosmeticInventoryProps) {
+  const [category, setCategory] = useState<Selection>('');
+  const items = category ? cosmetics.filter((c) => c.category === category) : [];
+
+  return (
+    <div className={styles.root}>
+      <select
+        className={styles.barSelect}
+        aria-label="Inventory"
+        value={category}
+        onChange={(e) => {
+          // SAFETY: the options are exactly '' | 'clothing' | 'frame'.
+          const next = e.target.value as Selection;
+          setCategory(next);
+        }}
+      >
+        <option value="">Inventory</option>
+        <option value="clothing">Clothing</option>
+        <option value="frame">Frames</option>
+      </select>
+
+      {category ? (
+        <div className={styles.body}>
+          {error ? (
+            <div className={styles.empty}>{error}</div>
+          ) : isLoading ? (
+            <div className={styles.empty}>Loading…</div>
+          ) : items.length === 0 ? (
+            <div className={styles.empty}>None yet</div>
+          ) : (
+            <div className={styles.row}>
+              {category === 'frame' && onClearFrame ? (
+                <button
+                  type="button"
+                  className={`${styles.item} ${styles.noneItem}`}
+                  onClick={() => onClearFrame()}
+                  title="No frame"
+                  aria-label="No frame"
+                >
+                  <span className={styles.noneThumb} aria-hidden />
+                  <span className={styles.label}>None</span>
+                </button>
+              ) : null}
+              {items.map((cosmetic) => {
+                const url = cosmeticAssetUrl(cosmetic.asset_key);
+                return (
+                  <button
+                    key={cosmetic.id}
+                    type="button"
+                    className={styles.item}
+                    draggable
+                    onDragStart={(e) => setCosmeticDragData(e.dataTransfer, cosmetic)}
+                    onClick={() => onApply?.(cosmetic)}
+                    title={cosmetic.name}
+                    aria-label={`Apply ${cosmetic.name}`}
+                  >
+                    {url ? (
+                      <img src={url} alt="" className={styles.thumb} draggable={false} />
+                    ) : null}
+                    <span className={styles.label}>{cosmetic.name}</span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/app/frontend/Components/Cosmetics/cosmeticAssets.ts
+++ b/app/frontend/Components/Cosmetics/cosmeticAssets.ts
@@ -1,0 +1,111 @@
+import { Cosmetic, CosmeticCategory, CosmeticPlacement } from '@cctv/types';
+
+// The fixed drawing/coordinate space. Cosmetic placements are stored in this
+// space and scaled uniformly (size / DRAW_SIZE) wherever an avatar is rendered.
+export const DRAW_SIZE = 320;
+
+// Builds a placement for a cosmetic. Clothing is centered on (centerX, centerY)
+// at its default size; a frame ignores the drop point and fills the canvas.
+export function placementFromCosmetic(
+  cosmetic: Cosmetic,
+  centerX: number,
+  centerY: number,
+): CosmeticPlacement {
+  if (cosmetic.category === 'frame') {
+    return {
+      cosmetic_id: cosmetic.id,
+      slug: cosmetic.slug,
+      asset_key: cosmetic.asset_key,
+      category: 'frame',
+      x: 0,
+      y: 0,
+      width: DRAW_SIZE,
+      height: DRAW_SIZE,
+      rotation: 0,
+    };
+  }
+
+  const { width, height, rotation } = cosmetic.default_placement;
+  return {
+    cosmetic_id: cosmetic.id,
+    slug: cosmetic.slug,
+    asset_key: cosmetic.asset_key,
+    category: 'clothing',
+    x: centerX - width / 2,
+    y: centerY - height / 2,
+    width,
+    height,
+    rotation,
+  };
+}
+
+// Frames render on top of clothing. Stable-sorts so clothing keeps its order.
+export function sortCosmetics<T extends { category: CosmeticCategory }>(placements: T[]): T[] {
+  return placements.toSorted(
+    (a, b) => (a.category === 'frame' ? 1 : 0) - (b.category === 'frame' ? 1 : 0),
+  );
+}
+
+// Adds a cosmetic to the current placements: clothing is appended; a frame
+// replaces any existing frame (one at a time).
+export function applyCosmetic(
+  existing: CosmeticPlacement[],
+  cosmetic: Cosmetic,
+  centerX: number,
+  centerY: number,
+): CosmeticPlacement[] {
+  const placement = placementFromCosmetic(cosmetic, centerX, centerY);
+  if (placement.category === 'frame') {
+    return [...existing.filter((p) => p.category !== 'frame'), placement];
+  }
+  return [...existing, placement];
+}
+
+// Bundled cosmetic art, keyed by the `asset_key` stored on the Cosmetic record.
+// Each entry is an inline SVG so it can be rendered as an <img> (inventory,
+// avatar overlay) and loaded into a Konva image (drawing canvas) from one source.
+const COSMETIC_SVGS = new Map<string, string>([
+  [
+    'hat',
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 96">
+    <ellipse cx="60" cy="80" rx="56" ry="12" fill="#141414"/>
+    <rect x="30" y="12" width="60" height="62" rx="5" fill="#1c1c1c"/>
+    <rect x="30" y="56" width="60" height="12" fill="#8a2433"/>
+    <ellipse cx="60" cy="13" rx="30" ry="7" fill="#242424"/>
+  </svg>`,
+  ],
+  [
+    'sunglasses',
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 60">
+    <path d="M10 20 L2 13" stroke="#141414" stroke-width="4" stroke-linecap="round"/>
+    <path d="M130 20 L138 13" stroke="#141414" stroke-width="4" stroke-linecap="round"/>
+    <path d="M56 22 Q70 12 84 22" fill="none" stroke="#141414" stroke-width="4"/>
+    <rect x="8" y="16" width="50" height="34" rx="13" fill="#0b0b0b" stroke="#141414" stroke-width="3"/>
+    <rect x="82" y="16" width="50" height="34" rx="13" fill="#0b0b0b" stroke="#141414" stroke-width="3"/>
+    <path d="M16 24 L28 22" stroke="#c8f060" stroke-width="3" stroke-linecap="round" opacity="0.7"/>
+    <path d="M90 24 L102 22" stroke="#c8f060" stroke-width="3" stroke-linecap="round" opacity="0.7"/>
+  </svg>`,
+  ],
+  // Inset outline (not clipped by the 320 window) with a cursive "Beta Tester"
+  // signature straddling the bottom edge as if part of the frame.
+  [
+    'beta_tester_frame',
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 320">
+    <rect x="16" y="16" width="288" height="288" rx="16" fill="none" stroke="#c8f060" stroke-width="4"/>
+    <rect x="24" y="24" width="272" height="272" rx="11" fill="none" stroke="#c8f060" stroke-width="1.5" opacity="0.55"/>
+    <path d="M16 44 L16 16 L44 16" fill="none" stroke="#f0ede4" stroke-width="3"/>
+    <path d="M304 276 L304 304 L276 304" fill="none" stroke="#f0ede4" stroke-width="3"/>
+    <text x="104" y="306" transform="rotate(-7 104 306)"
+      font-family="'Brush Script MT','Snell Roundhand','Segoe Script',cursive"
+      font-size="34" fill="#c8f060" stroke="#080808" stroke-width="0.6"
+      paint-order="stroke">Beta Tester</text>
+  </svg>`,
+  ],
+]);
+
+// Returns a data URL for the given asset_key, or null if unknown.
+export function cosmeticAssetUrl(assetKey: string): string | null {
+  const svg = COSMETIC_SVGS.get(assetKey);
+  if (!svg) return null;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}

--- a/app/frontend/Components/Cosmetics/cosmeticDrag.ts
+++ b/app/frontend/Components/Cosmetics/cosmeticDrag.ts
@@ -1,0 +1,20 @@
+import { Cosmetic } from '@cctv/types';
+
+export const COSMETIC_DRAG_MIME = 'application/x-cctv-cosmetic';
+
+export function setCosmeticDragData(dataTransfer: DataTransfer, cosmetic: Cosmetic) {
+  dataTransfer.setData(COSMETIC_DRAG_MIME, JSON.stringify(cosmetic));
+  dataTransfer.effectAllowed = 'copy';
+}
+
+export function getCosmeticDragData(dataTransfer: DataTransfer): Cosmetic | null {
+  const raw = dataTransfer.getData(COSMETIC_DRAG_MIME);
+  if (!raw) return null;
+  try {
+    // SAFETY: the payload was serialized by setCosmeticDragData from a Cosmetic;
+    // a malformed value throws and is caught below.
+    return JSON.parse(raw) as Cosmetic;
+  } catch {
+    return null;
+  }
+}

--- a/app/frontend/Components/Cosmetics/index.ts
+++ b/app/frontend/Components/Cosmetics/index.ts
@@ -1,0 +1,10 @@
+export { default as CosmeticInventory } from './CosmeticInventory';
+export type { CosmeticInventoryProps } from './CosmeticInventory';
+export {
+  applyCosmetic,
+  cosmeticAssetUrl,
+  DRAW_SIZE,
+  placementFromCosmetic,
+  sortCosmetics,
+} from './cosmeticAssets';
+export { COSMETIC_DRAG_MIME, getCosmeticDragData, setCosmeticDragData } from './cosmeticDrag';

--- a/app/frontend/Components/DrawingCanvas/CosmeticNode.tsx
+++ b/app/frontend/Components/DrawingCanvas/CosmeticNode.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState } from 'react';
+
+import type Konva from 'konva';
+import { Image as KonvaImage, Transformer } from 'react-konva';
+
+import { cosmeticAssetUrl } from '@cctv/components/Cosmetics';
+import { CosmeticPlacement } from '@cctv/types';
+
+interface CosmeticNodeProps {
+  placement: CosmeticPlacement;
+  // When false the cosmetic is locked: not draggable/selectable and it ignores
+  // pointer events so the user can draw over it.
+  interactive: boolean;
+  selected: boolean;
+  onSelect: () => void;
+  onChange: (next: CosmeticPlacement) => void;
+}
+
+export default function CosmeticNode({
+  placement,
+  interactive,
+  selected,
+  onSelect,
+  onChange,
+}: CosmeticNodeProps) {
+  const [image, setImage] = useState<HTMLImageElement | null>(null);
+  const nodeRef = useRef<Konva.Image>(null);
+  const transformerRef = useRef<Konva.Transformer>(null);
+
+  useEffect(() => {
+    const url = cosmeticAssetUrl(placement.asset_key);
+    if (!url) return;
+    const img = new window.Image();
+    img.addEventListener('load', () => setImage(img));
+    img.src = url;
+  }, [placement.asset_key]);
+
+  // A selected, interactive cosmetic gets a rotate handle via the Transformer.
+  const showTransformer = interactive && selected;
+  useEffect(() => {
+    if (showTransformer && transformerRef.current && nodeRef.current) {
+      transformerRef.current.nodes([nodeRef.current]);
+      transformerRef.current.getLayer()?.batchDraw();
+    }
+  }, [showTransformer, image]);
+
+  if (!image) return null;
+
+  // Render about the center so drag and rotation share the same origin.
+  const centerX = placement.x + placement.width / 2;
+  const centerY = placement.y + placement.height / 2;
+
+  const persist = () => {
+    const node = nodeRef.current;
+    if (!node) return;
+    onChange({
+      ...placement,
+      x: node.x() - placement.width / 2,
+      y: node.y() - placement.height / 2,
+      rotation: node.rotation(),
+    });
+  };
+
+  return (
+    <>
+      <KonvaImage
+        ref={nodeRef}
+        name="cosmetic"
+        image={image}
+        x={centerX}
+        y={centerY}
+        offsetX={placement.width / 2}
+        offsetY={placement.height / 2}
+        width={placement.width}
+        height={placement.height}
+        rotation={placement.rotation}
+        listening={interactive}
+        draggable={interactive}
+        onMouseDown={interactive ? onSelect : undefined}
+        onTouchStart={interactive ? onSelect : undefined}
+        onDragStart={interactive ? onSelect : undefined}
+        onDragEnd={interactive ? persist : undefined}
+        onTransformEnd={interactive ? persist : undefined}
+      />
+      {showTransformer ? (
+        <Transformer
+          ref={transformerRef}
+          rotateEnabled
+          resizeEnabled={false}
+          enabledAnchors={[]}
+          rotateAnchorOffset={22}
+          borderStroke="#c8f060"
+          borderDash={[6, 4]}
+          anchorStroke="#c8f060"
+          anchorFill="#080808"
+          anchorSize={12}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/app/frontend/Components/DrawingCanvas/DrawingCanvas.module.scss
+++ b/app/frontend/Components/DrawingCanvas/DrawingCanvas.module.scss
@@ -60,6 +60,8 @@
   gap: var(--space-xs) var(--space-xs);
   align-items: center;
   justify-content: center;
+  // Breathing room so the active swatch's outline-offset isn't clipped.
+  padding: 4px 0;
 }
 
 .sizeGroup {
@@ -72,6 +74,8 @@
   display: inline-flex;
   gap: var(--space-xs);
   align-items: center;
+  // Keep the active swatch outline (2px + 2px offset) from being clipped.
+  padding: 5px;
 }
 
 .swatch {
@@ -85,6 +89,63 @@
 .swatchActive {
   outline: 2px solid hsl(var(--ring));
   outline-offset: 2px;
+}
+
+// "No background" swatch: a red diagonal over a muted base.
+.swatchNone {
+  background:
+    linear-gradient(45deg, transparent 44%, var(--red) 44%, var(--red) 56%, transparent 56%),
+    hsl(var(--muted));
+}
+
+// Compact "click-into" tool selectors that live below the canvas.
+.tools {
+  display: flex;
+  gap: var(--space-xs);
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.toolBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-height: 36px;
+  padding: 0.35rem 0.75rem;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--muted));
+  color: hsl(var(--foreground));
+  border-radius: 9999px;
+  font-size: 0.85rem;
+  cursor: pointer;
+
+  &:hover {
+    border-color: hsl(var(--ring));
+  }
+
+  &[aria-expanded='true'] {
+    border-color: hsl(var(--ring));
+    outline: 2px solid hsl(var(--ring) / 0.25);
+    outline-offset: 1px;
+  }
+}
+
+.toolSwatch {
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  border: 1px solid hsl(var(--border));
+}
+
+.toolNone {
+  font-size: 0.75rem;
+  color: hsl(var(--muted-foreground));
+}
+
+.toolPanel {
+  flex-wrap: wrap;
+  padding: 5px;
 }
 
 .colorPickerLabel {

--- a/app/frontend/Components/DrawingCanvas/DrawingCanvas.stories.tsx
+++ b/app/frontend/Components/DrawingCanvas/DrawingCanvas.stories.tsx
@@ -10,6 +10,7 @@ const meta: Meta<typeof DrawingCanvas> = {
   args: {
     onSubmit: fn(),
     onStrokeEvent: fn(),
+    onCosmeticsChange: fn(),
   },
 };
 export default meta;
@@ -17,6 +18,37 @@ export default meta;
 type Story = StoryObj<typeof DrawingCanvas>;
 
 export const Empty: Story = {};
+
+export const BackgroundMode: Story = {
+  args: {
+    mode: 'background',
+    initialStrokes: [
+      { points: [90, 120, 150, 120, 150, 180, 90, 180, 90, 120], color: '#080808', width: 4 },
+    ],
+  },
+};
+
+export const WithCosmetic: Story = {
+  args: {
+    mode: 'decorate',
+    initialStrokes: [
+      { points: [80, 120, 160, 120, 160, 200, 80, 200, 80, 120], color: '#c8f060', width: 4 },
+    ],
+    cosmetics: [
+      {
+        cosmetic_id: 'hat-1',
+        slug: 'top-hat',
+        asset_key: 'hat',
+        category: 'clothing',
+        x: 100,
+        y: 60,
+        width: 120,
+        height: 96,
+        rotation: 0,
+      },
+    ],
+  },
+};
 
 export const WithInitialStrokes: Story = {
   args: {

--- a/app/frontend/Components/DrawingCanvas/DrawingCanvas.test.tsx
+++ b/app/frontend/Components/DrawingCanvas/DrawingCanvas.test.tsx
@@ -36,6 +36,8 @@ vi.mock('react-konva', () => ({
   ),
   Layer: ({ children }: MockLayerProps) => <div data-testid="konva-layer">{children}</div>,
   Line: ({ stroke }: MockLineProps) => <div data-testid="konva-line" data-stroke={stroke} />,
+  Rect: () => <div data-testid="konva-rect" />,
+  Image: () => <div data-testid="konva-image" />,
 }));
 
 describe('DrawingCanvas', () => {
@@ -52,13 +54,19 @@ describe('DrawingCanvas', () => {
     expect(screen.getByText('Submit')).toBeInTheDocument();
   });
 
-  it('renders brush size buttons', () => {
+  it('reveals brush size buttons after opening the Brush tool', async () => {
+    const user = userEvent.setup();
     render(<DrawingCanvas {...defaultProps} />);
 
-    expect(screen.getByText('Thin')).toBeInTheDocument();
-    expect(screen.getByText('Medium')).toBeInTheDocument();
-    expect(screen.getByText('Thick')).toBeInTheDocument();
-    expect(screen.getByText('Huge')).toBeInTheDocument();
+    // Sizes are hidden behind the compact Brush control.
+    expect(screen.queryByRole('button', { name: 'Thin' })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /^Brush:/ }));
+
+    expect(screen.getByRole('button', { name: 'Thin' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Medium' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Thick' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Huge' })).toBeInTheDocument();
   });
 
   it('disables Submit when no strokes are drawn', () => {
@@ -143,7 +151,7 @@ describe('DrawingCanvas', () => {
     expect(onStrokeEvent).toHaveBeenCalledWith({ operation: 'canvas_cleared' });
   });
 
-  it('calls onSubmit with committed strokes on Submit', async () => {
+  it('calls onSubmit with a flattened image and cosmetics on Submit', async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
     const strokes = [{ points: [10, 10, 20, 20], color: '#ff0000', width: 4 }];
@@ -152,9 +160,30 @@ describe('DrawingCanvas', () => {
 
     await user.click(screen.getByRole('button', { name: 'Submit' }));
 
-    expect(onSubmit).toHaveBeenCalledWith([
-      { points: [10, 10, 20, 20], color: '#ff0000', width: 4, committed: true },
-    ]);
+    expect(onSubmit).toHaveBeenCalledWith({
+      image: expect.any(String),
+      cosmetics: [],
+    });
+  });
+
+  it('selects a background color and submits a background-only avatar', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <DrawingCanvas onSubmit={onSubmit} mode="background" palette={['#ff0000', '#00ff00']} />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+
+    await user.click(screen.getByRole('button', { name: /^Color/ }));
+    await user.click(screen.getByRole('button', { name: 'Background #ff0000' }));
+
+    const submit = screen.getByRole('button', { name: 'Submit' });
+    expect(submit).toBeEnabled();
+
+    await user.click(submit);
+    expect(onSubmit).toHaveBeenCalledWith({ image: expect.any(String), cosmetics: [] });
   });
 
   it('shows Save button instead of Submit when onBack is provided', () => {
@@ -164,7 +193,7 @@ describe('DrawingCanvas', () => {
     expect(screen.queryByRole('button', { name: 'Submit' })).not.toBeInTheDocument();
   });
 
-  it('calls onSubmit with committed strokes and onBack on Save', async () => {
+  it('calls onSubmit with a flattened image and onBack on Save', async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
     const onBack = vi.fn();
@@ -174,9 +203,10 @@ describe('DrawingCanvas', () => {
 
     await user.click(screen.getByRole('button', { name: 'Save' }));
 
-    expect(onSubmit).toHaveBeenCalledWith([
-      { points: [10, 10, 20, 20], color: '#ff0000', width: 4, committed: true },
-    ]);
+    expect(onSubmit).toHaveBeenCalledWith({
+      image: expect.any(String),
+      cosmetics: [],
+    });
     expect(onBack).toHaveBeenCalled();
   });
 

--- a/app/frontend/Components/DrawingCanvas/DrawingCanvas.tsx
+++ b/app/frontend/Components/DrawingCanvas/DrawingCanvas.tsx
@@ -1,9 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { Layer, Line, Stage } from 'react-konva';
+import { Image as KonvaImage, Layer, Line, Rect, Stage } from 'react-konva';
 
+import { applyCosmetic, getCosmeticDragData } from '@cctv/components/Cosmetics';
 import { Button } from '@cctv/core/Button/Button';
-import { AvatarStroke } from '@cctv/types';
+import { AvatarStroke, CosmeticPlacement } from '@cctv/types';
+
+import CosmeticNode from './CosmeticNode';
+import { flattenStrokesToDataUrl } from './flatten';
 
 import styles from './DrawingCanvas.module.scss';
 
@@ -22,13 +26,27 @@ interface CanvasStroke extends AvatarStroke {
   id: string;
 }
 
+export interface DrawingCanvasSubmission {
+  image: string;
+  cosmetics: CosmeticPlacement[];
+}
+
+export type DrawingCanvasMode = 'draw' | 'decorate' | 'background';
+
 export interface DrawingCanvasProps {
   initialStrokes?: AvatarStroke[];
+  // A previously flattened avatar image, shown as the base layer when re-editing.
+  initialImage?: string | null;
+  cosmetics?: CosmeticPlacement[];
+  onCosmeticsChange?: (next: CosmeticPlacement[]) => void;
+  // 'draw' lets the user draw and locks cosmetics; 'decorate' locks drawing and
+  // lets the user move/remove clothing.
+  mode?: DrawingCanvasMode;
   palette?: string[];
   brushSizes?: number[];
   drawSize?: { w: number; h: number };
   onStrokeEvent?: (event: DrawingCanvasEvent) => void;
-  onSubmit: (strokes: AvatarStroke[]) => void | Promise<void>;
+  onSubmit: (submission: DrawingCanvasSubmission) => void | Promise<void>;
   onBack?: () => void;
 }
 
@@ -42,6 +60,7 @@ const DEFAULT_PALETTE_VARS = [
 ] as const;
 
 const NO_INITIAL_STROKES: AvatarStroke[] = [];
+const NO_COSMETICS: CosmeticPlacement[] = [];
 const DEFAULT_BRUSH_SIZES = [2, 4, 8, 32];
 const DEFAULT_DRAW_SIZE = { w: 320, h: 320 };
 
@@ -65,8 +84,17 @@ function resolveCssVar(name: string) {
   return v || '#000000';
 }
 
+function handleDragOver(e: React.DragEvent) {
+  e.preventDefault();
+  e.dataTransfer.dropEffect = 'copy';
+}
+
 export default function DrawingCanvas({
   initialStrokes = NO_INITIAL_STROKES,
+  initialImage = null,
+  cosmetics = NO_COSMETICS,
+  onCosmeticsChange,
+  mode = 'draw',
   palette,
   brushSizes = DEFAULT_BRUSH_SIZES,
   drawSize = DEFAULT_DRAW_SIZE,
@@ -77,7 +105,32 @@ export default function DrawingCanvas({
   const [lines, setLines] = useState<CanvasStroke[]>(() => withRenderIds(initialStrokes));
   const [clearedLines, setClearedLines] = useState<CanvasStroke[] | null>(null);
   const [isDrawing, setIsDrawing] = useState(false);
+  const [selectedCosmetic, setSelectedCosmetic] = useState<number | null>(null);
+  const [backgroundColor, setBackgroundColor] = useState<string | null>(null);
+  const [openTool, setOpenTool] = useState<'brush' | 'color' | null>(null);
+  const [baseImage, setBaseImage] = useState<HTMLImageElement | null>(null);
+  const [clearedBaseImage, setClearedBaseImage] = useState<HTMLImageElement | null>(null);
   const hasLoadedInitialRef = useRef(false);
+  const hasLoadedImageRef = useRef(false);
+
+  // Load the previously flattened avatar as the base layer (once).
+  useEffect(() => {
+    if (hasLoadedImageRef.current || !initialImage) return;
+    hasLoadedImageRef.current = true;
+    const img = new window.Image();
+    img.addEventListener('load', () => setBaseImage(img));
+    img.src = initialImage;
+  }, [initialImage]);
+
+  // Leaving decorate mode drops any cosmetic selection; changing mode collapses
+  // any open tool panel.
+  useEffect(() => {
+    if (mode !== 'decorate') setSelectedCosmetic(null);
+    setOpenTool(null);
+  }, [mode]);
+
+  const toggleTool = (tool: 'brush' | 'color') =>
+    setOpenTool((prev) => (prev === tool ? null : tool));
 
   const [penWidth, setPenWidth] = useState<number>(4);
   const [penColor, setPenColor] = useState<string>('#000000');
@@ -115,7 +168,12 @@ export default function DrawingCanvas({
   });
 
   const onPointerDown = (e: any) => {
+    // Drawing is only possible in draw mode; cosmetics are locked here.
+    if (mode !== 'draw') return;
+    // Interacting with a cosmetic (select/drag) must not start a stroke.
+    if (e?.target?.name?.() === 'cosmetic') return;
     if (e?.evt?.preventDefault) e.evt.preventDefault();
+    setSelectedCosmetic(null);
     setClearedLines(null);
     setIsDrawing(true);
     isDrawingRef.current = true;
@@ -244,7 +302,9 @@ export default function DrawingCanvas({
   const onUndo = () => {
     if (lines.length === 0 && clearedLines) {
       setLines(clearedLines);
+      setBaseImage(clearedBaseImage);
       setClearedLines(null);
+      setClearedBaseImage(null);
       onStrokeEvent?.({
         operation: 'canvas_clear_undone',
         data: { strokes: withoutRenderIds(clearedLines) },
@@ -259,10 +319,33 @@ export default function DrawingCanvas({
 
   const canUndo = lines.some((s) => !s.committed) || (lines.length === 0 && !!clearedLines);
 
+  // Flatten the background + drawing layers to a fixed-size raster; cosmetics
+  // stay a separate layer and are submitted as structured placements.
+  const buildSubmission = () => ({
+    image: flattenStrokesToDataUrl(lines, drawSize.w, backgroundColor, baseImage),
+    cosmetics,
+  });
+
   const handleSubmit = async () => {
-    const committedLines = lines.map((s) => ({ ...s, committed: true }));
-    await onSubmit(withoutRenderIds(committedLines));
-    setLines(committedLines);
+    await onSubmit(buildSubmission());
+  };
+
+  const updateCosmetic = (index: number, next: CosmeticPlacement) => {
+    onCosmeticsChange?.(cosmetics.map((c, i) => (i === index ? next : c)));
+  };
+
+  const removeCosmetic = (index: number) => {
+    onCosmeticsChange?.(cosmetics.filter((_, i) => i !== index));
+    setSelectedCosmetic(null);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    const cosmetic = getCosmeticDragData(e.dataTransfer);
+    const rect = drawWrapRef.current?.getBoundingClientRect();
+    if (!cosmetic || !rect || !onCosmeticsChange) return;
+    const dp = toDrawSpace(e.clientX - rect.left, e.clientY - rect.top);
+    onCosmeticsChange(applyCosmetic(cosmetics, cosmetic, dp.x, dp.y));
   };
 
   useEffect(() => {
@@ -284,28 +367,157 @@ export default function DrawingCanvas({
 
   return (
     <div className={styles.root}>
-      <div className={styles.toolbar}>
-        <div className={styles.sizeGroup}>
+      <div
+        ref={drawWrapRef}
+        className={`${styles.stageWrap} ${styles.square}`}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+      >
+        <Stage
+          width={drawStageSize.w}
+          height={drawStageSize.h}
+          onMouseDown={onPointerDown}
+          onMouseMove={onPointerMove}
+          onMouseUp={onPointerUp}
+          onTouchStart={onPointerDown}
+          onTouchMove={onPointerMove}
+          onTouchEnd={onPointerUp}
+        >
+          <Layer scaleX={drawScale.x} scaleY={drawScale.y}>
+            {backgroundColor ? (
+              <Rect
+                x={0}
+                y={0}
+                width={drawSize.w}
+                height={drawSize.h}
+                fill={backgroundColor}
+                listening={false}
+              />
+            ) : null}
+            {baseImage ? (
+              <KonvaImage
+                image={baseImage}
+                x={0}
+                y={0}
+                width={drawSize.w}
+                height={drawSize.h}
+                listening={false}
+              />
+            ) : null}
+            {lines.map((s) => (
+              <Line
+                key={s.id}
+                points={s.points}
+                stroke={s.color}
+                strokeWidth={s.width}
+                lineCap="round"
+              />
+            ))}
+          </Layer>
+          <Layer scaleX={drawScale.x} scaleY={drawScale.y}>
+            {cosmetics
+              .map((placement, i) => ({ placement, i }))
+              .toSorted(
+                (a, b) =>
+                  (a.placement.category === 'frame' ? 1 : 0) -
+                  (b.placement.category === 'frame' ? 1 : 0),
+              )
+              .map(({ placement, i }) => (
+                <CosmeticNode
+                  key={`${placement.cosmetic_id}-${i}`}
+                  placement={placement}
+                  interactive={mode === 'decorate' && placement.category === 'clothing'}
+                  selected={selectedCosmetic === i}
+                  onSelect={() => setSelectedCosmetic(i)}
+                  onChange={(next) => updateCosmetic(i, next)}
+                />
+              ))}
+          </Layer>
+        </Stage>
+      </div>
+
+      {mode === 'draw' ? (
+        <div className={styles.tools}>
+          <button
+            type="button"
+            className={styles.toolBtn}
+            aria-expanded={openTool === 'brush'}
+            onClick={() => toggleTool('brush')}
+          >
+            Brush:{' '}
+            {penWidth === 2
+              ? 'Thin'
+              : penWidth === 4
+                ? 'Medium'
+                : penWidth === 8
+                  ? 'Thick'
+                  : 'Huge'}
+          </button>
+          <button
+            type="button"
+            className={styles.toolBtn}
+            aria-expanded={openTool === 'color'}
+            onClick={() => toggleTool('color')}
+          >
+            Color
+            <span className={styles.toolSwatch} style={{ background: penColor }} aria-hidden />
+          </button>
+        </div>
+      ) : null}
+
+      {mode === 'background' ? (
+        <div className={styles.tools}>
+          <button
+            type="button"
+            className={styles.toolBtn}
+            aria-expanded={openTool === 'color'}
+            onClick={() => toggleTool('color')}
+          >
+            Color
+            {backgroundColor ? (
+              <span
+                className={styles.toolSwatch}
+                style={{ background: backgroundColor }}
+                aria-hidden
+              />
+            ) : (
+              <span className={styles.toolNone}>None</span>
+            )}
+          </button>
+        </div>
+      ) : null}
+
+      {mode === 'draw' && openTool === 'brush' ? (
+        <div className={`${styles.toolPanel} ${styles.sizeGroup}`}>
           {brushSizes.map((sz) => (
             <Button
               key={sz}
               variant="outline"
               size="sm"
               aria-pressed={penWidth === sz}
-              onClick={() => setPenWidth(sz)}
+              onClick={() => {
+                setPenWidth(sz);
+                setOpenTool(null);
+              }}
             >
               {sz === 2 ? 'Thin' : sz === 4 ? 'Medium' : sz === 8 ? 'Thick' : 'Huge'}
             </Button>
           ))}
         </div>
-        <div className={styles.palette}>
+      ) : null}
+
+      {mode === 'draw' && openTool === 'color' ? (
+        <div className={`${styles.toolPanel} ${styles.palette}`}>
           {colors.map((c) => (
             <button
               key={c}
               aria-label={`Color ${c}`}
               className={`${styles.swatch} ${penColor === c ? styles.swatchActive : ''}`}
               style={{ background: c }}
-              onClick={() => setPenColor(c)}
+              onClick={() => {
+                setPenColor(c);
+                setOpenTool(null);
+              }}
             />
           ))}
           <label
@@ -323,63 +535,102 @@ export default function DrawingCanvas({
             />
           </label>
         </div>
-      </div>
+      ) : null}
 
-      <div ref={drawWrapRef} className={`${styles.stageWrap} ${styles.square}`}>
-        <Stage
-          width={drawStageSize.w}
-          height={drawStageSize.h}
-          onMouseDown={onPointerDown}
-          onMouseMove={onPointerMove}
-          onMouseUp={onPointerUp}
-          onTouchStart={onPointerDown}
-          onTouchMove={onPointerMove}
-          onTouchEnd={onPointerUp}
-        >
-          <Layer scaleX={drawScale.x} scaleY={drawScale.y}>
-            {lines.map((s) => (
-              <Line
-                key={s.id}
-                points={s.points}
-                stroke={s.color}
-                strokeWidth={s.width}
-                lineCap="round"
-              />
-            ))}
-          </Layer>
-        </Stage>
-      </div>
+      {mode === 'background' && openTool === 'color' ? (
+        <div className={`${styles.toolPanel} ${styles.palette}`}>
+          <button
+            type="button"
+            aria-label="No background"
+            aria-pressed={backgroundColor === null}
+            className={`${styles.swatch} ${styles.swatchNone} ${backgroundColor === null ? styles.swatchActive : ''}`}
+            title="No background"
+            onClick={() => {
+              setBackgroundColor(null);
+              setOpenTool(null);
+            }}
+          />
+          {colors.map((c) => (
+            <button
+              key={c}
+              aria-label={`Background ${c}`}
+              aria-pressed={backgroundColor === c}
+              className={`${styles.swatch} ${backgroundColor === c ? styles.swatchActive : ''}`}
+              style={{ background: c }}
+              onClick={() => {
+                setBackgroundColor(c);
+                setOpenTool(null);
+              }}
+            />
+          ))}
+          <label
+            className={`${styles.swatch} ${styles.colorPickerLabel} ${backgroundColor && !colors.includes(backgroundColor) ? styles.swatchActive : ''}`}
+            style={
+              backgroundColor && !colors.includes(backgroundColor)
+                ? { background: backgroundColor }
+                : undefined
+            }
+            aria-label="Custom background color"
+            title="Custom background color"
+          >
+            <input
+              type="color"
+              aria-label="Custom background color"
+              className={styles.hiddenColorInput}
+              value={backgroundColor ?? '#000000'}
+              onChange={(e) => setBackgroundColor(e.target.value)}
+            />
+          </label>
+        </div>
+      ) : null}
 
       <div className={styles.controls}>
-        <Button variant="secondary" size="sm" onClick={onUndo} disabled={!canUndo}>
-          Undo
-        </Button>
-        <Button
-          variant="secondary"
-          size="sm"
-          onClick={() => {
-            if (lines.length > 0) setClearedLines(lines);
-            setLines([]);
-            onStrokeEvent?.({ operation: 'canvas_cleared' });
-          }}
-        >
-          Clear
-        </Button>
+        {mode === 'draw' ? (
+          <>
+            <Button variant="secondary" size="sm" onClick={onUndo} disabled={!canUndo}>
+              Undo
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => {
+                if (lines.length > 0 || baseImage) {
+                  setClearedLines(lines);
+                  setClearedBaseImage(baseImage);
+                }
+                setLines([]);
+                setBaseImage(null);
+                onStrokeEvent?.({ operation: 'canvas_cleared' });
+              }}
+            >
+              Clear
+            </Button>
+          </>
+        ) : null}
+        {selectedCosmetic !== null ? (
+          <Button variant="secondary" size="sm" onClick={() => removeCosmetic(selectedCosmetic)}>
+            Remove
+          </Button>
+        ) : null}
         {onBack ? (
           <Button
             variant="secondary"
             size="sm"
             onClick={async () => {
-              const committedLines = lines.map((s) => ({ ...s, committed: true }));
-              await onSubmit(withoutRenderIds(committedLines));
-              setLines(committedLines);
+              await onSubmit(buildSubmission());
               onBack();
             }}
           >
             Save
           </Button>
         ) : (
-          <Button size="sm" onClick={handleSubmit} disabled={lines.length === 0}>
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            disabled={
+              lines.length === 0 && cosmetics.length === 0 && !backgroundColor && !baseImage
+            }
+          >
             Submit
           </Button>
         )}

--- a/app/frontend/Components/DrawingCanvas/flatten.ts
+++ b/app/frontend/Components/DrawingCanvas/flatten.ts
@@ -1,0 +1,67 @@
+import { AvatarStroke } from '@cctv/types';
+
+// Rasterizes stroke data into a fixed-size PNG data URL. Strokes are stored in
+// the same coordinate space as `size` (the 320x320 draw space), so they map 1:1.
+// Every avatar is flattened to identical dimensions for predictable sizing. An
+// optional background fill is painted below the strokes and baked into the PNG.
+export function flattenStrokesToDataUrl(
+  strokes: AvatarStroke[],
+  size = 320,
+  backgroundColor?: string | null,
+  baseImage?: HTMLImageElement | null,
+): string {
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  let ctx: CanvasRenderingContext2D | null = null;
+  try {
+    ctx = canvas.getContext('2d');
+  } catch {
+    return '';
+  }
+  if (!ctx) return '';
+
+  if (backgroundColor) {
+    ctx.fillStyle = backgroundColor;
+    ctx.fillRect(0, 0, size, size);
+  }
+
+  // A previously flattened avatar (drawing + its own background) sits below the
+  // new strokes so re-editing keeps prior work.
+  if (baseImage) {
+    try {
+      ctx.drawImage(baseImage, 0, 0, size, size);
+    } catch {
+      // ignore images that fail to draw (e.g. not fully decoded)
+    }
+  }
+
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+
+  for (const stroke of strokes) {
+    const pts = stroke.points;
+    if (!pts || pts.length < 2) continue;
+
+    // A tap produces a degenerate stroke; render it as a dot.
+    const degenerate = pts.every((v, i) => v === pts[i % 2]);
+    if (degenerate) {
+      ctx.beginPath();
+      ctx.fillStyle = stroke.color;
+      ctx.arc(pts[0], pts[1], Math.max(stroke.width / 2, 0.5), 0, Math.PI * 2);
+      ctx.fill();
+      continue;
+    }
+
+    ctx.beginPath();
+    ctx.strokeStyle = stroke.color;
+    ctx.lineWidth = stroke.width;
+    ctx.moveTo(pts[0], pts[1]);
+    for (let i = 2; i + 1 < pts.length; i += 2) {
+      ctx.lineTo(pts[i], pts[i + 1]);
+    }
+    ctx.stroke();
+  }
+
+  return canvas.toDataURL('image/png');
+}

--- a/app/frontend/Contexts/LobbyDrawingContext.tsx
+++ b/app/frontend/Contexts/LobbyDrawingContext.tsx
@@ -1,11 +1,20 @@
 import { ReactNode, createContext, useContext, useReducer } from 'react';
 
+import { CosmeticPlacement } from '@cctv/types';
+
 type Stroke = { points: number[]; color: string; width: number; ended?: boolean };
-type DrawingState = { strokes: { [participantId: string]: Stroke[] } };
+type CommittedAvatar = { image: string; cosmetics: CosmeticPlacement[] };
+type DrawingState = {
+  strokes: { [participantId: string]: Stroke[] };
+  committed: { [participantId: string]: CommittedAvatar };
+};
 
 type DrawingData =
   | { operation: 'clear_all' }
-  | { operation: 'avatar_committed'; data?: { strokes: Stroke[] } }
+  | {
+      operation: 'avatar_committed';
+      data?: { strokes?: Stroke[]; image?: string; cosmetics?: CosmeticPlacement[] };
+    }
   | { operation: 'canvas_cleared' }
   | { operation: 'stroke_started'; data?: { points: number[]; color: string; width: number } }
   | { operation: 'stroke_points_appended'; data?: { points: number[] } }
@@ -15,27 +24,54 @@ type DrawingData =
 
 export type DrawingAction = { type: 'drawing_update'; participant_id: string } & DrawingData;
 
+function withoutKey<T>(map: { [k: string]: T }, key: string) {
+  const next = { ...map };
+  delete next[key];
+  return next;
+}
+
 function reducer(state: DrawingState, action: DrawingAction): DrawingState {
   const { participant_id, operation } = action;
   const existing = state.strokes[participant_id] || [];
 
   switch (operation) {
     case 'clear_all':
-      return { strokes: {} };
+      return { strokes: {}, committed: {} };
     case 'avatar_committed':
-      return { strokes: { ...state.strokes, [participant_id]: action.data?.strokes || [] } };
-    case 'canvas_cleared': {
-      const next = { ...state.strokes };
-      delete next[participant_id];
-      return { strokes: next };
-    }
+      // Flattened avatar: image + cosmetics replace any live strokes.
+      if (action.data?.image !== undefined) {
+        return {
+          strokes: withoutKey(state.strokes, participant_id),
+          committed: {
+            ...state.committed,
+            [participant_id]: {
+              image: action.data.image,
+              cosmetics: action.data.cosmetics ?? [],
+            },
+          },
+        };
+      }
+      // Legacy stroke-based commit.
+      return {
+        ...state,
+        strokes: { ...state.strokes, [participant_id]: action.data?.strokes || [] },
+      };
+    case 'canvas_cleared':
+      return {
+        strokes: withoutKey(state.strokes, participant_id),
+        committed: withoutKey(state.committed, participant_id),
+      };
     case 'stroke_started': {
       const stroke: Stroke = {
         points: action.data?.points || [],
         color: action.data?.color || '#000',
         width: action.data?.width || 4,
       };
-      return { strokes: { ...state.strokes, [participant_id]: [...existing, stroke] } };
+      // A fresh stroke means the participant is (re)drawing; drop any finalized image.
+      return {
+        strokes: { ...state.strokes, [participant_id]: [...existing, stroke] },
+        committed: withoutKey(state.committed, participant_id),
+      };
     }
     case 'stroke_points_appended': {
       if (existing.length === 0) return state;
@@ -43,7 +79,7 @@ function reducer(state: DrawingState, action: DrawingAction): DrawingState {
       const s = { ...next[next.length - 1] };
       s.points = [...s.points, ...(action.data?.points || [])];
       next[next.length - 1] = s;
-      return { strokes: { ...state.strokes, [participant_id]: next } };
+      return { ...state, strokes: { ...state.strokes, [participant_id]: next } };
     }
     case 'stroke_ended': {
       if (existing.length === 0) return state;
@@ -53,14 +89,15 @@ function reducer(state: DrawingState, action: DrawingAction): DrawingState {
         last.points = [...last.points, last.points[0], last.points[1]];
       }
       next[next.length - 1] = last;
-      return { strokes: { ...state.strokes, [participant_id]: next } };
+      return { ...state, strokes: { ...state.strokes, [participant_id]: next } };
     }
     case 'stroke_undone': {
       if (existing.length === 0) return state;
-      return { strokes: { ...state.strokes, [participant_id]: existing.slice(0, -1) } };
+      return { ...state, strokes: { ...state.strokes, [participant_id]: existing.slice(0, -1) } };
     }
     case 'canvas_clear_undone': {
       return {
+        ...state,
         strokes: { ...state.strokes, [participant_id]: action.data?.strokes || [] },
       };
     }
@@ -75,7 +112,7 @@ const LobbyDrawingDispatchContext = createContext<((action: DrawingAction) => vo
 );
 
 export function LobbyDrawingProvider({ children }: { children: ReactNode }) {
-  const [state, dispatch] = useReducer(reducer, { strokes: {} });
+  const [state, dispatch] = useReducer(reducer, { strokes: {}, committed: {} });
   return (
     <LobbyDrawingStateContext.Provider value={state}>
       <LobbyDrawingDispatchContext.Provider value={dispatch}>

--- a/app/frontend/Contexts/UserContext.tsx
+++ b/app/frontend/Contexts/UserContext.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react';
 
 import { clearAllExperienceJWTs } from '@cctv/contexts/jwtStorage';
-import { AvatarStroke, UserRole } from '@cctv/types';
+import { AvatarData, UserRole } from '@cctv/types';
 
 interface User {
   id: string;
@@ -21,7 +21,7 @@ interface User {
   admin: boolean;
   super_admin: boolean;
   most_recent_participant_name?: string;
-  most_recent_avatar?: { strokes?: AvatarStroke[] } | null;
+  most_recent_avatar?: AvatarData | null;
   performer_slug?: string | null;
 }
 

--- a/app/frontend/Experiences/Buzzer/Buzzer.tsx
+++ b/app/frontend/Experiences/Buzzer/Buzzer.tsx
@@ -1,34 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { Layer, Line, Stage } from 'react-konva';
-
 import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { useExperienceState } from '@cctv/contexts/ExperienceStateContext';
+import Avatar from '@cctv/experiences/GuessWho/Avatar';
 import { useSubmitBuzzerResponse } from '@cctv/hooks/useSubmitBuzzerResponse';
-import { AvatarStroke, BuzzerBlock } from '@cctv/types';
+import { BuzzerBlock } from '@cctv/types';
 
 import styles from './Buzzer.module.scss';
 
-const DRAW_SIZE = 320;
 const AVATAR_DISPLAY_SIZE = 280;
-const AVATAR_SCALE = AVATAR_DISPLAY_SIZE / DRAW_SIZE;
-
-interface IdentifiedStroke {
-  id: string;
-  stroke: AvatarStroke;
-}
-
-// Strokes carry no id, so identity comes from the drawn geometry plus an
-// occurrence counter that keeps repeated identical marks distinct.
-function identifyStrokes(strokes: AvatarStroke[]): IdentifiedStroke[] {
-  const occurrences = new Map<string, number>();
-  return strokes.map((stroke) => {
-    const drawn = `${stroke.color}:${stroke.width}:${stroke.points.join(',')}`;
-    const occurrence = occurrences.get(drawn) ?? 0;
-    occurrences.set(drawn, occurrence + 1);
-    return { id: `${drawn}#${occurrence}`, stroke };
-  });
-}
 
 function playBuzzerSound() {
   try {
@@ -174,28 +154,17 @@ export default function Buzzer({ block, viewContext = 'participant' }: BuzzerPro
     const sourceView = monitorView ?? experience;
     const allParticipants = [...(sourceView?.participants ?? []), ...(sourceView?.hosts ?? [])];
     const winner = allParticipants.find((p) => p.id === firstResponse.experience_participant_id);
-    const strokes = firstResponse.avatar?.strokes ?? [];
+    const avatar = firstResponse.avatar;
+    const hasAvatar = !!(avatar?.image || avatar?.strokes?.length);
 
     return (
       <div className={styles.monitorWinner}>
         <p className={styles.monitorLabel}>
           {block.payload.prompt || 'Contestants be ready to buzz in!'}
         </p>
-        {strokes.length > 0 ? (
+        {hasAvatar ? (
           <div className={styles.avatarWrap}>
-            <Stage width={AVATAR_DISPLAY_SIZE} height={AVATAR_DISPLAY_SIZE}>
-              <Layer scaleX={AVATAR_SCALE} scaleY={AVATAR_SCALE}>
-                {identifyStrokes(strokes).map(({ id, stroke }) => (
-                  <Line
-                    key={id}
-                    points={stroke.points}
-                    stroke={stroke.color}
-                    strokeWidth={stroke.width}
-                    lineCap="round"
-                  />
-                ))}
-              </Layer>
-            </Stage>
+            <Avatar avatar={avatar} size={AVATAR_DISPLAY_SIZE} />
           </div>
         ) : (
           <div className={styles.avatarPlaceholder} />

--- a/app/frontend/Experiences/GuessWho/Avatar.stories.tsx
+++ b/app/frontend/Experiences/GuessWho/Avatar.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import Avatar from './Avatar';
+
+// A tiny flattened drawing (a face) as an SVG data URL, standing in for the PNG
+// a real avatar flattens to.
+const FACE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 320">
+  <circle cx="160" cy="170" r="90" fill="#c8f060"/>
+  <circle cx="130" cy="150" r="10" fill="#080808"/>
+  <circle cx="190" cy="150" r="10" fill="#080808"/>
+  <path d="M120 200 Q160 230 200 200" stroke="#080808" stroke-width="6" fill="none"/>
+</svg>`;
+const faceImage = `data:image/svg+xml,${encodeURIComponent(FACE_SVG)}`;
+
+const meta: Meta<typeof Avatar> = {
+  title: 'Experiences/GuessWho/Avatar',
+  component: Avatar,
+  tags: ['autodocs'],
+  args: { size: 192 },
+};
+export default meta;
+
+type Story = StoryObj<typeof Avatar>;
+
+export const FlattenedImage: Story = {
+  args: {
+    avatar: { image: faceImage, cosmetics: [] },
+  },
+};
+
+export const FlattenedWithHat: Story = {
+  args: {
+    avatar: {
+      image: faceImage,
+      cosmetics: [
+        {
+          cosmetic_id: 'hat-1',
+          slug: 'top-hat',
+          asset_key: 'hat',
+          category: 'clothing',
+          x: 100,
+          y: 20,
+          width: 120,
+          height: 96,
+          rotation: 0,
+        },
+      ],
+    },
+  },
+};
+
+export const FlattenedWithFrame: Story = {
+  args: {
+    avatar: {
+      image: faceImage,
+      cosmetics: [
+        {
+          cosmetic_id: 'frame-1',
+          slug: 'beta-tester-frame',
+          asset_key: 'beta_tester_frame',
+          category: 'frame',
+          x: 0,
+          y: 0,
+          width: 320,
+          height: 320,
+          rotation: 0,
+        },
+      ],
+    },
+  },
+};
+
+export const LegacyStrokes: Story = {
+  args: {
+    avatar: {
+      strokes: [
+        { points: [80, 60, 160, 60, 160, 140, 80, 140, 80, 60], color: '#c8f060', width: 4 },
+        { points: [100, 90, 120, 80, 140, 90], color: '#ff4911', width: 3 },
+      ],
+    },
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    avatar: null,
+  },
+};

--- a/app/frontend/Experiences/GuessWho/Avatar.tsx
+++ b/app/frontend/Experiences/GuessWho/Avatar.tsx
@@ -2,16 +2,17 @@ import { useMemo } from 'react';
 
 import { Layer, Line, Stage } from 'react-konva';
 
-import { AvatarStroke } from '@cctv/types';
+import { DRAW_SIZE, cosmeticAssetUrl, sortCosmetics } from '@cctv/components/Cosmetics';
+import { AvatarData, AvatarStroke } from '@cctv/types';
 
 interface AvatarProps {
-  strokes?: AvatarStroke[] | null;
+  avatar?: AvatarData | null;
   size?: number;
   className?: string;
 }
 
-// Fraction of the box kept clear around the drawing so strokes don't touch the
-// edges when fitted.
+// Fraction of the box kept clear around a legacy drawing so strokes don't touch
+// the edges when fitted.
 const PADDING_RATIO = 0.1;
 
 interface IdentifiedStroke {
@@ -31,20 +32,22 @@ function identifyStrokes(strokes: AvatarStroke[]): IdentifiedStroke[] {
   });
 }
 
-export default function Avatar({ strokes, size = 96, className }: AvatarProps) {
-  const list = useMemo(() => strokes ?? [], [strokes]);
-  const identified = useMemo(() => identifyStrokes(list), [list]);
+export default function Avatar({ avatar, size = 96, className }: AvatarProps) {
+  const image = avatar?.image;
+  const cosmetics = useMemo(() => avatar?.cosmetics ?? [], [avatar?.cosmetics]);
+  const strokes = useMemo(() => avatar?.strokes ?? [], [avatar?.strokes]);
+  const identified = useMemo(() => identifyStrokes(strokes), [strokes]);
 
-  // Fit the drawing to its own bounding box so it fills the avatar area instead
-  // of floating tiny in a corner of the 400x400 drawing space.
+  // Fit legacy stroke drawings to their bounding box (pre-flatten avatars).
   const fit = useMemo(() => {
+    if (image || strokes.length === 0) return null;
     let minX = Infinity;
     let minY = Infinity;
     let maxX = -Infinity;
     let maxY = -Infinity;
     let maxStroke = 0;
 
-    for (const s of list) {
+    for (const s of strokes) {
       maxStroke = Math.max(maxStroke, s.width ?? 0);
       const pts = s.points ?? [];
       for (let i = 0; i + 1 < pts.length; i += 2) {
@@ -75,9 +78,41 @@ export default function Avatar({ strokes, size = 96, className }: AvatarProps) {
       offsetX: size / 2 - cx * scale,
       offsetY: size / 2 - cy * scale,
     };
-  }, [list, size]);
+  }, [image, strokes, size]);
 
-  if (list.length === 0 || !fit) {
+  // Flattened avatar: fixed-size raster image plus the separate cosmetics layer.
+  // No bbox-fit — every avatar renders at identical dimensions (whitespace kept).
+  if (image) {
+    const scale = size / DRAW_SIZE;
+    return (
+      <div className={className} style={{ position: 'relative', width: size, height: size }}>
+        <img src={image} width={size} height={size} alt="" style={{ display: 'block' }} />
+        {sortCosmetics(cosmetics).map((c) => {
+          const url = cosmeticAssetUrl(c.asset_key);
+          if (!url) return null;
+          return (
+            <img
+              key={`${c.cosmetic_id}-${c.x}-${c.y}-${c.rotation}`}
+              src={url}
+              alt=""
+              style={{
+                position: 'absolute',
+                left: c.x * scale,
+                top: c.y * scale,
+                width: c.width * scale,
+                height: c.height * scale,
+                transform: c.rotation ? `rotate(${c.rotation}deg)` : undefined,
+                transformOrigin: 'center',
+                pointerEvents: 'none',
+              }}
+            />
+          );
+        })}
+      </div>
+    );
+  }
+
+  if (strokes.length === 0 || !fit) {
     return (
       <div
         className={className}

--- a/app/frontend/Experiences/GuessWho/BoardGrid.tsx
+++ b/app/frontend/Experiences/GuessWho/BoardGrid.tsx
@@ -46,7 +46,7 @@ export default function BoardGrid({ contestant }: BoardGridProps) {
         return (
           <div key={uid} className={styles.boardCell}>
             <div className={styles.boardAvatarWrap}>
-              <Avatar strokes={p?.avatar?.strokes ?? null} size={AVATAR_SIZE} />
+              <Avatar avatar={p?.avatar} size={AVATAR_SIZE} />
               {isUnanswered && (
                 <span className={styles.shameBadge} aria-label="Did not respond">
                   ?

--- a/app/frontend/Experiences/GuessWho/GuessWhoMonitor.tsx
+++ b/app/frontend/Experiences/GuessWho/GuessWhoMonitor.tsx
@@ -18,7 +18,7 @@ interface GuessWhoMonitorProps {
 function ContestantHeader({ contestant }: { contestant: GuessWhoContestant }) {
   return (
     <div className={styles.contestantHeader}>
-      <Avatar strokes={contestant.contestant?.avatar?.strokes ?? null} size={96} />
+      <Avatar avatar={contestant.contestant?.avatar} size={96} />
       <div className={styles.contestantTitle}>
         <span className={styles.contestantLabel}>Contestant</span>
         <span className={styles.contestantName}>{contestant.contestant?.name ?? 'Unassigned'}</span>

--- a/app/frontend/Experiences/GuessWho/Reveal.tsx
+++ b/app/frontend/Experiences/GuessWho/Reveal.tsx
@@ -35,7 +35,7 @@ function ContestantCard({ contestant }: { contestant: GuessWhoContestant }) {
   return (
     <div className={styles.revealCard}>
       <div className={styles.revealLabel}>The mystery participant was…</div>
-      <Avatar strokes={contestant.mystery?.avatar?.strokes ?? null} size={192} />
+      <Avatar avatar={contestant.mystery?.avatar} size={192} />
       <div className={styles.revealName}>{contestant.mystery?.name ?? 'Unknown'}</div>
       <div className={styles.revealCrawl}>
         <div className={styles.crawlInner}>

--- a/app/frontend/Experiences/MinigameBalloonPump/MinigameBalloonPump.tsx
+++ b/app/frontend/Experiences/MinigameBalloonPump/MinigameBalloonPump.tsx
@@ -1,16 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 
-import { Layer, Line, Stage } from 'react-konva';
-
 import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { useExperienceState } from '@cctv/contexts/ExperienceStateContext';
+import Avatar from '@cctv/experiences/GuessWho/Avatar';
 import { useMinigameBalloonPump } from '@cctv/hooks/useMinigameBalloonPump';
 import { useSoundEffect } from '@cctv/sounds';
-import {
-  AvatarStroke,
-  MinigameBalloonPumpBlock,
-  MinigameBalloonPumpPodiumEntry,
-} from '@cctv/types';
+import { MinigameBalloonPumpBlock, MinigameBalloonPumpPodiumEntry } from '@cctv/types';
 
 import Balloon from './Balloon';
 import Pump from './Pump';
@@ -216,47 +211,12 @@ function Podium({ podium }: { podium: MinigameBalloonPumpPodiumEntry[] }) {
   );
 }
 
-const AVATAR_DRAW_SIZE = 320;
 const AVATAR_DISPLAY_SIZE = 112;
-const AVATAR_SCALE = AVATAR_DISPLAY_SIZE / AVATAR_DRAW_SIZE;
-
-interface IdentifiedStroke {
-  id: string;
-  stroke: AvatarStroke;
-}
-
-// Strokes carry no id, so identity comes from the drawn geometry plus an
-// occurrence counter that keeps repeated identical marks distinct.
-function identifyStrokes(strokes: AvatarStroke[]): IdentifiedStroke[] {
-  const occurrences = new Map<string, number>();
-  return strokes.map((stroke) => {
-    const drawn = `${stroke.color}:${stroke.width}:${stroke.points.join(',')}`;
-    const occurrence = occurrences.get(drawn) ?? 0;
-    occurrences.set(drawn, occurrence + 1);
-    return { id: `${drawn}#${occurrence}`, stroke };
-  });
-}
 
 function PodiumAvatar({ entry }: { entry: MinigameBalloonPumpPodiumEntry }) {
-  const strokes = entry.avatar?.strokes ?? [];
-  if (strokes.length === 0) {
-    return <div className={styles.podiumAvatar} />;
-  }
   return (
     <div className={styles.podiumAvatar}>
-      <Stage width={AVATAR_DISPLAY_SIZE} height={AVATAR_DISPLAY_SIZE}>
-        <Layer scaleX={AVATAR_SCALE} scaleY={AVATAR_SCALE}>
-          {identifyStrokes(strokes).map(({ id, stroke }) => (
-            <Line
-              key={id}
-              points={stroke.points}
-              stroke={stroke.color}
-              strokeWidth={stroke.width}
-              lineCap="round"
-            />
-          ))}
-        </Layer>
-      </Stage>
+      <Avatar avatar={entry.avatar} size={AVATAR_DISPLAY_SIZE} />
     </div>
   );
 }

--- a/app/frontend/Hooks/useCosmetics.ts
+++ b/app/frontend/Hooks/useCosmetics.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { useExperience } from '@cctv/contexts/ExperienceContext';
+import { Cosmetic } from '@cctv/types';
+
+export function useCosmetics() {
+  const { code, experienceFetch } = useExperience();
+  const [cosmetics, setCosmetics] = useState<Cosmetic[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchCosmetics = useCallback(async () => {
+    if (!code) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await experienceFetch(`/api/experiences/${encodeURIComponent(code)}/cosmetics`);
+      const data = await res.json();
+      setCosmetics(data.cosmetics ?? []);
+    } catch (e: any) {
+      setError(
+        e?.message === 'Authentication expired'
+          ? 'Authentication expired'
+          : 'Failed to load cosmetics',
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [code, experienceFetch]);
+
+  useEffect(() => {
+    fetchCosmetics();
+  }, [fetchCosmetics]);
+
+  return { cosmetics, isLoading, error, refetch: fetchCosmetics };
+}

--- a/app/frontend/Hooks/useSaveAvatar.ts
+++ b/app/frontend/Hooks/useSaveAvatar.ts
@@ -2,10 +2,11 @@ import { useCallback, useState } from 'react';
 
 import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { useExperienceState } from '@cctv/contexts/ExperienceStateContext';
-import { AvatarStroke } from '@cctv/types';
+import { CosmeticPlacement } from '@cctv/types';
 
 export interface SaveAvatarParams {
-  strokes?: AvatarStroke[];
+  image?: string;
+  cosmetics?: CosmeticPlacement[];
 }
 
 export function useSaveAvatar() {
@@ -15,7 +16,7 @@ export function useSaveAvatar() {
   const [error, setError] = useState<string | null>(null);
 
   const saveAvatar = useCallback(
-    async ({ strokes }: SaveAvatarParams) => {
+    async ({ image, cosmetics }: SaveAvatarParams) => {
       if (!code) {
         setError('Missing experience code');
         return { success: false, error: 'Missing experience code' } as const;
@@ -27,7 +28,7 @@ export function useSaveAvatar() {
       try {
         const res = await experienceFetch(`/api/experiences/${encodeURIComponent(code)}/avatar`, {
           method: 'POST',
-          body: JSON.stringify({ avatar: { strokes } }),
+          body: JSON.stringify({ avatar: { image, cosmetics } }),
         });
         const data = await res.json();
         if (!res.ok || data?.success === false) {

--- a/app/frontend/Pages/Experience/Experience.tsx
+++ b/app/frontend/Pages/Experience/Experience.tsx
@@ -7,6 +7,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { BookOpen } from 'lucide-react';
 
 import { ParticipantsList } from '@cctv/components';
+import { DRAW_SIZE, cosmeticAssetUrl, sortCosmetics } from '@cctv/components/Cosmetics';
 import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { useExperienceState } from '@cctv/contexts/ExperienceStateContext';
 import { useUser } from '@cctv/contexts/UserContext';
@@ -21,7 +22,7 @@ import {
 } from '@cctv/core';
 import ExperienceBlockContainer from '@cctv/experiences/ExperienceBlockContainer/ExperienceBlockContainer';
 import { useClearAvatars } from '@cctv/hooks/useClearAvatars';
-import { AvatarStroke, Block, BlockKind, SubmissionState } from '@cctv/types';
+import { AvatarData, AvatarStroke, Block, BlockKind, SubmissionState } from '@cctv/types';
 
 import AdminNotification from './AdminNotification/AdminNotification';
 
@@ -49,7 +50,41 @@ function keyedStrokes(strokes: AvatarStroke[]): { key: string; stroke: AvatarStr
   });
 }
 
-function AvatarCircle({ strokes }: { strokes: AvatarStroke[] }) {
+function AvatarCircle({ avatar }: { avatar?: AvatarData | null }) {
+  if (avatar?.image) {
+    return (
+      <div className={styles.avatarCircleSvg} style={{ position: 'relative', overflow: 'hidden' }}>
+        <img
+          src={avatar.image}
+          alt=""
+          style={{ width: '100%', height: '100%', display: 'block' }}
+        />
+        {sortCosmetics(avatar.cosmetics ?? []).map((c) => {
+          const url = cosmeticAssetUrl(c.asset_key);
+          if (!url) return null;
+          return (
+            <img
+              key={`${c.cosmetic_id}-${c.x}-${c.y}-${c.rotation}`}
+              src={url}
+              alt=""
+              style={{
+                position: 'absolute',
+                left: `${(c.x / DRAW_SIZE) * 100}%`,
+                top: `${(c.y / DRAW_SIZE) * 100}%`,
+                width: `${(c.width / DRAW_SIZE) * 100}%`,
+                height: `${(c.height / DRAW_SIZE) * 100}%`,
+                transform: c.rotation ? `rotate(${c.rotation}deg)` : undefined,
+                transformOrigin: 'center',
+                pointerEvents: 'none',
+              }}
+            />
+          );
+        })}
+      </div>
+    );
+  }
+
+  const strokes = avatar?.strokes ?? [];
   if (!strokes.length) {
     return (
       <svg viewBox="0 0 100 100" className={styles.avatarCircleSvg} aria-hidden>
@@ -131,7 +166,7 @@ export default function Experience() {
             title="Edit avatar"
             onClick={() => navigate(`/experiences/${code}/avatar`)}
           >
-            <AvatarCircle strokes={participant.avatar?.strokes ?? []} />
+            <AvatarCircle avatar={participant.avatar} />
           </button>,
           document.body,
         )

--- a/app/frontend/Pages/Monitor/LobbyAvatars.tsx
+++ b/app/frontend/Pages/Monitor/LobbyAvatars.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import type Konva from 'konva';
-import { Group, Layer, Line, Stage } from 'react-konva';
+import { Group, Image as KonvaImage, Layer, Line, Stage } from 'react-konva';
 
+import { cosmeticAssetUrl, sortCosmetics } from '@cctv/components/Cosmetics';
 import { useExperience } from '@cctv/contexts/ExperienceContext';
 import { useLobbyDrawingState } from '@cctv/contexts/LobbyDrawingContext';
-import type { AvatarStroke, ExperienceParticipant } from '@cctv/types';
+import type { AvatarStroke, CosmeticPlacement, ExperienceParticipant } from '@cctv/types';
 
 import styles from './LobbyAvatars.module.scss';
 
@@ -165,8 +166,9 @@ export default function LobbyAvatars() {
         <Stage width={size.w} height={size.h}>
           <Layer ref={layerRef}>
             {participants.map((p) => {
+              const committed = drawState.committed?.[p.id];
               const strokes = drawState.strokes[p.id] ?? [];
-              if (!strokes.length) return null;
+              if (!committed?.image && strokes.length === 0) return null;
 
               const motion = motionsRef.current.get(p.id);
               if (!motion) return null;
@@ -196,15 +198,19 @@ export default function LobbyAvatars() {
                   scaleY={initialScale}
                   opacity={isGrayed ? 0.3 : 1}
                 >
-                  {keyedStrokes(strokes).map(({ key, stroke }) => (
-                    <Line
-                      key={key}
-                      points={stroke.points}
-                      stroke={isGrayed ? 'hsl(60 4% 35%)' : stroke.color}
-                      strokeWidth={stroke.width}
-                      lineCap="round"
-                    />
-                  ))}
+                  {committed?.image ? (
+                    <FlattenedAvatar image={committed.image} cosmetics={committed.cosmetics} />
+                  ) : (
+                    keyedStrokes(strokes).map(({ key, stroke }) => (
+                      <Line
+                        key={key}
+                        points={stroke.points}
+                        stroke={isGrayed ? 'hsl(60 4% 35%)' : stroke.color}
+                        strokeWidth={stroke.width}
+                        lineCap="round"
+                      />
+                    ))
+                  )}
                 </Group>
               );
             })}
@@ -212,5 +218,67 @@ export default function LobbyAvatars() {
         </Stage>
       </div>
     </div>
+  );
+}
+
+function KonvaUrlImage({
+  src,
+  x,
+  y,
+  width,
+  height,
+  rotation,
+}: {
+  src: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  rotation?: number;
+}) {
+  const [img, setImg] = useState<HTMLImageElement | null>(null);
+  useEffect(() => {
+    if (!src) return;
+    const image = new window.Image();
+    image.addEventListener('load', () => setImg(image));
+    image.src = src;
+  }, [src]);
+  if (!img) return null;
+  // Render about the center so rotation matches the editor and HTML renderers.
+  return (
+    <KonvaImage
+      image={img}
+      x={x + width / 2}
+      y={y + height / 2}
+      offsetX={width / 2}
+      offsetY={height / 2}
+      width={width}
+      height={height}
+      rotation={rotation}
+      listening={false}
+    />
+  );
+}
+
+function FlattenedAvatar({ image, cosmetics }: { image: string; cosmetics: CosmeticPlacement[] }) {
+  return (
+    <>
+      <KonvaUrlImage src={image} x={0} y={0} width={DRAW_SIZE} height={DRAW_SIZE} />
+      {sortCosmetics(cosmetics).map((c) => {
+        const url = cosmeticAssetUrl(c.asset_key);
+        if (!url) return null;
+        return (
+          <KonvaUrlImage
+            key={`${c.cosmetic_id}-${c.x}-${c.y}-${c.rotation}`}
+            src={url}
+            x={c.x}
+            y={c.y}
+            width={c.width}
+            height={c.height}
+            rotation={c.rotation}
+          />
+        );
+      })}
+    </>
   );
 }

--- a/app/frontend/types.ts
+++ b/app/frontend/types.ts
@@ -145,7 +145,7 @@ export interface GuessWhoClue {
 export interface GuessWhoUserSummary {
   user_id: string;
   name: string;
-  avatar?: { strokes?: AvatarStroke[] } | null;
+  avatar?: AvatarData | null;
 }
 
 export interface GuessWhoContestant {
@@ -211,7 +211,7 @@ export interface MinigameArithmeticLeaderboardEntry {
   participant_id: string;
   user_id: string;
   name: string;
-  avatar?: { strokes?: AvatarStroke[] } | null;
+  avatar?: AvatarData | null;
   correct: number;
   completed: number;
   rank: number;
@@ -235,7 +235,7 @@ export interface MinigameBalloonPumpPodiumEntry {
   place: 1 | 2 | 3;
   participant_id: string;
   name: string;
-  avatar?: { strokes?: AvatarStroke[] } | null;
+  avatar?: AvatarData | null;
   fill_amount: number;
 }
 
@@ -405,6 +405,46 @@ export interface AvatarStroke {
   committed?: boolean;
 }
 
+// Clothing is placed/draggable; a frame wraps the whole avatar and is not
+// manipulable.
+export type CosmeticCategory = 'clothing' | 'frame';
+
+// Placement of a cosmetic on the avatar, in the fixed 320x320 draw space.
+// `asset_key` is denormalized so any renderer can resolve the art without the
+// cosmetic catalog.
+export interface CosmeticPlacement {
+  cosmetic_id: string;
+  slug: string;
+  asset_key: string;
+  category: CosmeticCategory;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  rotation: number;
+}
+
+// A cosmetic the user owns, available to apply to their avatar.
+export interface Cosmetic {
+  id: string;
+  name: string;
+  slug: string;
+  kind: string;
+  category: CosmeticCategory;
+  asset_key: string;
+  default_placement: Pick<CosmeticPlacement, 'x' | 'y' | 'width' | 'height' | 'rotation'>;
+}
+
+// Persisted avatar. Finalized avatars store a flattened `image` plus a separate,
+// non-flattened `cosmetics` layer. `strokes` is legacy (avatars drawn before the
+// flatten change) and is still rendered as a fallback.
+export interface AvatarData {
+  image?: string;
+  cosmetics?: CosmeticPlacement[];
+  strokes?: AvatarStroke[];
+  updated_at?: string;
+}
+
 export interface ExperienceParticipant {
   id: string;
   user_id: string;
@@ -418,10 +458,7 @@ export interface ExperienceParticipant {
   fingerprint: string | null;
   created_at: string;
   updated_at: string;
-  avatar?: {
-    strokes?: AvatarStroke[];
-    updated_at?: string;
-  } | null;
+  avatar?: AvatarData | null;
 }
 
 export interface BlockResponse {
@@ -514,7 +551,7 @@ export interface BuzzerBlock extends BaseBlock {
       experience_participant_id: string;
       answer: { buzzed_at: string };
       created_at: string;
-      avatar?: { strokes?: AvatarStroke[] } | null;
+      avatar?: AvatarData | null;
     }>;
   };
 }

--- a/app/models/cosmetic.rb
+++ b/app/models/cosmetic.rb
@@ -1,0 +1,31 @@
+class Cosmetic < ApplicationRecord
+  KINDS = %w[hat sunglasses frame].freeze
+  CATEGORIES = %w[clothing frame].freeze
+
+  has_many :user_cosmetics, dependent: :destroy
+  has_many :users, through: :user_cosmetics
+
+  validates :name, presence: true
+  validates :slug, presence: true, uniqueness: true
+  validates :kind, presence: true, inclusion: { in: KINDS }
+  validates :category, presence: true, inclusion: { in: CATEGORIES }
+  validates :asset_key, presence: true
+
+  scope :active, -> { where(active: true) }
+  scope :default_grant, -> { where(default_grant: true) }
+  scope :beta_only, -> { where(beta_only: true) }
+  scope :clothing, -> { where(category: "clothing") }
+  scope :frames, -> { where(category: "frame") }
+
+  after_create :grant_to_beta_testers
+
+  private
+
+  def grant_to_beta_testers
+    return unless active? && beta_only?
+
+    User.beta_testers.find_each do |user|
+      user.user_cosmetics.find_or_create_by!(cosmetic: self) { |uc| uc.source = "grant" }
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,12 +6,20 @@ class User < ApplicationRecord
   has_one :performer, dependent: :destroy
   has_many :follows, dependent: :destroy
   has_many :followed_performers, through: :follows, source: :performer
+  has_many :user_cosmetics, dependent: :destroy
+  has_many :cosmetics, through: :user_cosmetics
+
+  # Users created before this cutoff are beta testers and receive beta-only
+  # cosmetics. The cutoff is in the past, so new signups are not beta testers.
+  BETA_TESTER_CUTOFF = Time.utc(2026, 7, 1)
 
   enum :role, {
     user: "user",
     admin: "admin",
     superadmin: "superadmin"
   }
+
+  scope :beta_testers, -> { where("created_at < ?", BETA_TESTER_CUTOFF) }
 
   validates :name, presence: true, length: { minimum: 1, maximum: 255 }
   validates :email,
@@ -22,6 +30,20 @@ class User < ApplicationRecord
   passwordless_with :email
 
   before_save { self.email = email.downcase.strip }
+  after_create :grant_starter_cosmetics
+
+  def beta_tester?
+    created_at.present? && created_at < BETA_TESTER_CUTOFF
+  end
+
+  # Everyone gets default-granted cosmetics; beta testers additionally get
+  # beta-only cosmetics.
+  def grant_starter_cosmetics
+    scope = beta_tester? ? Cosmetic.active.where("default_grant OR beta_only") : Cosmetic.active.default_grant
+    scope.find_each do |cosmetic|
+      user_cosmetics.find_or_create_by!(cosmetic: cosmetic) { |uc| uc.source = "grant" }
+    end
+  end
 
   # Used by posthog-rails to associate automatically captured errors with this user.
   def posthog_distinct_id

--- a/app/models/user_cosmetic.rb
+++ b/app/models/user_cosmetic.rb
@@ -1,0 +1,14 @@
+class UserCosmetic < ApplicationRecord
+  belongs_to :user
+  belongs_to :cosmetic
+
+  validates :cosmetic_id, uniqueness: { scope: :user_id }
+
+  before_validation :set_acquired_at, on: :create
+
+  private
+
+  def set_acquired_at
+    self.acquired_at ||= Time.current
+  end
+end

--- a/app/policies/experience_participant_policy.rb
+++ b/app/policies/experience_participant_policy.rb
@@ -1,4 +1,8 @@
 class ExperienceParticipantPolicy < ApplicationPolicy
+  def show?
+    own_record? || manage?
+  end
+
   def update_avatar?
     own_record? || manage?
   end

--- a/app/serializers/cosmetic_serializer.rb
+++ b/app/serializers/cosmetic_serializer.rb
@@ -1,0 +1,13 @@
+class CosmeticSerializer
+  def self.serialize(cosmetic)
+    {
+      id: cosmetic.id,
+      name: cosmetic.name,
+      slug: cosmetic.slug,
+      kind: cosmetic.kind,
+      category: cosmetic.category,
+      asset_key: cosmetic.asset_key,
+      default_placement: cosmetic.default_placement
+    }
+  end
+end

--- a/app/services/experiences/orchestrator.rb
+++ b/app/services/experiences/orchestrator.rb
@@ -6,15 +6,19 @@ module Experiences
     # Upper bound on AI-generated synthetic answers per question.
     MAX_SYNTHETIC_ANSWERS = 200
 
+    # The fixed avatar draw space. Frames are stored as a full-canvas placement.
+    AVATAR_DRAW_SIZE = 320
+
     attr_reader :profile_changes
     def kick_participant!(participant)
       participant.destroy!
     end
 
-    def update_participant_avatar!(participant:, strokes:)
-      avatar = participant.avatar || {}
-      avatar[:strokes] = strokes unless strokes.nil?
-      participant.update!(avatar: avatar)
+    def update_participant_avatar!(participant:, image:, cosmetics: nil)
+      participant.update!(avatar: {
+        "image" => image,
+        "cosmetics" => sanitize_cosmetics(participant: participant, cosmetics: cosmetics)
+      })
       participant
     end
 
@@ -1415,6 +1419,51 @@ module Experiences
     end
 
     private
+
+    def sanitize_cosmetics(participant:, cosmetics:)
+      return [] if cosmetics.blank?
+
+      owned = participant.user.cosmetics.active.index_by(&:id)
+
+      placements = Array(cosmetics).filter_map do |placement|
+        placement = (placement.respond_to?(:to_unsafe_h) ? placement.to_unsafe_h : placement.to_h)
+          .with_indifferent_access
+        cosmetic = owned[placement[:cosmetic_id].to_s]
+        next unless cosmetic
+
+        build_placement(cosmetic, placement)
+      end
+
+      # Frames are one-at-a-time (last wins) and render on top of clothing.
+      clothing, frames = placements.partition { |p| p["category"] != "frame" }
+      clothing + frames.last(1)
+    end
+
+    def build_placement(cosmetic, placement)
+      base = {
+        "cosmetic_id" => cosmetic.id,
+        "slug" => cosmetic.slug,
+        "asset_key" => cosmetic.asset_key,
+        "category" => cosmetic.category
+      }
+
+      if cosmetic.category == "frame"
+        # Frames wrap the whole avatar; geometry is fixed, not client-controlled.
+        base.merge(
+          "x" => 0.0, "y" => 0.0,
+          "width" => AVATAR_DRAW_SIZE.to_f, "height" => AVATAR_DRAW_SIZE.to_f,
+          "rotation" => 0.0
+        )
+      else
+        base.merge(
+          "x" => placement[:x].to_f,
+          "y" => placement[:y].to_f,
+          "width" => placement[:width].to_f,
+          "height" => placement[:height].to_f,
+          "rotation" => placement[:rotation].to_f
+        )
+      end
+    end
 
     # Cap the board at the most popular MAX_FAMILY_FEUD_BUCKETS buckets (by member
     # count), preserving order; overflow buckets' answers fall back to unassigned.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
         post :clear_avatars
         patch :update_playbill
         post :avatar, to: 'experience_avatar#create'
+        get :cosmetics, to: 'experience_cosmetics#index'
       end
 
       resources(

--- a/db/migrate/20260707000001_create_cosmetics.rb
+++ b/db/migrate/20260707000001_create_cosmetics.rb
@@ -1,0 +1,18 @@
+class CreateCosmetics < ActiveRecord::Migration[7.2]
+  def change
+    create_table :cosmetics, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      t.string :name, null: false
+      t.string :slug, null: false
+      t.string :kind, null: false
+      t.string :asset_key, null: false
+      t.jsonb :default_placement, null: false, default: {}
+      t.integer :price_cents, null: false, default: 0
+      t.boolean :default_grant, null: false, default: false
+      t.boolean :active, null: false, default: true
+      t.timestamps
+    end
+
+    add_index :cosmetics, :slug, unique: true
+    add_index :cosmetics, :default_grant
+  end
+end

--- a/db/migrate/20260707000002_create_user_cosmetics.rb
+++ b/db/migrate/20260707000002_create_user_cosmetics.rb
@@ -1,0 +1,16 @@
+class CreateUserCosmetics < ActiveRecord::Migration[7.2]
+  def change
+    create_table :user_cosmetics, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      t.uuid :user_id, null: false
+      t.uuid :cosmetic_id, null: false
+      t.datetime :acquired_at, null: false
+      t.string :source, null: false, default: "grant"
+      t.timestamps
+    end
+
+    add_index :user_cosmetics, [:user_id, :cosmetic_id], unique: true
+    add_index :user_cosmetics, :cosmetic_id
+    add_foreign_key :user_cosmetics, :users, on_delete: :cascade
+    add_foreign_key :user_cosmetics, :cosmetics, on_delete: :cascade
+  end
+end

--- a/db/migrate/20260707000003_add_category_and_beta_to_cosmetics.rb
+++ b/db/migrate/20260707000003_add_category_and_beta_to_cosmetics.rb
@@ -1,0 +1,7 @@
+class AddCategoryAndBetaToCosmetics < ActiveRecord::Migration[7.2]
+  def change
+    add_column :cosmetics, :category, :string, null: false, default: "clothing"
+    add_column :cosmetics, :beta_only, :boolean, null: false, default: false
+    add_index :cosmetics, :category
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_10_000002) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_07_000003) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -51,6 +51,24 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_10_000002) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "cosmetics", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "slug", null: false
+    t.string "kind", null: false
+    t.string "asset_key", null: false
+    t.jsonb "default_placement", default: {}, null: false
+    t.integer "price_cents", default: 0, null: false
+    t.boolean "default_grant", default: false, null: false
+    t.boolean "active", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "category", default: "clothing", null: false
+    t.boolean "beta_only", default: false, null: false
+    t.index ["category"], name: "index_cosmetics_on_category"
+    t.index ["default_grant"], name: "index_cosmetics_on_default_grant"
+    t.index ["slug"], name: "index_cosmetics_on_slug", unique: true
   end
 
   create_table "event_performers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -321,6 +339,17 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_10_000002) do
     t.index ["user_id"], name: "index_performers_on_user_id", unique: true
   end
 
+  create_table "user_cosmetics", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.uuid "cosmetic_id", null: false
+    t.datetime "acquired_at", null: false
+    t.string "source", default: "grant", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["cosmetic_id"], name: "index_user_cosmetics_on_cosmetic_id"
+    t.index ["user_id", "cosmetic_id"], name: "index_user_cosmetics_on_user_id_and_cosmetic_id", unique: true
+  end
+
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -371,4 +400,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_10_000002) do
   add_foreign_key "improv_votes", "experience_participants", on_delete: :cascade
   add_foreign_key "improv_votes", "improv_suggestions", on_delete: :cascade
   add_foreign_key "performers", "users", on_delete: :cascade
+  add_foreign_key "user_cosmetics", "cosmetics", on_delete: :cascade
+  add_foreign_key "user_cosmetics", "users", on_delete: :cascade
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,6 +15,66 @@ superadmins = [
   User.find_or_create_by!(name: name, email: email, role: "superadmin")
 end
 
+Cosmetic.find_or_create_by!(slug: "top-hat") do |cosmetic|
+  cosmetic.name             = "Top Hat"
+  cosmetic.kind             = "hat"
+  cosmetic.category         = "clothing"
+  cosmetic.asset_key        = "hat"
+  cosmetic.default_placement = { "x" => 100, "y" => 24, "width" => 120, "height" => 96, "rotation" => 0 }
+  cosmetic.price_cents      = 0
+  cosmetic.default_grant    = true
+  cosmetic.active           = true
+end
+
+Cosmetic.find_or_create_by!(slug: "sunglasses") do |cosmetic|
+  cosmetic.name             = "Sunglasses"
+  cosmetic.kind             = "sunglasses"
+  cosmetic.category         = "clothing"
+  cosmetic.asset_key        = "sunglasses"
+  cosmetic.default_placement = { "x" => 100, "y" => 120, "width" => 120, "height" => 52, "rotation" => 0 }
+  cosmetic.price_cents      = 0
+  cosmetic.default_grant    = true
+  cosmetic.active           = true
+end
+
+User.find_each do |user|
+  Cosmetic.active.default_grant.find_each do |cosmetic|
+    user.user_cosmetics.find_or_create_by!(cosmetic: cosmetic) { |uc| uc.source = "grant" }
+  end
+end
+
+# A frame wraps the whole avatar and is gated to beta testers (users created
+# before User::BETA_TESTER_CUTOFF).
+Cosmetic.find_or_create_by!(slug: "beta-tester-frame") do |cosmetic|
+  cosmetic.name             = "Beta Tester"
+  cosmetic.kind             = "frame"
+  cosmetic.category         = "frame"
+  cosmetic.asset_key        = "beta_tester_frame"
+  cosmetic.default_placement = { "x" => 0, "y" => 0, "width" => 320, "height" => 320, "rotation" => 0 }
+  cosmetic.price_cents      = 0
+  cosmetic.default_grant    = false
+  cosmetic.beta_only        = true
+  cosmetic.active           = true
+end
+
+User.beta_testers.find_each do |user|
+  Cosmetic.active.beta_only.find_each do |cosmetic|
+    user.user_cosmetics.find_or_create_by!(cosmetic: cosmetic) { |uc| uc.source = "grant" }
+  end
+end
+
+# Non-admin account for exercising the cosmetics/avatar flow. Admin and superadmin
+# accounts bypass the avatar drawing screen, so use this user to reach it. Owns
+# every active cosmetic.
+cosmetics_tester = User.find_or_create_by!(email: "cosmetics_test_user@gmail.com") do |user|
+  user.name = "Cosmetics Test User"
+  user.role = "user"
+end
+
+Cosmetic.active.find_each do |cosmetic|
+  cosmetics_tester.user_cosmetics.find_or_create_by!(cosmetic: cosmetic) { |uc| uc.source = "grant" }
+end
+
 Event.find_or_create_by!(slug: "chicago-comedy-social-technical-expo-2026") do |event|
   event.title         = "Chicago Comedy Social & Technical Expo"
   event.description   = "A celebration of Chicago's comedy community at The Den Theatre."

--- a/spec/controllers/api/experience_avatar_controller_spec.rb
+++ b/spec/controllers/api/experience_avatar_controller_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Api::ExperienceAvatarController, type: :controller do
   let!(:participant) do
     create(:experience_participant, experience: experience, role: :audience)
   end
-  let(:strokes) { [{ "points" => [1, 2, 3, 4], "color" => "#ff0000", "width" => 4 }] }
+  let(:image) { "data:image/png;base64,AAAA" }
+  let(:cosmetics) { [] }
 
   before do
     jwt = Experiences::AuthService.jwt_for_participant(
@@ -22,18 +23,80 @@ RSpec.describe Api::ExperienceAvatarController, type: :controller do
       :create,
       params: {
         id: experience.code_slug,
-        avatar: { strokes: strokes }
+        avatar: { image: image, cosmetics: cosmetics }
       },
       as: :json
     )
   end
 
-  it "updates the participant avatar" do
+  it "flattens the participant avatar to an image" do
     subject
 
     expect(response).to have_http_status(:ok)
     expect(JSON.parse(response.body)["success"]).to be(true)
-    expect(participant.reload.avatar["strokes"]).to eq(strokes)
+    avatar = participant.reload.avatar
+    expect(avatar["image"]).to eq(image)
+    expect(avatar["cosmetics"]).to eq([])
+    expect(avatar).not_to have_key("strokes")
+  end
+
+  context "with cosmetics" do
+    let!(:owned) { create(:cosmetic) }
+    let!(:unowned) { create(:cosmetic) }
+    let(:cosmetics) do
+      [
+        { cosmetic_id: owned.id, x: 10, y: 20, width: 100, height: 80, rotation: 0 },
+        { cosmetic_id: unowned.id, x: 0, y: 0, width: 10, height: 10, rotation: 0 }
+      ]
+    end
+
+    before { create(:user_cosmetic, user: participant.user, cosmetic: owned) }
+
+    it "keeps owned cosmetics and drops unowned ones, deriving slug/asset from the record" do
+      subject
+
+      placed = participant.reload.avatar["cosmetics"]
+      expect(placed.length).to eq(1)
+      expect(placed.first).to include(
+        "cosmetic_id" => owned.id,
+        "slug" => owned.slug,
+        "asset_key" => owned.asset_key,
+        "x" => 10.0,
+        "y" => 20.0
+      )
+    end
+  end
+
+  context "with frame cosmetics" do
+    let!(:frame_one) { create(:cosmetic, :frame) }
+    let!(:frame_two) { create(:cosmetic, :frame) }
+    let(:cosmetics) do
+      [
+        { cosmetic_id: frame_one.id, x: 50, y: 50, width: 10, height: 10, rotation: 45 },
+        { cosmetic_id: frame_two.id, x: 5, y: 5, width: 8, height: 8, rotation: 10 }
+      ]
+    end
+
+    before do
+      create(:user_cosmetic, user: participant.user, cosmetic: frame_one)
+      create(:user_cosmetic, user: participant.user, cosmetic: frame_two)
+    end
+
+    it "keeps only one frame (last wins) and forces full-canvas geometry" do
+      subject
+
+      frames = participant.reload.avatar["cosmetics"].select { |c| c["category"] == "frame" }
+      expect(frames.length).to eq(1)
+      expect(frames.first).to include(
+        "cosmetic_id" => frame_two.id,
+        "category" => "frame",
+        "x" => 0.0,
+        "y" => 0.0,
+        "width" => 320.0,
+        "height" => 320.0,
+        "rotation" => 0.0
+      )
+    end
   end
 
   context "when the user has no participant record" do
@@ -66,7 +129,7 @@ RSpec.describe Api::ExperienceAvatarController, type: :controller do
       subject
 
       expect(response).to have_http_status(:ok)
-      expect(host_participant.reload.avatar["strokes"]).to eq(strokes)
+      expect(host_participant.reload.avatar["image"]).to eq(image)
     end
   end
 end

--- a/spec/controllers/api/experience_cosmetics_controller_spec.rb
+++ b/spec/controllers/api/experience_cosmetics_controller_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe Api::ExperienceCosmeticsController, type: :controller do
+  include Passwordless::ControllerHelpers
+
+  let!(:experience) { create(:experience) }
+  let!(:participant) do
+    create(:experience_participant, experience: experience, role: :audience)
+  end
+  let!(:owned) { create(:cosmetic, name: "Owned Hat") }
+  let!(:owned_inactive) { create(:cosmetic, active: false) }
+  let!(:unowned) { create(:cosmetic, name: "Unowned Hat") }
+
+  before do
+    create(:user_cosmetic, user: participant.user, cosmetic: owned)
+    create(:user_cosmetic, user: participant.user, cosmetic: owned_inactive)
+
+    jwt = Experiences::AuthService.jwt_for_participant(
+      experience: experience,
+      user: participant.user
+    )
+    request.headers["Authorization"] = "Bearer #{jwt}"
+  end
+
+  subject { get(:index, params: { id: experience.code_slug }, as: :json) }
+
+  it "returns only the current user's owned, active cosmetics" do
+    subject
+
+    expect(response).to have_http_status(:ok)
+    cosmetics = JSON.parse(response.body)["cosmetics"]
+    ids = cosmetics.map { |c| c["id"] }
+
+    expect(ids).to eq([owned.id])
+    expect(ids).not_to include(unowned.id)
+    expect(ids).not_to include(owned_inactive.id)
+    expect(cosmetics.first).to include(
+      "slug" => owned.slug,
+      "category" => owned.category,
+      "asset_key" => owned.asset_key,
+      "default_placement" => owned.default_placement
+    )
+  end
+
+  context "when the user has no participant record" do
+    before do
+      jwt = Experiences::AuthService.jwt_for_admin(user: create(:user, :admin))
+      request.headers["Authorization"] = "Bearer #{jwt}"
+    end
+
+    it "returns not found" do
+      subject
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/factories/cosmetics_factory.rb
+++ b/spec/factories/cosmetics_factory.rb
@@ -1,0 +1,28 @@
+FactoryBot.define do
+  factory :cosmetic do
+    sequence(:name) { |n| "Cosmetic #{n}" }
+    sequence(:slug) { |n| "cosmetic-#{n}" }
+    kind { "hat" }
+    category { "clothing" }
+    asset_key { "hat" }
+    default_placement { { "x" => 100, "y" => 24, "width" => 120, "height" => 96, "rotation" => 0 } }
+    price_cents { 0 }
+    default_grant { false }
+    beta_only { false }
+    active { true }
+
+    trait :frame do
+      kind { "frame" }
+      category { "frame" }
+      asset_key { "beta_tester_frame" }
+      beta_only { true }
+      default_placement { { "x" => 0, "y" => 0, "width" => 320, "height" => 320, "rotation" => 0 } }
+    end
+  end
+
+  factory :user_cosmetic do
+    association :user
+    association :cosmetic
+    source { "grant" }
+  end
+end

--- a/spec/models/cosmetic_spec.rb
+++ b/spec/models/cosmetic_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe Cosmetic, type: :model do
+  describe "granting beta-only cosmetics on create" do
+    let!(:beta_user) { create(:user, created_at: Time.utc(2026, 1, 1)) }
+    let!(:regular_user) { create(:user, created_at: Time.utc(2026, 8, 1)) }
+
+    it "grants a new beta-only cosmetic to existing beta testers only" do
+      frame = create(:cosmetic, :frame)
+
+      expect(beta_user.reload.cosmetics).to include(frame)
+      expect(regular_user.reload.cosmetics).not_to include(frame)
+    end
+
+    it "does not auto-grant non-beta cosmetics to anyone" do
+      hat = create(:cosmetic)
+
+      expect(beta_user.reload.cosmetics).not_to include(hat)
+      expect(regular_user.reload.cosmetics).not_to include(hat)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -31,6 +31,32 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#beta_tester?' do
+    it 'is true for users created before the cutoff' do
+      expect(build(:user, created_at: User::BETA_TESTER_CUTOFF - 1.day).beta_tester?).to be(true)
+    end
+
+    it 'is false for users created at or after the cutoff' do
+      expect(build(:user, created_at: User::BETA_TESTER_CUTOFF).beta_tester?).to be(false)
+    end
+  end
+
+  describe 'starter cosmetics on create' do
+    before do
+      create(:cosmetic, slug: 'everyone-hat', default_grant: true)
+      create(:cosmetic, :frame, slug: 'beta-frame')
+    end
+
+    it 'grants default cosmetics to everyone and beta cosmetics only to beta testers' do
+      beta = create(:user, created_at: Time.utc(2026, 1, 1))
+      regular = create(:user, created_at: Time.utc(2026, 8, 1))
+
+      expect(beta.cosmetics.pluck(:slug)).to include('everyone-hat', 'beta-frame')
+      expect(regular.cosmetics.pluck(:slug)).to include('everyone-hat')
+      expect(regular.cosmetics.pluck(:slug)).not_to include('beta-frame')
+    end
+  end
+
   describe '#most_recent_avatar' do
     it 'returns nil when the user has no participants' do
       expect(create(:user).most_recent_avatar).to be_nil

--- a/spec/system/experiences/avatar_cosmetics_spec.rb
+++ b/spec/system/experiences/avatar_cosmetics_spec.rb
@@ -1,0 +1,114 @@
+require "rails_helper"
+
+RSpec.describe "Avatar cosmetics", type: :system do
+  let(:admin) { create(:user, :admin) }
+  let!(:experience) do
+    create(
+      :experience,
+      :draft,
+      creator: admin,
+      name: "Test Experience",
+      code: "test-experience"
+    )
+  end
+  let!(:hat) { create(:cosmetic, name: "Top Hat", slug: "top-hat", default_grant: true) }
+
+  def register_alice
+    register_participant(
+      code: experience.code_slug,
+      name: "Alice",
+      email: "alice@example.com",
+      experience_name: experience.name,
+      draw_avatar: false
+    )
+    expect(page).to have_current_path("/experiences/#{experience.code_slug}/avatar")
+  end
+
+  it "applies an owned cosmetic and shows the flattened avatar with a separate cosmetic layer" do
+    using_session(:participant) do
+      register_alice
+      draw_on_canvas
+
+      # Inventory is only available in Decorate mode; it defaults to closed.
+      click_button "Decorate"
+      expect(page).to have_text(/inventory/i)
+      select "Clothing", from: "Inventory"
+      expect(page).to have_button("Apply Top Hat")
+      click_button "Apply Top Hat"
+
+      expect(page).to have_button("Submit", disabled: false)
+      click_button "Submit"
+      expect(page).to have_current_path("/experiences/#{experience.code_slug}")
+
+      # The finalized avatar renders a flattened raster plus the hat overlay.
+      within('button[aria-label="Edit avatar"]') do
+        expect(page).to have_css("img[src^='data:image/png']")
+        expect(page).to have_css("img", minimum: 2)
+      end
+    end
+  end
+
+  it "only shows cosmetics the participant owns" do
+    create(:cosmetic, name: "Secret Crown", slug: "secret-crown", default_grant: false)
+
+    using_session(:participant) do
+      register_alice
+      draw_on_canvas
+
+      click_button "Decorate"
+      select "Clothing", from: "Inventory"
+
+      expect(page).to have_button("Apply Top Hat")
+      expect(page).to have_no_button("Apply Secret Crown")
+    end
+  end
+
+  it "switches inventory category via the dropdown" do
+    using_session(:participant) do
+      register_alice
+      draw_on_canvas
+      click_button "Decorate"
+
+      select "Clothing", from: "Inventory"
+      expect(page).to have_button("Apply Top Hat")
+
+      select "Frames", from: "Inventory"
+
+      # Switched away from clothing; Alice owns no frames.
+      expect(page).to have_no_button("Apply Top Hat")
+      expect(page).to have_text("None yet")
+    end
+  end
+
+  it "lets a background color be chosen and baked into the flattened avatar" do
+    using_session(:participant) do
+      register_alice
+
+      click_button "Background"
+      click_button "Color"
+      expect(page).to have_button("No background")
+
+      first("button[aria-label^='Background ']").click
+
+      expect(page).to have_button("Submit", disabled: false)
+      click_button "Submit"
+      expect(page).to have_current_path("/experiences/#{experience.code_slug}")
+
+      within('button[aria-label="Edit avatar"]') do
+        expect(page).to have_css("img[src^='data:image/png']")
+      end
+    end
+  end
+
+  it "hides the inventory while drawing and reveals it in decorate mode" do
+    using_session(:participant) do
+      register_alice
+
+      click_button "Decorate"
+      expect(page).to have_text(/inventory/i)
+
+      click_button "Draw"
+      expect(page).to have_no_text(/inventory/i)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a **cosmetics system** to the avatar editor. Audience members can decorate their avatar with clothing and frames during the drawing flow.

### Editor
- **Draw / Decorate / Background** modes (mutually exclusive) via a toggle. Draw locks cosmetics; Decorate locks drawing; Background fills the canvas.
- Compact **click-into Brush/Color** controls that live *below* the canvas (with the Inventory), so switching modes no longer shifts the canvas.
- **Inventory** is a full-width bar `select` (default closed) with **Clothing** / **Frames** options; items drag-and-drop or click-to-apply.
- **Clothing**: draggable + **rotatable** (Konva `Transformer` handle when selected). **Frames**: full-avatar outline, one at a time, with a **None** option.

### Flatten model (Option B)
- On submit the **drawing + background flatten to a fixed 320×320 raster**; cosmetics persist as a **separate, non-flattened layer** (structured placements). Re-editing reloads the flattened image as a base layer so prior work is preserved.
- All avatar renderers (Guess Who, minigame podium, buzzer, lobby, the avatar button) go through one component and render `image` + cosmetics, with a legacy-strokes fallback.

### Backend
- `cosmetics` + `user_cosmetics` tables; ownership drives everything and the API returns **only owned cosmetics**. Server validates ownership on save; frames are forced to full-canvas and capped to one.
- `category` (`clothing` | `frame`) and `beta_only` columns. **Temporal beta gate**: users created before `2026-07-01` (`User::BETA_TESTER_CUTOFF`) own `beta_only` cosmetics — no user flag needed.
- Seeds: **Top Hat**, **Sunglasses** (clothing, default-granted) and a **Beta Tester** frame; plus a non-admin `cosmetics_test_user@gmail.com` for manual testing (admin/superadmin accounts bypass the avatar screen).

## Testing
- `tsc` clean · `oxlint` clean · **201** frontend unit tests · **387** backend specs · avatar + cosmetics **system specs** green.
- New: cosmetics/avatar controller specs (ownership, category, frame single/full-canvas), `Cosmetic`/`User` model specs (temporal beta grant), and a cosmetics system spec (mode gating, apply, dropdown switch, background, flatten via the UI).

## Notes
- Rebased on latest `main`; merged with the anti-slop lint + PostHog analytics changes (all my files are lint-clean).
- The rotate-handle *drag* interaction isn't covered by an automated test (Konva `Transformer` drag is impractical in jsdom/Ferrum) — verify manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)